### PR TITLE
Compose xformOp stacks ourselves, fixing the cornellbox mis-render

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,21 +158,16 @@ that mention a `usd` **feature flag** are stale — there is no such feature.
 
 ## Known incomplete work
 
-- **`samples/cornellbox.usda` renders wrong — upstream `openusd` xformOp bug.** The image
-  shows a few floating objects against sky (~89% of primary rays miss the scene) instead
-  of a Cornell box. Root cause: `openusd` 0.5.0 (latest as of 2026-06) composes multi-op
-  `xformOpOrder` stacks in the wrong order. UsdGeomXformable applies ops in *reverse*
-  declaration order — for the Maya-authored `["xformOp:translate", "xformOp:scale"]` the
-  scale applies to points first and the translate last, so the local matrix's translation
-  must equal the authored translate. Instead `local_to_parent_transform` returns the
-  translate *multiplied by the scale*: `pCube1` (translate `(0,2,0)`, scale 4) comes back
-  with translation `(0,8,0)`, so the box shell lands at y∈[6,10] instead of y∈[0,4], and
-  every scaled prop shrinks toward the origin (`pSphere1`: authored translate
-  `(-1.156, 0.2, -0.556)`, scale 0.2 → returned translation `(-0.231, 0.04, -0.111)`).
-  Translate-only prims (all cameras/lights, every prim in the other samples) are
-  unaffected, which is why only this scene breaks. Fix options: patch upstream, or stop
-  using `local_to_parent_transform` in `usd_import.rs::local_matrix_at` and compose the
-  individual `xformOp:*` attrs ourselves in reverse order. See the note at that function.
+- **Upstream `openusd` xformOp bug, worked around locally.** `openusd` 0.5.0 (latest as
+  of 2026-06) composes multi-op `xformOpOrder` stacks in the wrong order (the authored
+  translate comes back multiplied by the scale), which used to make
+  `samples/cornellbox.usda` render as floating objects against sky. `usd_import.rs`
+  therefore composes the individual `xformOp:*` attributes itself
+  (`compose_xform_ops`: translate/scale/rotateX·Y·Z/rotate-Euler-triples/orient/
+  transform, `!invert!` prefixes, namespaced suffixes), falling back to openusd's
+  composition — with a warning — only for op kinds it cannot decode. Regression test:
+  `cornellbox_transforms_compose_correctly`. If upstream fixes the bug, the fallback
+  (`local_matrix_via_openusd`) and possibly the whole composer can be dropped.
 - USD lux light schemas beyond `SphereLight`/`RectLight` are skipped (see above). Disk
   lights need a disk primitive; distant/dome lights need non-area `Light` impls and
   integrator support for lights without scene geometry.

--- a/crates/crust-core/src/scene/usd_import.rs
+++ b/crates/crust-core/src/scene/usd_import.rs
@@ -142,21 +142,141 @@ fn usd_mat_to_glam(m: Matrix4d) -> GMat4 {
     ])
 }
 
-/// Local-to-parent transform of `prim`, tried across the concrete
-/// Xformable schemas the tracer cares about.
+/// Local-to-parent transform of `prim`, composed from its authored
+/// `xformOp:*` attributes by [`compose_xform_ops`].
 ///
