### PR TITLE
Dielectic lobe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 image.ppm
 Cargo.lock
 output.exr
+/test_images

--- a/crates/crust-render/src/convert.rs
+++ b/crates/crust-render/src/convert.rs
@@ -9,7 +9,11 @@ fn unique_timestamp() -> String {
         .duration_since(UNIX_EPOCH)
         .expect("Time went backwards");
 
-    format!("{}{:03}.png", now.as_secs(), now.subsec_millis())
+    format!(
+        "./test_images/{}{:03}.png",
+        now.as_secs(),
+        now.subsec_millis()
+    )
 }
 
 /// compress any possible f32 into the range of [0,1].

--- a/crates/crust-render/src/material/dielectric.rs
+++ b/crates/crust-render/src/material/dielectric.rs
@@ -1,5 +1,6 @@
 use crate::hittable::HitRecord;
 use crate::material::Material;
+use crate::material::brdf;
 use crate::ray::Ray;
 use utils::Color;
 
@@ -50,6 +51,78 @@ impl Material for Dielectric {
 
         *attenuation = Color::new(1.0, 1.0, 1.0);
         *scattered = Ray::new(rec.p, direction);
+        true
+    }
+}
+
+pub struct ComplexDielectric {
+    pub ior: f32,
+    pub roughness: f32,
+    pub absorption: Option<Color>,
+    pub thin: bool,
+}
+
+impl ComplexDielectric {
+    pub fn new(ior: f32, roughness: f32, absorption: Option<Color>, thin: bool) -> Self {
+        Self {
+            ior,
+            roughness,
+            absorption,
+            thin,
+        }
+    }
+}
+
+impl Material for ComplexDielectric {
+    fn scatter(
+        &self,
+        r_in: &Ray,
+        rec: &HitRecord,
+        attenuation: &mut Color,
+        scattered: &mut Ray,
+    ) -> bool {
+        let normal = rec.normal;
+        let view = -utils::unit_vector(r_in.direction());
+        let n = if rec.front_face { normal } else { -normal };
+
+        // Sample half vector from GGX VNDF
+        let h = brdf::sample_vndf_ggx(view, self.roughness);
+        let h = if utils::dot(h, n) < 0.0 { -h } else { h };
+
+        let cos_theta = utils::dot(view, h).max(0.0);
+        let f0 = Color::new(1.0, 1.0, 1.0) * (((1.0 - self.ior) / (1.0 + self.ior)).powi(2));
+        let fresnel = brdf::fresnel_schlick(cos_theta, f0);
+
+        // Decide between reflection and refraction
+        let reflect = utils::random() < fresnel.x();
+
+        let direction = if reflect {
+            utils::reflect(view, h)
+        } else {
+            let eta = if rec.front_face || self.thin {
+                1.0 / self.ior
+            } else {
+                self.ior
+            };
+            utils::refract(view, h, eta)
+        };
+
+        *scattered = Ray::new(rec.p, direction);
+
+        // Attenuation for transmission (Beer’s Law)
+        if reflect || self.thin {
+            *attenuation = Color::new(1.0, 1.0, 1.0);
+        } else if let Some(abs) = self.absorption {
+            let distance = 1.0; // Or distance inside medium, if available
+            *attenuation = Color::new(
+                (-abs.x() * distance).exp(),
+                (-abs.y() * distance).exp(),
+                (-abs.z() * distance).exp(),
+            );
+        } else {
+            *attenuation = Color::new(1.0, 1.0, 1.0);
+        }
+
         true
     }
 }

--- a/crates/crust-render/src/material/mod.rs
+++ b/crates/crust-render/src/material/mod.rs
@@ -5,7 +5,7 @@ pub use lambert::Lambertian;
 mod metal;
 pub use metal::Metal;
 mod dielectric;
-pub use dielectric::Dielectric;
+pub use dielectric::{ComplexDielectric, Dielectric};
 mod blinn_phong;
 pub use blinn_phong::BlinnPhong;
 mod cook_torrance;


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `ComplexDielectric` material with advanced scattering logic.
  - Supports GGX VNDF sampling and Fresnel effects.
  - Includes absorption and thin material handling.

- Implemented `unique_timestamp` function for saving images with unique names.
  - Images are saved in the `test_images` directory.

- Refactored `tone_map` function for reusability in the `convert` module.

- Updated `.gitignore` to exclude the `test_images` directory.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>convert.rs</strong><dd><code>Refactor image saving and tone mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/crust-render/src/convert.rs

<li>Added <code>unique_timestamp</code> function for unique image naming.<br> <li> Refactored <code>tone_map</code> function for reusability.<br> <li> Updated image saving to use <code>unique_timestamp</code>.


</details>


  </td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/38/files#diff-fa50cbd46fd45f24e3ec0f2c5005bbfea3b1b2d9f96fabed12181ff9c0be5841">+28/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dielectric.rs</strong><dd><code>Introduced ComplexDielectric material with advanced features</code></dd></summary>
<hr>

crates/crust-render/src/material/dielectric.rs

<li>Added <code>ComplexDielectric</code> material with advanced scattering logic.<br> <li> Implemented GGX VNDF sampling and Fresnel effects.<br> <li> Included absorption and thin material handling.


</details>


  </td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/38/files#diff-387e713e08e541b2c4d59556d20f6405d7da2cf1cb4d8ff11b33d147165a9981">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Export ComplexDielectric material</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/crust-render/src/material/mod.rs

- Exported `ComplexDielectric` material for external use.


</details>


  </td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/38/files#diff-3200ae6ceb057d49d385801f44b4033917dc24eb49a35d51afffbc00a6d724d0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>