### PR TITLE
Add indicatif for progress tracking in rendering process

### DIFF
--- a/crates/crust-render/Cargo.toml
+++ b/crates/crust-render/Cargo.toml
@@ -18,6 +18,7 @@ clap = { version = "4.5.34", features = ["derive"] }
 serde.workspace = true
 ron = "0.9.0"
 obj-rs = "0.7.4"
+indicatif = "0.17.11"
 
 [dependencies.tracing]
 version = "0.1.41"

--- a/crates/crust-render/src/tracer.rs
+++ b/crates/crust-render/src/tracer.rs
@@ -35,6 +35,9 @@ impl Renderer {
         let samples_sqrt = (self.settings.samples_per_pixel as f32).sqrt().ceil() as usize;
         let cmj_samples = generate_cmj_2d(samples_sqrt);
         let bar = ProgressBar::new(self.settings.height as u64);
+        bar.set_style(indicatif::ProgressStyle::default_bar()
+            .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})")
+            .unwrap());
         for j in (0..self.settings.height).rev() {
             let pixel_colors: Vec<_> = (0..self.settings.width)
                 .into_par_iter()

--- a/crates/crust-render/src/tracer.rs
+++ b/crates/crust-render/src/tracer.rs
@@ -6,6 +6,7 @@ use crate::{LightList, camera::Camera, hittable_list::HittableList};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use utils::Color;
+use indicatif::ProgressBar;
 
 pub struct Renderer {
     pub camera: Camera,
@@ -33,8 +34,8 @@ impl Renderer {
         let mut buffer = Buffer::new(self.settings.width, self.settings.height);
         let samples_sqrt = (self.settings.samples_per_pixel as f32).sqrt().ceil() as usize;
         let cmj_samples = generate_cmj_2d(samples_sqrt);
+        let bar = ProgressBar::new(self.settings.height as u64);
         for j in (0..self.settings.height).rev() {
-            eprint!("\rScanlines remaining: {} ", j);
             let pixel_colors: Vec<_> = (0..self.settings.width)
                 .into_par_iter()
                 .map(|i| {
@@ -83,7 +84,9 @@ impl Renderer {
             for (i, pixel_color) in pixel_colors.into_iter().enumerate() {
                 buffer.set_pixel(i, j, pixel_color);
             }
+            bar.inc(1);
         }
+        bar.finish();
         buffer
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `indicatif` progress bar for rendering process.

- Integrated progress bar into the `Renderer::render` method.

- Updated `Cargo.toml` to include `indicatif` dependency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tracer.rs</strong><dd><code>Integrated `indicatif` progress bar in rendering logic</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/crust-render/src/tracer.rs

<li>Imported <code>indicatif::ProgressBar</code> for progress tracking.<br> <li> Initialized and used a progress bar in the <code>render</code> method.<br> <li> Removed previous scanline logging with <code>eprint!</code>.


</details>


  </td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/55/files#diff-bf85d031ec2251e76907e3c8fa87c2b1e63be00702868f423a0526b8e2c686f0">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Added `indicatif` dependency to Cargo.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/crust-render/Cargo.toml

- Added `indicatif` version `0.17.11` as a dependency.


</details>


  </td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/55/files#diff-bf38ade4ebcb331ebffeffa14ad214bd6ed741bd305eb66fc6c4c24d4e98c07c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>