### PR TITLE
Fix correctness bugs in material shaders

### DIFF
--- a/crates/crust-core/src/material/brdf.rs
+++ b/crates/crust-core/src/material/brdf.rs
@@ -79,11 +79,23 @@ pub fn disney_diffuse(
         * (1.0 + (fd90 - 1.0) * view_scatter)
 }
 
-// GTR1 distribution for clearcoat
+// GTR1 distribution for clearcoat (Disney / Burley).
+//
+// D_GTR1 = (a^2 - 1) / (PI * ln(a^2) * (1 + (a^2 - 1) * NdotH^2))
+//
+// The previous implementation squared the denominator (that is the GTR2/GGX
+// form) and dropped the `ln(a^2)` term. Because `alpha < 1`, the numerator
+// `a^2 - 1` is negative, so without the (also negative) `ln(a^2)` factor the
+// function returned a *negative* density, which made the clearcoat lobe
+// subtract energy instead of adding it.
 pub fn gtr1(n_dot_h: f32, alpha: f32) -> f32 {
     let a2 = alpha * alpha;
-    let denom = PI * ((n_dot_h * n_dot_h * (a2 - 1.0) + 1.0).powi(2));
-    (a2 - 1.0) / denom.max(1e-4)
+    if a2 >= 1.0 {
+        // Perfectly rough clearcoat degenerates to a uniform distribution.
+        return 1.0 / PI;
+    }
+    let t = 1.0 + (a2 - 1.0) * n_dot_h * n_dot_h;
+    (a2 - 1.0) / (PI * a2.ln() * t)
 }
 
 // Clearcoat Fresnel approx

