### PR TITLE
Add instance management and matrix transformations for object handling

### DIFF
--- a/crates/crust-render/Cargo.toml
+++ b/crates/crust-render/Cargo.toml
@@ -19,6 +19,7 @@ serde.workspace = true
 ron = "0.9.0"
 obj-rs = "0.7.4"
 indicatif = "0.17.11"
+once_cell = "1.21.3"
 
 [dependencies.tracing]
 version = "0.1.41"

--- a/crates/crust-render/src/aabb.rs
+++ b/crates/crust-render/src/aabb.rs
@@ -34,14 +34,14 @@ impl AABB {
             let inv_d = 1.0 / ray.direction()[a];
             let mut t0 = (self.minimum[a] - ray.origin()[a]) * inv_d;
             let mut t1 = (self.maximum[a] - ray.origin()[a]) * inv_d;
-    
+
             if inv_d < 0.0 {
                 std::mem::swap(&mut t0, &mut t1);
             }
-    
+
             t_min = t_min.max(t0);
             t_max = t_max.min(t1);
-    
+
             if t_max <= t_min {
                 return false;
             }

--- a/crates/crust-render/src/document.rs
+++ b/crates/crust-render/src/document.rs
@@ -5,7 +5,7 @@ use crate::hittable::Hittable;
 use crate::hittable_list::HittableList;
 use crate::instance::Instance;
 use crate::light::{self, LightList};
-use crate::primitives::{Object, Primitive};
+use crate::primitives::{Object, Primitive, BVHNode};
 use crate::tracer::RenderSettings;
 use serde::{Deserialize, Serialize};
 use std::io::Write;
@@ -14,6 +14,9 @@ use std::sync::Arc;
 use tracing::error;
 use tracing::warn;
 use utils::{Mat4, Point3};
+use crate::scene_cache::GLOBAL_OBJ_CACHE;
+use obj::{Obj, load_obj};
+use std::{fs::File, io::BufReader};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Document {
@@ -161,11 +164,6 @@ impl DocObject {
 }
 
 pub fn load_obj_bvh(path: &str, material: Arc<dyn Material>) -> Arc<dyn Hittable> {
-    use crate::primitives::{BVHNode, Object}; // Your actual modules
-    use crate::scene_cache::GLOBAL_OBJ_CACHE;
-    use obj::{Obj, load_obj};
-    use std::{fs::File, io::BufReader};
-
     {
         let cache = GLOBAL_OBJ_CACHE.read().unwrap();
         if let Some(bvh) = cache.get(path) {

--- a/crates/crust-render/src/document.rs
+++ b/crates/crust-render/src/document.rs
@@ -5,18 +5,18 @@ use crate::hittable::Hittable;
 use crate::hittable_list::HittableList;
 use crate::instance::Instance;
 use crate::light::{self, LightList};
-use crate::primitives::{Object, Primitive, BVHNode};
+use crate::primitives::{BVHNode, Object, Primitive};
+use crate::scene_cache::GLOBAL_OBJ_CACHE;
 use crate::tracer::RenderSettings;
+use obj::{Obj, load_obj};
 use serde::{Deserialize, Serialize};
 use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
+use std::{fs::File, io::BufReader};
 use tracing::error;
 use tracing::warn;
 use utils::{Mat4, Point3};
-use crate::scene_cache::GLOBAL_OBJ_CACHE;
-use obj::{Obj, load_obj};
-use std::{fs::File, io::BufReader};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Document {
@@ -85,7 +85,7 @@ impl Document {
                     world.add(Box::new(Instance {
                         object: shared_bvh,
                         transform: my_transform,
-                        inverse_transform: my_transform,  // Identity matrix is its own inverse
+                        inverse_transform: my_transform, // Identity matrix is its own inverse
                     }) as Box<dyn Hittable>);
                 }
             }

--- a/crates/crust-render/src/document.rs
+++ b/crates/crust-render/src/document.rs
@@ -77,12 +77,12 @@ impl Document {
                 }
                 Primitive::Obj { path } => {
                     let shared_bvh = load_obj_bvh(&path, material.clone());
-                    let my_transform = Mat4::translate(0.0, 0.0, 0.0) * Mat4::scale(1.0);
+                    let my_transform = Mat4::identity();
 
                     world.add(Box::new(Instance {
                         object: shared_bvh,
                         transform: my_transform,
-                        inverse_transform: my_transform.inverse(),
+                        inverse_transform: my_transform,  // Identity matrix is its own inverse
                     }) as Box<dyn Hittable>);
                 }
             }

--- a/crates/crust-render/src/instance.rs
+++ b/crates/crust-render/src/instance.rs
@@ -1,0 +1,44 @@
+use crate::aabb::AABB;
+use crate::hittable::{HitRecord, Hittable};
+use crate::ray::Ray;
+use std::sync::Arc;
+use utils::Mat4; // Adjust based on your math module
+
+pub struct Instance {
+    pub object: Arc<dyn Hittable>,
+    pub transform: Mat4,
+    pub inverse_transform: Mat4,
+}
+
+impl Hittable for Instance {
+    fn hit(&self, r: &Ray, t_min: f32, t_max: f32, rec: &mut HitRecord) -> bool {
+        let transformed_ray = Ray::new(
+            self.inverse_transform.transform_point(r.origin()),
+            self.inverse_transform.transform_direction(r.direction()),
+        );
+
+        let mut temp_rec = HitRecord::default();
+
+        if !self
+            .object
+            .hit(&transformed_ray, t_min, t_max, &mut temp_rec)
+        {
+            return false;
+        }
+
+        temp_rec.p = self.transform.transform_point(temp_rec.p);
+        temp_rec.set_face_normal(
+            r,
+            self.transform
+                .transform_direction(temp_rec.normal)
+                .unit_vector(),
+        );
+
+        *rec = temp_rec;
+        true
+    }
+
+    fn bounding_box(&self) -> Option<AABB> {
+        self.object.bounding_box() // not transformed — OK for now
+    }
+}

--- a/crates/crust-render/src/instance.rs
+++ b/crates/crust-render/src/instance.rs
@@ -39,6 +39,43 @@ impl Hittable for Instance {
     }
 
     fn bounding_box(&self) -> Option<AABB> {
-        self.object.bounding_box() // not transformed — OK for now
+        if let Some(bbox) = self.object.bounding_box() {
+            // Transform the bounding box corners
+            let min = bbox.minimum;
+            let max = bbox.maximum;
+        
+            // Transform all 8 corners of the box and find the new bounds
+            let corners = [
+                Point3::new(min.x(), min.y(), min.z()),
+                Point3::new(max.x(), min.y(), min.z()),
+                Point3::new(min.x(), max.y(), min.z()),
+                Point3::new(min.x(), min.y(), max.z()),
+                Point3::new(max.x(), max.y(), min.z()),
+                Point3::new(max.x(), min.y(), max.z()),
+                Point3::new(min.x(), max.y(), max.z()),
+                Point3::new(max.x(), max.y(), max.z()),
+            ];
+        
+            let mut new_min = self.transform.transform_point(corners[0]);
+            let mut new_max = new_min;
+        
+            for i in 1..8 {
+                let p = self.transform.transform_point(corners[i]);
+                new_min = Point3::new(
+                    new_min.x().min(p.x()),
+                    new_min.y().min(p.y()),
+                    new_min.z().min(p.z()),
+                );
+                new_max = Point3::new(
+                    new_max.x().max(p.x()),
+                    new_max.y().max(p.y()),
+                    new_max.z().max(p.z()),
+                );
+            }
+        
+            Some(AABB::new(new_min, new_max))
+        } else {
+            None
+        }
     }
 }

--- a/crates/crust-render/src/instance.rs
+++ b/crates/crust-render/src/instance.rs
@@ -2,7 +2,7 @@ use crate::aabb::AABB;
 use crate::hittable::{HitRecord, Hittable};
 use crate::ray::Ray;
 use std::sync::Arc;
-use utils::Mat4; // Adjust based on your math module
+use utils::{Mat4,Point3};
 
 pub struct Instance {
     pub object: Arc<dyn Hittable>,

--- a/crates/crust-render/src/instance.rs
+++ b/crates/crust-render/src/instance.rs
@@ -2,7 +2,7 @@ use crate::aabb::AABB;
 use crate::hittable::{HitRecord, Hittable};
 use crate::ray::Ray;
 use std::sync::Arc;
-use utils::{Mat4,Point3};
+use utils::{Mat4, Point3};
 
 pub struct Instance {
     pub object: Arc<dyn Hittable>,
@@ -43,7 +43,7 @@ impl Hittable for Instance {
             // Transform the bounding box corners
             let min = bbox.minimum;
             let max = bbox.maximum;
-        
+
             // Transform all 8 corners of the box and find the new bounds
             let corners = [
                 Point3::new(min.x(), min.y(), min.z()),
@@ -55,10 +55,10 @@ impl Hittable for Instance {
                 Point3::new(min.x(), max.y(), max.z()),
                 Point3::new(max.x(), max.y(), max.z()),
             ];
-        
+
             let mut new_min = self.transform.transform_point(corners[0]);
             let mut new_max = new_min;
-        
+
             for i in 1..8 {
                 let p = self.transform.transform_point(corners[i]);
                 new_min = Point3::new(
@@ -72,7 +72,7 @@ impl Hittable for Instance {
                     new_max.z().max(p.z()),
                 );
             }
-        
+
             Some(AABB::new(new_min, new_max))
         } else {
             None

--- a/crates/crust-render/src/lib.rs
+++ b/crates/crust-render/src/lib.rs
@@ -5,11 +5,13 @@ mod convert;
 mod document;
 mod hittable;
 mod hittable_list;
+mod instance;
 mod light;
 mod material;
 mod primitives;
 mod ray;
 mod sampler;
+mod scene_cache;
 mod tracer;
 mod world;
 

--- a/crates/crust-render/src/primitives/mod.rs
+++ b/crates/crust-render/src/primitives/mod.rs
@@ -1,5 +1,6 @@
 mod generator;
 mod prim;
 pub use generator::{UVSphere, UVTorus};
+pub use prim::BVHNode;
 pub use prim::Object;
 pub use prim::Primitive;

--- a/crates/crust-render/src/primitives/prim.rs
+++ b/crates/crust-render/src/primitives/prim.rs
@@ -5,7 +5,6 @@ use crate::ray::Ray;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::BufReader;
-use rand::Rng;
 use std::sync::Arc;
 use std::sync::RwLock;
 use tracing::error;
@@ -76,14 +75,6 @@ impl Object {
     pub fn new_mesh(vertices: Vec<Point3>, indices: Vec<u32>, material: Arc<dyn Material>) -> Self {
         Self {
             primitive: Primitive::Mesh { vertices, indices },
-            material,
-            obj_cache: RwLock::new(None),
-        }
-    }
-
-    pub fn new_obj(path: String, material: Arc<dyn Material>) -> Self {
-        Self {
-            primitive: Primitive::Obj { path },
             material,
             obj_cache: RwLock::new(None),
         }

--- a/crates/crust-render/src/scene_cache.rs
+++ b/crates/crust-render/src/scene_cache.rs
@@ -1,0 +1,7 @@
+use crate::hittable::Hittable;
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+pub static GLOBAL_OBJ_CACHE: Lazy<RwLock<HashMap<String, Arc<dyn Hittable>>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));

--- a/crates/crust-render/src/tracer.rs
+++ b/crates/crust-render/src/tracer.rs
@@ -3,10 +3,10 @@ use crate::hittable::{HitRecord, Hittable};
 use crate::ray::Ray;
 use crate::sampler::generate_cmj_2d;
 use crate::{LightList, camera::Camera, hittable_list::HittableList};
+use indicatif::ProgressBar;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use utils::Color;
-use indicatif::ProgressBar;
 
 pub struct Renderer {
     pub camera: Camera,
@@ -35,9 +35,13 @@ impl Renderer {
         let samples_sqrt = (self.settings.samples_per_pixel as f32).sqrt().ceil() as usize;
         let cmj_samples = generate_cmj_2d(samples_sqrt);
         let bar = ProgressBar::new(self.settings.height as u64);
-        bar.set_style(indicatif::ProgressStyle::default_bar()
-            .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})")
-            .unwrap());
+        bar.set_style(
+            indicatif::ProgressStyle::default_bar()
+                .template(
+                    "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})",
+                )
+                .unwrap(),
+        );
         for j in (0..self.settings.height).rev() {
             let pixel_colors: Vec<_> = (0..self.settings.width)
                 .into_par_iter()

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -11,3 +11,5 @@ pub use common::{balance_heuristic, clamp};
 pub use common::{degrees_to_radians, random, random_range, random2};
 mod color;
 pub use color::Color;
+pub mod mat4;
+pub use mat4::Mat4;

--- a/crates/utils/src/mat4.rs
+++ b/crates/utils/src/mat4.rs
@@ -1,0 +1,78 @@
+use crate::{Point3, Vec3};
+use std::ops::Mul;
+#[derive(Debug, Clone, Copy)]
+pub struct Mat4 {
+    // 4x4 matrix as flat array or rows
+    pub data: [[f32; 4]; 4],
+}
+
+impl Mat4 {
+    pub fn identity() -> Self {
+        Mat4 {
+            data: [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+        }
+    }
+
+    pub fn translate(x: f32, y: f32, z: f32) -> Self {
+        let mut m = Self::identity();
+        m.data[0][3] = x;
+        m.data[1][3] = y;
+        m.data[2][3] = z;
+        m
+    }
+
+    pub fn scale(s: f32) -> Self {
+        let mut m = Self::identity();
+        m.data[0][0] = s;
+        m.data[1][1] = s;
+        m.data[2][2] = s;
+        m
+    }
+
+    pub fn transform_point(&self, p: Point3) -> Point3 {
+        let x = self.data[0][0] * p.x() + self.data[0][1] * p.y() + self.data[0][2] * p.z() + self.data[0][3];
+        let y = self.data[1][0] * p.x() + self.data[1][1] * p.y() + self.data[1][2] * p.z() + self.data[1][3];
+        let z = self.data[2][0] * p.x() + self.data[2][1] * p.y() + self.data[2][2] * p.z() + self.data[2][3];
+        Point3::new(x, y, z)
+    }
+
+    pub fn transform_direction(&self, v: Vec3) -> Vec3 {
+        let x = self.data[0][0] * v.x() + self.data[0][1] * v.y() + self.data[0][2] * v.z();
+        let y = self.data[1][0] * v.x() + self.data[1][1] * v.y() + self.data[1][2] * v.z();
+        let z = self.data[2][0] * v.x() + self.data[2][1] * v.y() + self.data[2][2] * v.z();
+        Vec3::new(x, y, z)
+    }
+    pub fn inverse(&self) -> Self {
+        let mut inv = Self::identity();
+        inv.data[0][0] = 1.0 / self.data[0][0]; // inverse scale
+        inv.data[1][1] = 1.0 / self.data[1][1];
+        inv.data[2][2] = 1.0 / self.data[2][2];
+    
+        inv.data[0][3] = -self.data[0][3] * inv.data[0][0];
+        inv.data[1][3] = -self.data[1][3] * inv.data[1][1];
+        inv.data[2][3] = -self.data[2][3] * inv.data[2][2];
+    
+        inv
+    }
+}
+
+impl Mul for Mat4 {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        let mut result = Mat4::identity();
+
+        for i in 0..4 {
+            for j in 0..4 {
+                result.data[i][j] = (0..4).map(|k| self.data[i][k] * rhs.data[k][j]).sum();
+            }
+        }
+
+        result
+    }
+}

--- a/crates/utils/src/mat4.rs
+++ b/crates/utils/src/mat4.rs
@@ -35,9 +35,18 @@ impl Mat4 {
     }
 
     pub fn transform_point(&self, p: Point3) -> Point3 {
-        let x = self.data[0][0] * p.x() + self.data[0][1] * p.y() + self.data[0][2] * p.z() + self.data[0][3];
-        let y = self.data[1][0] * p.x() + self.data[1][1] * p.y() + self.data[1][2] * p.z() + self.data[1][3];
-        let z = self.data[2][0] * p.x() + self.data[2][1] * p.y() + self.data[2][2] * p.z() + self.data[2][3];
+        let x = self.data[0][0] * p.x()
+            + self.data[0][1] * p.y()
+            + self.data[0][2] * p.z()
+            + self.data[0][3];
+        let y = self.data[1][0] * p.x()
+            + self.data[1][1] * p.y()
+            + self.data[1][2] * p.z()
+            + self.data[1][3];
+        let z = self.data[2][0] * p.x()
+            + self.data[2][1] * p.y()
+            + self.data[2][2] * p.z()
+            + self.data[2][3];
         Point3::new(x, y, z)
     }
 
@@ -52,11 +61,11 @@ impl Mat4 {
         inv.data[0][0] = 1.0 / self.data[0][0]; // inverse scale
         inv.data[1][1] = 1.0 / self.data[1][1];
         inv.data[2][2] = 1.0 / self.data[2][2];
-    
+
         inv.data[0][3] = -self.data[0][3] * inv.data[0][0];
         inv.data[1][3] = -self.data[1][3] * inv.data[1][1];
         inv.data[2][3] = -self.data[2][3] * inv.data[2][2];
-    
+
         inv
     }
 }


### PR DESCRIPTION
### **User description**
- Introduced `Instance` struct for managing object instances with transformations.
- Implemented `load_obj_bvh` function for loading and caching BVH from OBJ files.
- Added `Mat4` struct for matrix operations including translation, scaling, and transformation.
- Updated `Document` to utilize `Instance` for adding objects.
- Refactored `Cargo.toml` to include `once_cell` for caching.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduced `Instance` struct for object transformations.
  - Added matrix operations (`Mat4`) for transformations.
  - Implemented `load_obj_bvh` for shared BVH caching.

- Enhanced `Document` to use instances for OBJ objects.

- Added global caching mechanism for OBJ files using `once_cell`.

- Refactored and improved code formatting and readability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>aabb.rs</strong><dd><code>Minor formatting adjustments in AABB implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/56/files#diff-37f62c292a8eebe2176b71110896bd084ce4fef969e244d824126784c7cbcf39">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tracer.rs</strong><dd><code>Minor formatting adjustments in tracer module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/56/files#diff-bf85d031ec2251e76907e3c8fa87c2b1e63be00702868f423a0526b8e2c686f0">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>document.rs</strong><dd><code>Added instance support and shared BVH caching in Document</code></dd></td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/56/files#diff-7355d515f666315efe42ab9a387939b09bfac36df2c159099f0baad8b105b055">+49/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>instance.rs</strong><dd><code>Introduced `Instance` struct for object transformations</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/56/files#diff-f4f6f22a1abc633474a7e5586cfc5ea0a537abe9e10af5af5e8e442707364f97">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Exported BVHNode for shared BVH functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/56/files#diff-8ae427eda1a9222ecde8c64719fcbd3673219eed8900e394ffd9b233a5dad568">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>prim.rs</strong><dd><code>Removed unused `new_obj` and refactored Object struct</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/56/files#diff-ad598d9293d0d9728cc7342dfd7166ca9a65a26160773af16c4f857e5e304c76">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scene_cache.rs</strong><dd><code>Added global caching mechanism for OBJ files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/56/files#diff-05287afcfdc9d931ce6666c10f371ad6c8ca215f01fea62b3a71f3f0d5c18430">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Added `Mat4` module for matrix operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/56/files#diff-1d8b7844066af51d6bb14aa4305e0bb53c38989c7d0da3a6765e50eccbee8e15">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mat4.rs</strong><dd><code>Implemented `Mat4` struct for matrix transformations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/56/files#diff-26f772195daec2ed94f062765fd23d5549e7153699d3a1f9e64e119b0f61d085">+78/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>lib.rs</strong><dd><code>Added new modules for instance and scene caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/56/files#diff-7b8f8d453c9490b647f208bf9398197607162001f777fbd780aae4d8a65ef791">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Cargo.toml</strong><dd><code>Added `once_cell` dependency for caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/crust-render/pull/56/files#diff-bf38ade4ebcb331ebffeffa14ad214bd6ed741bd305eb66fc6c4c24d4e98c07c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>