-/// KNOWN BUG (upstream, openusd 0.5.0): `local_to_parent_transform`
-/// composes multi-op `xformOpOrder` stacks in the wrong order. USD applies
-/// ops in reverse declaration order (for Maya's
-/// `["xformOp:translate", "xformOp:scale"]` the translate is outermost),
-/// but openusd returns the translate multiplied by the scale — e.g.
-/// `samples/cornellbox.usda`'s `pCube1` (translate `(0,2,0)`, scale 4)
-/// yields translation `(0,8,0)`, which is why that scene renders as
-/// floating objects against sky. Translate-only prims are unaffected.
-/// Fix: patch upstream, or read the individual `xformOp:*` attributes here
-/// and compose them ourselves in reverse order. See CLAUDE.md → "Known
-/// incomplete work".
+/// This deliberately does NOT use openusd's `local_to_parent_transform`:
+/// openusd 0.5.0 composes multi-op `xformOpOrder` stacks in the wrong
+/// order (the authored translate comes back multiplied by the scale — e.g.
+/// cornellbox's `pCube1`, translate `(0,2,0)` · scale 4, yielded
+/// translation `(0,8,0)`), which made `samples/cornellbox.usda` render as
+/// floating objects against sky. Stacks with an op we cannot decode fall
+/// back to openusd's composition with a warning, so unusual scenes behave
+/// no worse than before.
 fn local_matrix_at(stage: &Stage, prim: &Prim) -> GMat4 {
+    match compose_xform_ops(prim) {
+        Some(m) => m,
+        None => {
+            warn!(
+                "could not decode the xformOp stack at {} — falling back to openusd's \
+                 composition (known to be wrong for multi-op stacks)",
+                prim.path()
+            );
+            local_matrix_via_openusd(stage, prim)
+        }
+    }
+}
+
+/// Composes the prim's `xformOpOrder` stack into a local-to-parent matrix.
+///
+/// UsdGeomXformable semantics, in the column-vector convention used here:
+/// for `xformOpOrder = [op1, op2, …, opN]` a point transforms as
+/// `p' = M(op1)·M(op2)·…·M(opN)·p` — the last-listed op is applied to the
+/// point first and the first-listed is outermost. (Maya's
+/// `["xformOp:translate", "xformOp:scale"]` therefore scales points first
+/// and translates last: the composed translation equals the authored
+/// translate.)
+///
+/// Returns `None` if any op token or value cannot be decoded.
+fn compose_xform_ops(prim: &Prim) -> Option<GMat4> {
+    let order = match prim.attribute("xformOpOrder").get::<sdf::Value>() {
+        Ok(Some(sdf::Value::TokenVec(order))) => order,
+        Ok(Some(_)) => return None,
+        // No order authored: authored xformOp attrs (if any) do not apply.
+        _ => return Some(GMat4::IDENTITY),
+    };
+
+    let mut local = GMat4::IDENTITY;
+    for token in &order {
+        // Not a transform op: it truncates the inherited stack, which
+        // `resets_xform_stack_at` reports separately.
+        if token == "!resetXformStack!" {
+            continue;
+        }
+        let (name, inverted) = match token.strip_prefix("!invert!") {
+            Some(rest) => (rest, true),
+            None => (token.as_str(), false),
+        };
+        let mut m = xform_op_matrix(prim, name)?;
+        if inverted {
+            m = m.inverse();
+        }
+        local *= m;
+    }
+    Some(local)
+}
+
+/// Matrix of a single `xformOp:<kind>[:<suffix>]` attribute on `prim`, or
+/// `None` for op kinds/value types we do not support.
+fn xform_op_matrix(prim: &Prim, name: &str) -> Option<GMat4> {
+    let kind = name.strip_prefix("xformOp:")?;
+    // Suffixes name op instances (`xformOp:translate:pivot`); the kind is
+    // the first segment.
+    let kind = kind.split(':').next().unwrap_or(kind);
+    let value = prim.attribute(name).get::<sdf::Value>().ok().flatten()?;
+
+    match kind {
+        "translate" => Some(GMat4::from_translation(value_as_vec3(&value)?)),
+        "scale" => Some(GMat4::from_scale(value_as_vec3(&value)?)),
+        "transform" => match value {
+            sdf::Value::Matrix4d(m) => Some(usd_mat_to_glam(m)),
+            _ => None,
+        },
+        "orient" => match value {
+            sdf::Value::Quatf(q) => Some(GMat4::from_quat(
+                glam::Quat::from_xyzw(q.x, q.y, q.z, q.w).normalize(),
+            )),
+            sdf::Value::Quatd(q) => Some(GMat4::from_quat(
+                glam::Quat::from_xyzw(q.x as f32, q.y as f32, q.z as f32, q.w as f32).normalize(),
+            )),
+            _ => None,
+        },
+        "rotateX" => Some(GMat4::from_rotation_x(value_as_f32(&value)?.to_radians())),
+        "rotateY" => Some(GMat4::from_rotation_y(value_as_f32(&value)?.to_radians())),
+        "rotateZ" => Some(GMat4::from_rotation_z(value_as_f32(&value)?.to_radians())),
+        // Euler triples: the vector components are always the X/Y/Z-axis
+        // angles in degrees; the op name gives the application order, first
+        // named axis applied to the point first (so it sits rightmost).
+        "rotateXYZ" | "rotateXZY" | "rotateYXZ" | "rotateYZX" | "rotateZXY" | "rotateZYX" => {
+            let v = value_as_vec3(&value)?;
+            let rx = GMat4::from_rotation_x(v.x.to_radians());
+            let ry = GMat4::from_rotation_y(v.y.to_radians());
+            let rz = GMat4::from_rotation_z(v.z.to_radians());
+            Some(match kind {
+                "rotateXYZ" => rz * ry * rx,
+                "rotateXZY" => ry * rz * rx,
+                "rotateYXZ" => rz * rx * ry,
+                "rotateYZX" => rx * rz * ry,
+                "rotateZXY" => ry * rx * rz,
+                _ => rx * ry * rz, // rotateZYX
+            })
+        }
+        _ => None,
+    }
+}
+
+fn value_as_vec3(value: &sdf::Value) -> Option<Vec3> {
+    match value {
+        sdf::Value::Vec3f(v) => Some(Vec3::new(v.x, v.y, v.z)),
+        sdf::Value::Vec3d(v) => Some(Vec3::new(v.x as f32, v.y as f32, v.z as f32)),
+        sdf::Value::Vec3h(v) => Some(Vec3::new(v.x.to_f32(), v.y.to_f32(), v.z.to_f32())),
+        _ => None,
+    }
+}
+
+fn value_as_f32(value: &sdf::Value) -> Option<f32> {
+    match value {
+        sdf::Value::Float(v) => Some(*v),
+        sdf::Value::Double(v) => Some(*v as f32),
+        sdf::Value::Half(v) => Some(v.to_f32()),
+        _ => None,
+    }
+}
+
+/// openusd's own composition, kept as the fallback for op stacks
+/// `compose_xform_ops` cannot decode. Known to compose multi-op stacks in
+/// the wrong order (see `local_matrix_at`).
+fn local_matrix_via_openusd(stage: &Stage, prim: &Prim) -> GMat4 {
     if let Ok(Some(x)) = Xform::get(stage, prim.path().clone()) {
         if let Ok(m) = x.local_to_parent_transform(0.0) {
             return usd_mat_to_glam(m);

--- a/crates/crust-core/tests/usd_scene.rs
+++ b/crates/crust-core/tests/usd_scene.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crust_core::Scene;
+use crust_core::{Hittable, Scene};
 use openusd::schemas::shade::{Material as UsdMaterial, MaterialBindingAPI};
 use openusd::sdf;
 use openusd::usd::{PrimPredicate, Stage};
@@ -66,6 +66,40 @@ fn loads_openpbr_showcase_usda() {
         scene.lights.count(),
         scene.settings.get_dimensions(),
     );
+}
+
+/// Regression guard for xformOp composition: the Maya-authored Cornell box
+/// (`pCube1`: translate `(0,2,0)` then scale 4, i.e. a multi-op stack)
+/// must land with its shell spanning x,z ∈ [-2,2] and y ∈ [0,4]. openusd
+/// 0.5.0's `local_to_parent_transform` composes such stacks in the wrong
+/// order (translation came back scaled → shell at y ∈ [6,10], props shrunk
+/// toward the origin), which is why `usd_import` composes the individual
+/// `xformOp:*` attributes itself.
+#[test]
+fn cornellbox_transforms_compose_correctly() {
+    let scene = Scene::from_usd(&sample("cornellbox.usda"))
+        .expect("failed to open cornellbox.usda");
+    let bbox = scene
+        .world
+        .bounding_box()
+        .expect("cornellbox world must be bounded");
+
+    let tol = 0.1;
+    assert!(
+        (bbox.minimum.y).abs() < tol && (bbox.maximum.y - 4.0).abs() < tol,
+        "box shell must span y in [0, 4], got [{}, {}]",
+        bbox.minimum.y,
+        bbox.maximum.y
+    );
+    for (min, max, axis) in [
+        (bbox.minimum.x, bbox.maximum.x, "x"),
+        (bbox.minimum.z, bbox.maximum.z, "z"),
+    ] {
+        assert!(
+            (min + 2.0).abs() < tol && (max - 2.0).abs() < tol,
+            "box shell must span {axis} in [-2, 2], got [{min}, {max}]"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
samples/cornellbox.usda rendered as a few floating objects against sky (~89% of primary rays missed the scene) because openusd 0.5.0's local_to_parent_transform composes multi-op xformOpOrder stacks in the wrong order: the authored translate comes back multiplied by the scale (pCube1, translate (0,2,0) . scale 4, yielded translation (0,8,0), so the box shell sat at y in [6,10] and every scaled prop shrank toward the origin). Documented on main; this is the local workaround.

usd_import now composes the individual xformOp:* attributes itself (compose_xform_ops), following UsdGeomXformable semantics — for xformOpOrder = [op1, op2, ...] a point transforms as M(op1)*M(op2)*...*p, last-listed op applied first. Supported ops: translate, scale, rotateX/Y/Z, all six Euler-triple orders, orient (quatf/quatd), transform (matrix4d), !invert! prefixes, and namespaced suffixes like xformOp:translate:pivot; float/double/half value types. Stacks with an op we cannot decode fall back to openusd's composition with a warning, so unusual scenes behave no worse than before. A side benefit: rotation ops on prims and lights now import correctly at all (the old path handled them only as well as openusd did).

Validation: the cornellbox shell now spans exactly the authored x,z in [-2,2], y in [0,4] (new regression test
cornellbox_transforms_compose_correctly) and the scene renders as an actual Cornell box interior. Translate-only scenes are bit-identical to main (openpbr_showcase and rectlight diff at 0.0 exactly), and the ignored end-to-end guiding tests still pass.


Claude-Session: https://claude.ai/code/session_01Rq4SviyyqSrzexwhFj17jk