### PR TITLE
Add timing functionality to main rendering process

### DIFF
--- a/crates/crust-render/src/main.rs
+++ b/crates/crust-render/src/main.rs
@@ -4,6 +4,7 @@ use crust_render::convert;
 use crust_render::tracer::{RenderSettings, Renderer};
 use crust_render::world::simple_scene;
 use exr::prelude::*;
+use std::time::{Duration, Instant};
 use utils::Point3;
 
 #[derive(Parser)]
@@ -27,11 +28,13 @@ const MIN_SAMPLES: u32 = 32;
 const VARIANCE_THRESHOLD: f32 = 0.0; // You can tweak this!
 
 fn main() {
+    // CLI
     let cli = Cli::parse();
     let samples_per_pixel: u32 = cli.samples_per_pixel;
     let max_depth: u32 = cli.max_depth;
+    // Timer
+    let start = Instant::now();
     // World
-
     let (world, lights) = simple_scene();
     // Camera
 
@@ -60,6 +63,9 @@ fn main() {
     );
     let renderer = Renderer::new(cam, world, lights, render_settings);
     let buffer = renderer.render();
+    // Close Timer
+    let duration: Duration = start.elapsed();
+    println!("Time elapsed in rendering() is: {:?}", duration);
     // Render
     write_rgb_file("output.exr", IMAGE_WIDTH, IMAGE_HEIGHT, |x, y| {
         buffer.get_rgb(x, y)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added timing functionality to measure rendering duration.

- Introduced `Instant` and `Duration` for time tracking.

- Printed elapsed rendering time to console.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Added timing and elapsed time output in `main.rs`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/crust-render/src/main.rs

<li>Imported <code>std::time::{Duration, Instant}</code> for timing.<br> <li> Added a timer start at the beginning of the <code>main</code> function.<br> <li> Calculated and printed elapsed rendering time after rendering.


</details>


  </td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/37/files#diff-c4166b14d797fca754ddc7a86e699e707872188434442c99c46edb4eddc2790e">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>