--- a/crates/crust-core/src/material/dielectric.rs
+++ b/crates/crust-core/src/material/dielectric.rs
@@ -98,15 +98,20 @@ impl Material for ComplexDielectric {
         // Decide between reflection and refraction
         let reflect = utils::random() < fresnel.x;
 
+        // glam's `reflect`/`refract` expect the *incident* direction (pointing
+        // into the surface), not the view direction (pointing back toward the
+        // camera). Using `view` directly reflected the ray back into the
+        // surface; reflect the incident ray instead.
+        let incident = r_in.direction().normalize();
         let direction = if reflect {
-            view.reflect(h)
+            incident.reflect(h)
         } else {
             let eta = if rec.front_face || self.thin {
                 1.0 / self.ior
             } else {
                 self.ior
             };
-            view.refract(h, eta)
+            incident.refract(h, eta)
         };
 
         *scattered = Ray::new(rec.p, direction);

--- a/crates/crust-core/src/material/disney.rs
+++ b/crates/crust-core/src/material/disney.rs
@@ -92,7 +92,11 @@ impl Material for Disney {
 
         // Clearcoat lobe
         let h_clear = (v + l).normalize();
-        let clear_alpha = (1.0 - self.clearcoat_gloss).lerp(0.1, 0.001);
+        // Disney maps clearcoat gloss to roughness as mix(0.1, 0.001, gloss):
+        // gloss = 0 -> 0.1 (soft coat), gloss = 1 -> 0.001 (sharp coat).
+        // The previous `(1.0 - gloss).lerp(0.1, 0.001)` interpolated the *gloss
+        // value itself* by a constant t = 0.001, which is meaningless.
+        let clear_alpha = (0.1_f32).lerp(0.001, self.clearcoat_gloss);
         #[allow(non_snake_case)]
         let Dc = gtr1(n.dot(h_clear).max(0.0), clear_alpha);
         #[allow(non_snake_case)]

--- a/crates/crust-core/src/material/emissive.rs
+++ b/crates/crust-core/src/material/emissive.rs
@@ -75,8 +75,15 @@ impl Light for Emissive {
     fn pdf(&self, hit_point: Vec3A, light_point: Vec3A) -> f32 {
         let direction = light_point - hit_point;
         let distance_squared = direction.length_squared();
-        let normal = direction.normalize();
-        let cosine = f32::max(normal.dot((light_point - hit_point).normalize()), 0.0);
+        let dir_to_light = direction.normalize();
+        // Solid-angle pdf of sampling this point on the sphere uniformly by
+        // area: dist^2 / (cos(theta_light) * area), where theta_light is the
+        // angle between the light's *surface* normal at `light_point` and the
+        // direction back toward the shaded point. The previous code dotted the
+        // direction with itself, so the cosine was always 1.0, dropping the
+        // grazing-angle foreshortening entirely.
+        let light_normal = (light_point - self.position).normalize();
+        let cosine = f32::max(light_normal.dot(-dir_to_light), 0.0);
         let area = 4.0 * std::f32::consts::PI * self.radius * self.radius;
         distance_squared / (cosine * area + 1e-4)
     }

--- a/crates/crust-core/src/material/lambert.rs
+++ b/crates/crust-core/src/material/lambert.rs
@@ -3,7 +3,7 @@ use crate::material::Material;
 use crate::ray::Ray;
 use glam::Vec3A;
 use serde::{Deserialize, Serialize};
-use utils::random3;
+use utils::random_unit_vector;
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Lambertian {
     albedo: Vec3A,
@@ -23,7 +23,12 @@ impl Material for Lambertian {
         attenuation: &mut Vec3A,
         scattered: &mut Ray,
     ) -> bool {
-        let mut scatter_direction = rec.normal + random3();
+        // True Lambertian scattering: perturb the normal by a uniformly random
+        // unit vector. Previously this used `random3()`, which returns a vector
+        // with each component in [0, 1) — i.e. always pointing into the
+        // (+x, +y, +z) octant — biasing every diffuse bounce toward one corner
+        // of the world instead of producing an unbiased cosine distribution.
+        let mut scatter_direction = rec.normal + random_unit_vector();
 
         // Catch degenerate scatter direction
         if is_near_zero(scatter_direction) {

--- a/crates/utils/src/common.rs
+++ b/crates/utils/src/common.rs
@@ -70,6 +70,21 @@ pub fn random_vec3_unit_sphere(rng: &mut impl Rng) -> Vec3A {
     }
 }
 
+// Function to generate a uniformly distributed random Vec3A on the unit sphere
+// (a true random unit vector). Used for Lambertian diffuse scattering.
+pub fn random_unit_vector() -> Vec3A {
+    let mut rng = rand::rng();
+    loop {
+        let v = random_vec3_unit_cube(&mut rng);
+        let len_sq = v.length_squared();
+        // Reject points outside the unit sphere and the (near) origin to avoid
+        // dividing by zero when normalizing.
+        if (1e-12..1.0).contains(&len_sq) {
+            return v / len_sq.sqrt();
+        }
+    }
+}
+
 pub fn random_in_unit_disk() -> Vec3A {
     loop {
         let p = Vec3A::new(random_range(-1.0, 1.0), random_range(-1.0, 1.0), 0.0);

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -2,6 +2,6 @@ mod common;
 pub use common::Lerp;
 pub use common::{
     align_to_normal, degrees_to_radians, random, random_cosine_direction, random_in_unit_disk,
-    random_range, random_range3, random_vec3_unit_sphere, random2, random3,
+    random_range, random_range3, random_unit_vector, random_vec3_unit_sphere, random2, random3,
 };
 pub use common::{balance_heuristic, clamp};


### PR DESCRIPTION
Several of the BRDF/material "shaders" had concrete physical-correctness
bugs. This fixes the most impactful ones:

- Lambertian: diffuse scatter used `random3()`, whose components are each
  in [0, 1), so every bounce was perturbed toward the (+x, +y, +z) octant
  instead of by an unbiased random unit vector. Added `random_unit_vector()`
  to utils and use it for true cosine-distributed Lambertian scattering.

- Disney GTR1 (clearcoat): the distribution used the squared GGX denominator
  and dropped the `ln(a^2)` term, so with alpha < 1 it returned a *negative*
  density and the clearcoat lobe subtracted energy. Replaced with the correct
  GTR1 formula.

- Disney clearcoat roughness: `(1.0 - gloss).lerp(0.1, 0.001)` interpolated
  the gloss value by a constant t = 0.001 (meaningless). Replaced with the
  Disney mapping mix(0.1, 0.001, gloss).

- ComplexDielectric: reflected the view direction (pointing toward the
  camera) instead of the incident ray, sending reflected rays back into the
  surface. Reflect/refract the incident direction instead.

- Emissive light pdf: the cosine foreshortening term dotted a vector with
  itself and was therefore always 1.0. Use the sphere light's surface normal
  so grazing-angle samples are correctly weighted.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017xSVen8UzL44ST1MSeMcad