### PR TITLE
Add hg_phase and fix HG sampling to the forward-scattering convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,8 @@ material types, `simple_scene`, `get_settings`). Prefer importing from `crust_co
 
 ## Render pipeline (the big picture)
 
-1. **`main.rs`** builds a `Scene { camera, world, lights, settings }` — either from USD
-   (`Scene::from_usd`) or the procedural fallback (`world::simple_scene` + `get_settings`).
+1. **`main.rs`** builds a `Scene { camera, world, lights, settings, volumes }` — either from
+   USD (`Scene::from_usd`) or the procedural fallback (`world::simple_scene` + `get_settings`).
 2. **`Renderer`** (`tracer.rs`) drives sampling. Two entry points, both Rayon-parallel:
    - `render()` — parallel over pixels within each scanline row.
    - `render_with_tiles()` — parallel over 16×16 tiles (the `--bucket` path).
@@ -68,10 +68,35 @@ material types, `simple_scene`, `get_settings`). Prefer importing from `crust_co
    - **Russian roulette** from the 4th vertex on (`RR_START_BOUNCE`): survival tracks
      path throughput with a probability floor (`RR_MIN_PROB`), factor divided out on
      survival.
-   - Volumetric scattering (Henyey-Greenstein) and Beer-Lambert attenuation when a ray
-     carries `Some(Medium)` (set by transmissive OpenPBR refraction — see `ray.rs` /
-     `medium.rs`). Free-space rays are unaffected.
-   - A sky-gradient background when nothing is hit.
+   - Carried-medium transport (subsurface / glass interiors) when a ray holds
+     `Some(Medium)` (set by transmissive OpenPBR refraction — see `ray.rs` /
+     `medium.rs`): weighted analog free-flight sampling at the extinction majorant with
+     the chromatic correction `e^{(σ̄−σₜ)t}` (gray media reduce to the classic
+     albedo/Beer-Lambert forms). Carried-medium scatter vertices run **no NEE** and keep
+     `prev = None` (full-weight next emission) — that pairing is what avoids double
+     counting there. Free-space rays are unaffected.
+   - **Volume regions** (`volume.rs`): free-standing smoke/fog/absorption/fire volumes
+     held on `Renderer.volumes`, *outside* the surface BVH so their bounds never occlude
+     shadow rays. Each `VolumeRegion` is an oriented box (composed prim xform) with a
+     `DensityField` (`Homogeneous` | `Noise` fBm | `Grid` trilinear voxels) and
+     σₛ/σₐ/g/emission (densityScale pre-folded into the coefficients). Per segment the
+     integrator clips `Volumes::sample_interaction` to `min(t_surface, t_medium)` — the
+     nearest-event competition between surface, carried medium and regions is then exact.
+     Distance sampling is weighted delta tracking against the summed per-region majorant
+     (chromatic-safe null collisions; absorption decays the weight instead of
+     analog-terminating). Volume scatter vertices run **NEE with MIS** (`volume_nee`):
+     the phase mixture's value == pdf (`PhaseMix`), and the bounce-side
+     `bounce_emission_weight` has a matching `PrevVertex::Phase` arm — the two are a
+     coupled pair exactly like the surface NEE pair; change one and you double-count
+     emission. Shadow rays use `shadow_transmittance` (boolean surface occlusion ×
+     `Volumes::transmittance` — ratio tracking, exact Beer-Lambert fast path when all
+     crossed regions are homogeneous). Volume emission accumulates `σₐ·Lₑ` along the walk
+     into `VertexRec.segment_emit`, which the gather adds **outside** `atten` (it is
+     already weighted; folding it in would double-attenuate). Emission reached by a
+     bounce (`next_emit`) is stored pre-multiplied by the arriving segment's attenuation.
+     `volumes.is_empty()` short-circuits everything — volume-free scenes render as before.
+   - A sky-gradient background when nothing is hit (attenuated by, and adding the
+     emission of, any volumes the escaping segment crossed).
 4. **Path guiding** (opt-in via `crust:pathGuiding`, `guiding/` module): a pure-Rust
    Practical Path Guiding SD-tree (`GuidingField`). `render_guided()` runs training
    passes at 1, 2, 4, … spp, splats `(position, direction, luminance·cos²)` samples
@@ -148,6 +173,18 @@ Xform hierarchy into world matrices. Schema mapping:
   emitting along -Z per UsdLux; effectively one-sided). Sample scene: `samples/rectlight.usda`.
   Other lux types (`DiskLight`, `DistantLight`, `DomeLight`, `CylinderLight`) warn once and
   are skipped.
+- **Volumes**: any prim carrying `crust:volume:type` imports as a `VolumeRegion` (checked
+  *first* in the dispatch, so it never becomes geometry — its bounds must not occlude
+  shadow rays). The local box is `[-size/2, size/2]³` when the prim authors `size` (a
+  `Cube`; USD's default size is 2), else the unit cube; placement/orientation/scale come
+  from the composed prim transform. Attributes (all in `crust:volume:`, defaults in
+  parentheses): `type` = `homogeneous` | `smoke` | `grid` (required); `densityScale` (1);
+  `sigmaS` color3f (0.5 grey); `sigmaA` color3f (0); `emission` color3f (0);
+  `anisotropy` (0, clamped ±0.99). Smoke adds `noiseScale`/`noiseOctaves`/`noiseGain`/
+  `noiseLacunarity`/`noiseThreshold`/`noiseSeed` (4 / 4 / 0.5 / 2 / 0.3 / 0); grid needs
+  `gridDims` int[3] + `gridData` float[] (x-fastest, length must equal nx·ny·nz — warns
+  and skips otherwise). Sample scenes: `samples/fog.usda` (homogeneous god rays),
+  `samples/smoke.usda` (noise plume + emissive ember + tiny explicit grid).
 - `UsdRenderSettings` gives `resolution`; per-render params live as custom attrs in the
   `crust:` namespace (`crust:samplesPerPixel`, `crust:maxDepth`, `crust:minSamplesPerPixel`,
   `crust:varianceThreshold`, `crust:frame`). Missing attrs fall back to defaults (128 spp,
@@ -182,3 +219,21 @@ that mention a `usd` **feature flag** are stale — there is no such feature.
   thin-walled transmission remains a per-sample delta lobe (`ScatterSample::delta`),
   excluded from continuous mixtures. The guide-vs-BSDF selection probability is fixed (no learned α), and
   spatial lookups are not parallax-compensated.
+- **Volume regions** (`volume.rs`) have no OpenVDB / `UsdVolVolume` import (openusd 0.5
+  ships no `vol` feature) — density is homogeneous, procedural fBm noise, or an inline
+  voxel grid authored in the USDA. No volume path guiding (volume vertices push
+  `train: None`; volume-heavy scenes train the surface field on noisier estimates —
+  slower convergence, not bias). One global majorant per region — no coarse max-grid, so
+  a high `densityScale` over a large box tracks slowly. Emissive volumes are not
+  light-list entries: fire is found only by phase/BSDF-sampled paths (firefly risk near
+  bright emission), never by NEE. Carried-medium (subsurface) scatter vertices run no
+  NEE. Region overlap uses summed extinction (exact) with a σₛ-weighted phase mixture.
+- **HG convention fix**: `sample_henyey_greenstein` used to apply PBRT's inversion to the
+  propagation direction (PBRT's frame is around the *reversed* `wo`), so `g > 0`
+  scattered backward. It now scatters forward, matching `hg_phase` (value == pdf, cosθ
+  against the propagation direction); the histogram test in `medium.rs` pins the pair.
+  The carried-medium estimator was also fixed: it double-counted extinction for
+  scattering media (analog free-flight at σ̄ *plus* full Beer-Lambert) — scattering
+  interiors (subsurface) render brighter than before, correctly. And bounce-hit emission
+  (`next_emit`) is now attenuated by the arriving segment (tinted glass / smoke in front
+  of an emitter used to pass emission through undimmed).

--- a/crates/crust-core/src/lib.rs
+++ b/crates/crust-core/src/lib.rs
@@ -13,6 +13,7 @@ mod primitives;
 mod ray;
 mod scene;
 mod tracer;
+mod volume;
 mod world;
 
 pub use aabb::AABB;
@@ -31,4 +32,5 @@ pub use primitives::{SmoothTriangle, Sphere, Triangle};
 pub use ray::Ray;
 pub use scene::Scene;
 pub use tracer::{ProgressCallback, RenderSettings, Renderer, ray_color};
+pub use volume::{DensityField, PhaseMix, VolumeEvent, VolumeRegion, Volumes};
 pub use world::{get_settings, simple_scene};

--- a/crates/crust-core/src/medium.rs
+++ b/crates/crust-core/src/medium.rs
@@ -86,16 +86,32 @@ impl Medium {
     }
 }
 
+/// Henyey–Greenstein phase-function value — equal to its solid-angle pdf,
+/// since HG is normalized over the sphere. `cos_theta` is the dot product
+/// between the *propagation* direction of the incoming ray and the sampled
+/// outgoing direction, matching `sample_henyey_greenstein` (forward
+/// scattering ⇒ `cos_theta → +1` for `g > 0`).
+pub fn hg_phase(cos_theta: f32, g: f32) -> f32 {
+    use std::f32::consts::PI;
+    let denom = (1.0 + g * g - 2.0 * g * cos_theta).max(1e-6);
+    (1.0 - g * g) / (4.0 * PI * denom * denom.sqrt())
+}
+
 /// Henyey–Greenstein phase-function sampling. Returns a scattering direction
 /// in the local frame with the incoming direction `wi` on the +z axis of
-/// its own frame, then rotated so `wi` maps back to itself.
+/// its own frame, then rotated so `wi` maps back to itself. `g > 0` scatters
+/// forward (along the propagation direction `wi`), matching `hg_phase`.
 pub fn sample_henyey_greenstein(wi: Vec3A, g: f32, u1: f32, u2: f32) -> Vec3A {
     use std::f32::consts::PI;
     let cos_theta = if g.abs() < 1e-3 {
         1.0 - 2.0 * u1
     } else {
+        // PBRT's inversion, but evaluated for the propagation-direction
+        // convention: the sign is chosen so g > 0 peaks at cos θ = +1
+        // (forward). PBRT's own frame is built around the reversed
+        // direction wo, which is why its formula carries a leading minus.
         let sq = (1.0 - g * g) / (1.0 - g + 2.0 * g * u1);
-        -(1.0 + g * g - sq * sq) / (2.0 * g)
+        (1.0 + g * g - sq * sq) / (2.0 * g)
     };
     let cos_theta = cos_theta.clamp(-1.0, 1.0);
     let sin_theta = (1.0 - cos_theta * cos_theta).max(0.0).sqrt();
@@ -110,4 +126,69 @@ pub fn sample_henyey_greenstein(wi: Vec3A, g: f32, u1: f32, u2: f32) -> Vec3A {
     let t = wi.cross(up).normalize();
     let b = wi.cross(t);
     (t * (sin_theta * phi.cos()) + b * (sin_theta * phi.sin()) + wi * cos_theta).normalize()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hg_phase_normalizes_over_sphere() {
+        // ∫ p(µ) dµ over the sphere: 2π ∫_{-1}^{1} p(µ) dµ = 1.
+        for &g in &[-0.7f32, 0.0, 0.4, 0.9] {
+            let n = 20_000;
+            let mut sum = 0.0f64;
+            for i in 0..n {
+                let mu = -1.0 + 2.0 * (i as f32 + 0.5) / n as f32;
+                sum += hg_phase(mu, g) as f64;
+            }
+            let integral = 2.0 * std::f64::consts::PI * sum * (2.0 / n as f64);
+            assert!(
+                (integral - 1.0).abs() < 1e-3,
+                "g={g}: integral={integral}"
+            );
+        }
+    }
+
+    #[test]
+    fn hg_sampling_consistent_with_pdf() {
+        // Histogram sampled cos θ against the pdf. This pins the sign
+        // convention shared by `sample_henyey_greenstein` and `hg_phase`:
+        // cos θ is measured against the incoming *propagation* direction.
+        for &g in &[-0.5f32, 0.4, 0.8] {
+            let wi = Vec3A::new(0.3, -0.5, 0.8).normalize();
+            let bins = 20usize;
+            let n = 200_000u32;
+            let mut hist = vec![0u32; bins];
+            let mut rng = 0x9e3779b9u32;
+            let mut next = || {
+                // xorshift — deterministic, good enough for a histogram.
+                rng ^= rng << 13;
+                rng ^= rng >> 17;
+                rng ^= rng << 5;
+                (rng >> 8) as f32 / (1u32 << 24) as f32
+            };
+            for _ in 0..n {
+                let dir = sample_henyey_greenstein(wi, g, next(), next());
+                let mu = wi.dot(dir).clamp(-1.0, 1.0);
+                let b = (((mu + 1.0) * 0.5) * bins as f32).min(bins as f32 - 1.0) as usize;
+                hist[b] += 1;
+            }
+            // Exact bin mass from the HG CDF:
+            // ∫ 2π p dµ = (1-g²)/(2g) · [(1+g²-2gµ)^{-1/2}]_a^b.
+            let cdf_term = |mu: f32| (1.0 + g * g - 2.0 * g * mu).max(1e-9).powf(-0.5);
+            for b in 0..bins {
+                let lo = -1.0 + b as f32 * 2.0 / bins as f32;
+                let hi = lo + 2.0 / bins as f32;
+                let expected = (1.0 - g * g) / (2.0 * g) * (cdf_term(hi) - cdf_term(lo));
+                let observed = hist[b] as f32 / n as f32;
+                // 5% relative, floored at 4σ of binomial counting noise.
+                let tol = (0.05 * expected).max(4.0 * (expected / n as f32).sqrt());
+                assert!(
+                    (observed - expected).abs() < tol,
+                    "g={g} bin={b}: observed={observed} expected={expected}"
+                );
+            }
+        }
+    }
 }

--- a/crates/crust-core/src/scene.rs
+++ b/crates/crust-core/src/scene.rs
@@ -2,6 +2,7 @@ use crate::camera::Camera;
 use crate::hittable_list::HittableList;
 use crate::light::LightList;
 use crate::tracer::RenderSettings;
+use crate::volume::VolumeRegion;
 
 /// The renderer's runtime scene, produced from a USD stage
 /// (`Scene::from_usd`) or assembled by hand (`Scene::new`, e.g. from the
@@ -12,6 +13,9 @@ pub struct Scene {
     pub world: HittableList,
     pub lights: LightList,
     pub settings: RenderSettings,
+    /// Participating-media regions (smoke, fog, …), kept outside `world`
+    /// so their bounds never act as occluding geometry.
+    pub volumes: Vec<VolumeRegion>,
 }
 
 impl Scene {
@@ -26,7 +30,13 @@ impl Scene {
             world,
             lights,
             settings,
+            volumes: Vec::new(),
         }
+    }
+
+    pub fn with_volumes(mut self, volumes: Vec<VolumeRegion>) -> Self {
+        self.volumes = volumes;
+        self
     }
 }
 

--- a/crates/crust-core/src/scene/usd_import.rs
+++ b/crates/crust-core/src/scene/usd_import.rs
@@ -16,6 +16,7 @@ use crate::material::{Emissive, Material, OpenPBR};
 use crate::primitives::{Sphere as CrustSphere, Triangle};
 use crate::scene::Scene;
 use crate::tracer::RenderSettings;
+use crate::volume::{DensityField, VolumeRegion};
 use glam::{Vec3, Vec3A};
 
 use openusd::gf::{Matrix4d, Vec3f};
@@ -55,6 +56,7 @@ pub(crate) fn load_scene(path: &Path) -> Result<Scene, crate::Error> {
 
     let mut world = HittableList::new();
     let mut lights = LightList::new();
+    let mut volumes: Vec<VolumeRegion> = Vec::new();
     let mut camera_candidate: Option<Camera> = None;
 
     let mut stack: Vec<(Prim, GMat4)> = vec![(stage.prim_at(sdf::Path::abs_root()), GMat4::IDENTITY)];
@@ -64,9 +66,15 @@ pub(crate) fn load_scene(path: &Path) -> Result<Scene, crate::Error> {
         let resets = resets_xform_stack_at(&stage, &prim);
         let this_world = if resets { local } else { parent_world * local };
 
-        // Dispatch by schema. Order matters only for Meshes vs Sphere prims —
-        // both check first so we don't recurse into their materials as prims.
-        if let Ok(Some(mesh)) = UsdMesh::get(&stage, prim.path().clone()) {
+        // Dispatch by schema. Volume prims are checked first: a prim
+        // carrying `crust:volume:type` imports as a participating-media
+        // region only — never as geometry, so its bounds cannot occlude
+        // shadow rays. Otherwise order matters only for Meshes vs Sphere
+        // prims — both check first so we don't recurse into their
+        // materials as prims.
+        if custom_token(&prim, "crust:volume:type").is_some() {
+            emit_volume(&prim, this_world, &mut volumes);
+        } else if let Ok(Some(mesh)) = UsdMesh::get(&stage, prim.path().clone()) {
             let mat = resolve_material(&stage, &prim);
             emit_mesh(&mut world, &prim, &mesh, this_world, mat);
         } else if let Ok(Some(sphere)) = UsdSphere::get(&stage, prim.path().clone()) {
@@ -108,7 +116,88 @@ pub(crate) fn load_scene(path: &Path) -> Result<Scene, crate::Error> {
         crate::world::get_settings().0
     });
 
-    Ok(Scene::new(camera, world, lights, settings))
+    Ok(Scene::new(camera, world, lights, settings).with_volumes(volumes))
+}
+
+// -----------------------------------------------------------------------
+// Volumes
+// -----------------------------------------------------------------------
+
+/// Import a `crust:volume:*` prim as a `VolumeRegion`. The local box is
+/// `[-size/2, size/2]^3` when the prim authors a `size` attribute (a
+/// `Cube`'s convention; USD's default cube size is 2) and the unit cube
+/// `[-0.5, 0.5]^3` otherwise; placement, orientation and scale come from
+/// the composed prim transform.
+fn emit_volume(prim: &Prim, world_xf: GMat4, volumes: &mut Vec<VolumeRegion>) {
+    let ty = custom_token(prim, "crust:volume:type").expect("checked by dispatch");
+
+    let field = match ty.as_str() {
+        "homogeneous" => DensityField::Homogeneous,
+        "smoke" => DensityField::Noise {
+            scale: custom_f32(prim, "crust:volume:noiseScale").unwrap_or(4.0),
+            octaves: custom_i32(prim, "crust:volume:noiseOctaves").unwrap_or(4).max(1) as u32,
+            gain: custom_f32(prim, "crust:volume:noiseGain").unwrap_or(0.5),
+            lacunarity: custom_f32(prim, "crust:volume:noiseLacunarity").unwrap_or(2.0),
+            threshold: custom_f32(prim, "crust:volume:noiseThreshold").unwrap_or(0.3),
+            seed: custom_i32(prim, "crust:volume:noiseSeed").unwrap_or(0) as u32,
+        },
+        "grid" => {
+            let dims = custom_i32_array(prim, "crust:volume:gridDims");
+            let data = custom_f32_array(prim, "crust:volume:gridData");
+            match (dims, data) {
+                (Some(d), Some(data)) if d.len() == 3 => {
+                    let (nx, ny, nz) = (d[0].max(1) as usize, d[1].max(1) as usize, d[2].max(1) as usize);
+                    if nx * ny * nz != data.len() {
+                        warn!(
+                            "Volume at {}: gridDims {}x{}x{} does not match gridData length {} — skipped",
+                            prim.path(), nx, ny, nz, data.len()
+                        );
+                        return;
+                    }
+                    DensityField::Grid { nx, ny, nz, data }
+                }
+                _ => {
+                    warn!(
+                        "Volume at {}: grid type needs int[3] crust:volume:gridDims and float[] crust:volume:gridData — skipped",
+                        prim.path()
+                    );
+                    return;
+                }
+            }
+        }
+        other => {
+            warn!(
+                "Volume at {}: unknown crust:volume:type \"{}\" (expected homogeneous | smoke | grid) — skipped",
+                prim.path(),
+                other
+            );
+            return;
+        }
+    };
+
+    let sigma_s = custom_color3(prim, "crust:volume:sigmaS").unwrap_or(Vec3A::splat(0.5));
+    let sigma_a = custom_color3(prim, "crust:volume:sigmaA").unwrap_or(Vec3A::ZERO);
+    let emission = custom_color3(prim, "crust:volume:emission").unwrap_or(Vec3A::ZERO);
+    let g = custom_f32(prim, "crust:volume:anisotropy").unwrap_or(0.0);
+    let density_scale = custom_f32(prim, "crust:volume:densityScale").unwrap_or(1.0);
+    let half = custom_f32(prim, "size").map_or(0.5, |s| s * 0.5);
+
+    info!(
+        "Imported {} volume at {} (densityScale={})",
+        ty,
+        prim.path(),
+        density_scale
+    );
+    volumes.push(VolumeRegion::new(
+        world_xf,
+        Vec3A::splat(half),
+        sigma_s,
+        sigma_a,
+        g,
+        emission,
+        density_scale,
+        field,
+    ));
 }
 
 // -----------------------------------------------------------------------
@@ -978,6 +1067,41 @@ fn custom_bool(prim: &Prim, name: &str) -> Option<bool> {
         sdf::Value::Bool(b) => Some(b),
         // Authoring tools sometimes write bools as ints.
         sdf::Value::Int(i) => Some(i != 0),
+        _ => None,
+    }
+}
+
+fn custom_token(prim: &Prim, name: &str) -> Option<String> {
+    let v = prim.attribute(name).get::<sdf::Value>().ok()??;
+    match v {
+        sdf::Value::Token(t) => Some(t),
+        sdf::Value::String(s) => Some(s),
+        _ => None,
+    }
+}
+
+fn custom_color3(prim: &Prim, name: &str) -> Option<Vec3A> {
+    let v = prim.attribute(name).get::<sdf::Value>().ok()??;
+    match v {
+        sdf::Value::Vec3f(c) => Some(Vec3A::new(c.x, c.y, c.z)),
+        sdf::Value::Vec3d(c) => Some(Vec3A::new(c.x as f32, c.y as f32, c.z as f32)),
+        _ => None,
+    }
+}
+
+fn custom_f32_array(prim: &Prim, name: &str) -> Option<Vec<f32>> {
+    let v = prim.attribute(name).get::<sdf::Value>().ok()??;
+    match v {
+        sdf::Value::FloatVec(v) => Some(v),
+        sdf::Value::DoubleVec(v) => Some(v.into_iter().map(|d| d as f32).collect()),
+        _ => None,
+    }
+}
+
+fn custom_i32_array(prim: &Prim, name: &str) -> Option<Vec<i32>> {
+    let v = prim.attribute(name).get::<sdf::Value>().ok()??;
+    match v {
+        sdf::Value::IntVec(v) => Some(v),
         _ => None,
     }
 }

--- a/crates/crust-core/src/tracer.rs
+++ b/crates/crust-core/src/tracer.rs
@@ -5,6 +5,7 @@ use crate::hittable::{HitRecord, Hittable};
 use crate::material::{Material, ScatterSample};
 use crate::medium::sample_henyey_greenstein;
 use crate::ray::Ray;
+use crate::volume::{PhaseMix, VolumeEvent, Volumes};
 use crate::{LightList, camera::Camera, hittable_list::HittableList};
 use glam::Vec3A;
 use rayon::prelude::*;
@@ -52,6 +53,10 @@ pub struct Renderer {
     pub world: Bvh,
     pub lights: LightList,
     pub settings: RenderSettings,
+    /// Participating-media regions, sampled outside the BVH (see
+    /// `volume.rs`). Empty for scenes without volumes — every volume code
+    /// path short-circuits then.
+    pub volumes: Volumes,
 }
 
 impl Renderer {
@@ -69,7 +74,13 @@ impl Renderer {
             world,
             lights,
             settings,
+            volumes: Volumes::default(),
         }
+    }
+
+    pub fn with_volumes(mut self, regions: Vec<crate::volume::VolumeRegion>) -> Self {
+        self.volumes = Volumes::new(regions);
+        self
     }
 
     pub fn render(&self) -> Buffer {
@@ -314,6 +325,7 @@ impl Renderer {
                 &r,
                 &self.world,
                 &self.lights,
+                &self.volumes,
                 self.settings.max_depth as i32,
                 &mut sampler,
                 gctx,
@@ -415,11 +427,12 @@ pub fn ray_color(
     r: &Ray,
     world: &dyn Hittable,
     lights: &LightList,
+    volumes: &Volumes,
     depth: i32,
     sampler: &mut dyn Sampler,
 ) -> Vec3A {
     let mut no_training = Vec::new();
-    trace_path(r, world, lights, depth, sampler, None, &mut no_training)
+    trace_path(r, world, lights, volumes, depth, sampler, None, &mut no_training)
 }
 
 /// Choose the bounce direction and the pdf its contribution is divided by.
@@ -482,13 +495,20 @@ fn sample_bounce_direction(
 
 /// Everything recorded at one path vertex during the forward walk. The
 /// backward gather reconstructs the radiance estimate from these exactly as
-/// the old recursion did: `R = atten · (emit_here + nee + factor ·
-/// (next_emit·next_emit_weight + R_incoming))`.
+/// the old recursion did: `R = segment_emit + atten · (emit_here + nee +
+/// factor · (next_emit·next_emit_weight + R_incoming))`.
 struct VertexRec {
-    /// Beer-Lambert transmittance over the segment that arrived at this
-    /// vertex (`ONE` for volume-scatter vertices, whose segment the
-    /// estimator does not attenuate).
+    /// Transmittance over the segment that arrived at this vertex —
+    /// Beer-Lambert for a carried medium times the volume-region tracking
+    /// weight. For volume-scatter vertices this is the full walk weight of
+    /// the event (transmittance × albedo compensation), which multiplies
+    /// everything at and beyond the vertex, NEE included.
     atten: Vec3A,
+    /// Volume emission collected along the arriving segment, already
+    /// weighted by the tracking-walk weight up to each emission point.
+    /// Added OUTSIDE `atten` in the gather — folding it into `emit_here`
+    /// would attenuate it a second time.
+    segment_emit: Vec3A,
     /// Emission counted at this vertex itself: primary and post-scatter
     /// vertices only. Emission at bounce-arrival vertices is owned by the
     /// previous vertex via `next_emit`/`next_emit_weight`.
@@ -528,6 +548,21 @@ struct PrevBounce<'a> {
     delta: bool,
 }
 
+/// The previous path vertex, as far as emission MIS is concerned: either a
+/// surface bounce or a volume-region phase scatter (which runs NEE, so its
+/// bounce-hit emission must be MIS-weighted against the same light
+/// strategy or it is double-counted). Carried-medium (subsurface) scatters
+/// run no NEE and keep `prev = None` instead.
+enum PrevVertex<'a> {
+    Surface(PrevBounce<'a>),
+    Phase {
+        /// The scatter point (the light strategy's pdf is evaluated from it).
+        pos: Vec3A,
+        /// Solid-angle pdf of the sampled phase direction.
+        pdf: f32,
+    },
+}
+
 /// MIS weight for emission reached by the previous vertex's bounce ray.
 /// Delta samples are invisible to light sampling (their lobe is excluded
 /// from eval), so the bounce carries the emission whole — likewise at
@@ -535,18 +570,82 @@ struct PrevBounce<'a> {
 /// light-list entry, which NEE can never sample. Otherwise the competing
 /// density is the same strategy the NEE side uses: uniform 1-of-N pick
 /// times the hit light's area-sampling pdf.
-fn bounce_emission_weight(prev: &PrevBounce, lights: &LightList, hit: &crate::hittable::Hit) -> f32 {
-    if prev.delta || prev.mat.eval(&prev.ray, &prev.rec, prev.dir).is_none() {
-        return 1.0;
-    }
+fn bounce_emission_weight(
+    prev: &PrevVertex,
+    lights: &LightList,
+    hit: &crate::hittable::Hit,
+) -> f32 {
+    let (from, bounce_pdf) = match prev {
+        PrevVertex::Surface(p) => {
+            if p.delta || p.mat.eval(&p.ray, &p.rec, p.dir).is_none() {
+                return 1.0;
+            }
+            (p.rec.p, p.pdf)
+        }
+        PrevVertex::Phase { pos, pdf } => (*pos, *pdf),
+    };
     match lights.find_by_material(hit.mat) {
         Some(light) => {
-            let light_pdf =
-                (light.pdf(prev.rec.p, hit.rec.p) / lights.count() as f32).max(1e-6);
-            utils::balance_heuristic(prev.pdf, light_pdf)
+            let light_pdf = (light.pdf(from, hit.rec.p) / lights.count() as f32).max(1e-6);
+            utils::balance_heuristic(bounce_pdf, light_pdf)
         }
         None => 1.0,
     }
+}
+
+/// NEE shadow test used at surface and volume vertices alike: ZERO when a
+/// surface occludes the segment, otherwise the volumetric transmittance
+/// through every region it crosses (stochastic for heterogeneous regions,
+/// exact for homogeneous ones). MIS weights are unaffected — transmittance
+/// is part of the integrand on both strategies, not of either pdf.
+fn shadow_transmittance(
+    world: &dyn Hittable,
+    volumes: &Volumes,
+    shadow_ray: &Ray,
+    distance: f32,
+    sampler: &mut dyn Sampler,
+) -> Vec3A {
+    if world.hit(shadow_ray, 0.001, distance - 0.001).is_some() {
+        return Vec3A::ZERO;
+    }
+    if volumes.is_empty() {
+        return Vec3A::ONE;
+    }
+    volumes.transmittance(shadow_ray, 0.001, distance - 0.001, sampler)
+}
+
+/// Direct lighting at a volume-region scatter point. The exact mirror of
+/// the surface NEE block: same uniform 1-of-N light strategy, with the
+/// phase function (value == pdf for the HG mixture) in place of
+/// `brdf·cos`, and the same phase pdf as the competing bounce density that
+/// `bounce_emission_weight`'s `Phase` arm uses.
+fn volume_nee(
+    p: Vec3A,
+    wi: Vec3A,
+    phase: &PhaseMix,
+    world: &dyn Hittable,
+    volumes: &Volumes,
+    lights: &LightList,
+    sampler: &mut dyn Sampler,
+) -> Vec3A {
+    let Some(light) = lights.sample(sampler) else {
+        return Vec3A::ZERO;
+    };
+    let n_lights = lights.count() as f32;
+    let area_uv = sampler.next_2d();
+    let light_point = light.sample_point(area_uv[0], area_uv[1]);
+    let light_dir = light_point - p;
+    let light_distance = light_dir.length();
+    let light_dir_unit = light_dir / light_distance.max(1e-6);
+    let shadow_ray = Ray::new(p, light_dir_unit);
+    let tr = shadow_transmittance(world, volumes, &shadow_ray, light_distance, sampler);
+    if tr == Vec3A::ZERO {
+        return Vec3A::ZERO;
+    }
+    let light_pdf = (light.pdf(p, light_point) / n_lights).max(1e-6);
+    let phase_val = phase.pdf(wi.dot(light_dir_unit));
+    let weight = utils::balance_heuristic(light_pdf, phase_val);
+    light.emission() * phase_val * tr * weight / light_pdf
 }
 
 /// The integrator: an iterative path tracer in two passes. The forward walk
@@ -561,6 +660,7 @@ fn trace_path(
     r: &Ray,
     world: &dyn Hittable,
     lights: &LightList,
+    volumes: &Volumes,
     depth: i32,
     sampler: &mut dyn Sampler,
     guiding: Option<&GuidingContext>,
@@ -570,9 +670,10 @@ fn trace_path(
     let mut records: Vec<VertexRec> = Vec::with_capacity(depth.max(0) as usize);
     let mut ray = r.clone();
     let mut remaining = depth;
-    // Set after every surface bounce; `None` at the primary vertex and
-    // after volume scatters, where the next vertex's emission counts fully.
-    let mut prev: Option<PrevBounce> = None;
+    // Set after surface bounces and volume-region phase scatters; `None`
+    // at the primary vertex and after carried-medium (subsurface)
+    // scatters, where the next vertex's emission counts fully.
+    let mut prev: Option<PrevVertex> = None;
     // Running throughput. Only drives the roulette survival probability —
     // the estimate itself is rebuilt by the backward gather.
     let mut beta = Vec3A::ONE;
@@ -583,11 +684,18 @@ fn trace_path(
         if remaining <= 0 {
             // Depth exhausted. The old recursion still counted bounce-hit
             // emission at the last vertex (its `add_emission` term traced
-            // the ray itself) but never the background — reproduce both.
+            // the ray itself) but never the background — reproduce both,
+            // attenuating through any media the final segment crosses.
             if let Some(p) = &prev {
                 if let Some(hit) = world.hit(&ray, 0.001, f32::INFINITY) {
-                    let emitted = hit.mat.emitted();
+                    let mut emitted = hit.mat.emitted();
                     if emitted.length_squared() > 0.0 {
+                        if let Some(m) = ray.medium() {
+                            emitted *= m.transmittance(hit.rec.t);
+                        }
+                        if !volumes.is_empty() {
+                            emitted *= volumes.transmittance(&ray, 0.001, hit.rec.t, sampler);
+                        }
                         let last = records.last_mut().expect("prev implies a record");
                         last.next_emit = emitted;
                         last.next_emit_weight = bounce_emission_weight(p, lights, &hit);
@@ -601,76 +709,202 @@ fn trace_path(
         // padded-Sobol later.
         sampler.advance_bounce();
 
-        let Some(hit) = world.hit(&ray, 0.001, f32::INFINITY) else {
+        let hit_opt = world.hit(&ray, 0.001, f32::INFINITY);
+        let t_surf = hit_opt.as_ref().map_or(f32::INFINITY, |h| h.rec.t);
+
+        // Free-flight candidate in the carried homogeneous medium
+        // (subsurface / participating glass interiors) — analog sampling
+        // at the extinction majorant, exactly as before.
+        let t_med = match ray.medium() {
+            Some(m) if m.is_scattering() => {
+                let sigma_t_max = m.sigma_t_max().max(1e-4);
+                -(sampler.next_1d().ln()) / sigma_t_max
+            }
+            _ => f32::INFINITY,
+        };
+
+        // Volume-region interaction, clipped to whatever event would
+        // otherwise end the segment. Because the walk is bounded by
+        // `t_lim`, a real collision is the nearest event by construction —
+        // the competition between the carried medium, the surface and the
+        // regions is exact (superposed processes), and the `Passthrough`
+        // weight is precisely the region transmittance up to the winner.
+        let t_lim = t_surf.min(t_med);
+        let event = if volumes.is_empty() {
+            VolumeEvent::Passthrough {
+                transmittance: Vec3A::ONE,
+                emitted: Vec3A::ZERO,
+            }
+        } else {
+            volumes.sample_interaction(&ray, 0.001, t_lim, sampler)
+        };
+
+        let (vol_tr, vol_emit) = match event {
+            VolumeEvent::Scatter {
+                p,
+                weight,
+                phase,
+                emitted,
+                ..
+            } => {
+                // === Volume-region scatter vertex ===
+                let wi = ray.direction().normalize();
+                let dir = phase.sample(wi, sampler);
+                let phase_pdf = phase.pdf(wi.dot(dir)).max(1e-6);
+                let nee = volume_nee(p, wi, &phase, world, volumes, lights, sampler);
+
+                // The walk weight goes into `atten` (it multiplies NEE and
+                // everything beyond); the continuation factor is ONE
+                // because the HG value and pdf cancel exactly. Volume
+                // vertices are not trained on — the field guides surface
+                // bounces only.
+                let mut vrec = VertexRec {
+                    atten: weight,
+                    segment_emit: emitted,
+                    emit_here: Vec3A::ZERO,
+                    nee,
+                    factor: Vec3A::ONE,
+                    next_emit: Vec3A::ZERO,
+                    next_emit_weight: 1.0,
+                    train: None,
+                };
+                beta *= weight;
+                let mut survived = true;
+                if records.len() >= RR_START_BOUNCE {
+                    let p_survive = beta.max_element().clamp(RR_MIN_PROB, 1.0);
+                    if p_survive < 1.0 {
+                        if sampler.next_1d() >= p_survive {
+                            survived = false;
+                            vrec.factor = Vec3A::ZERO;
+                        } else {
+                            vrec.factor /= p_survive;
+                            beta /= p_survive;
+                        }
+                    }
+                }
+                if !survived {
+                    records.push(vrec);
+                    break;
+                }
+                prev = Some(PrevVertex::Phase { pos: p, pdf: phase_pdf });
+                records.push(vrec);
+                // Preserve the carried medium: scattering in fog inside a
+                // glass interior must keep attenuating in the glass.
+                ray = match ray.medium() {
+                    Some(m) => Ray::new_in_medium(p, dir, m.clone()),
+                    None => Ray::new(p, dir),
+                };
+                remaining -= 1;
+                continue;
+            }
+            VolumeEvent::Passthrough {
+                transmittance,
+                emitted,
+            } => (transmittance, emitted),
+        };
+
+        if t_med < t_surf {
+            // === Carried-medium scatter vertex (subsurface interiors) ===
+            let medium = ray.medium().expect("t_med implies a medium").clone();
+            let sigma_bar = medium.sigma_t_max().max(1e-4);
+            let pos = ray.at(t_med);
+            let phase_uv = sampler.next_2d();
+            let dir = sample_henyey_greenstein(
+                ray.direction().normalize(),
+                medium.g,
+                phase_uv[0],
+                phase_uv[1],
+            );
+            // Weighted analog estimator: sampling was at rate σ̄ (the
+            // max-channel extinction), so the event pays σₛ/σ̄ with the
+            // chromatic correction e^{(σ̄−σₜ)·t} per channel. For a gray
+            // medium this is exactly the single-scattering albedo — the
+            // old code's `factor = albedo` with an extra Beer-Lambert on
+            // top double-counted extinction.
+            let e = (Vec3A::splat(sigma_bar) - (medium.sigma_a + medium.sigma_s)) * t_med;
+            let factor = medium.sigma_s / sigma_bar * Vec3A::new(e.x.exp(), e.y.exp(), e.z.exp());
+            // Subsurface vertices run no NEE (their shadow rays are
+            // blocked by the enclosing surface), so `prev = None` keeps
+            // the next hit's emission at full weight — the pairing that
+            // avoids double counting.
+            let mut vrec = VertexRec {
+                atten: vol_tr,
+                segment_emit: vol_emit,
+                emit_here: Vec3A::ZERO,
+                nee: Vec3A::ZERO,
+                factor,
+                next_emit: Vec3A::ZERO,
+                next_emit_weight: 1.0,
+                train: None,
+            };
+            beta *= vol_tr * factor;
+            let mut survived = true;
+            if records.len() >= RR_START_BOUNCE {
+                let p_survive = beta.max_element().clamp(RR_MIN_PROB, 1.0);
+                if p_survive < 1.0 {
+                    if sampler.next_1d() >= p_survive {
+                        survived = false;
+                        vrec.factor = Vec3A::ZERO;
+                    } else {
+                        vrec.factor /= p_survive;
+                        beta /= p_survive;
+                    }
+                }
+            }
+            if !survived {
+                records.push(vrec);
+                break;
+            }
+            records.push(vrec);
+            ray = Ray::new_in_medium(pos, dir, medium);
+            remaining -= 1;
+            prev = None;
+            continue;
+        }
+
+        let Some(hit) = hit_opt else {
             // === Background ===
             let unit_direction = Vec3A::normalize(ray.direction());
             let t = 0.5 * (unit_direction.y + 1.0);
-            terminal = (1.0 - t) * Vec3A::new(1.0, 1.0, 1.0) + t * Vec3A::new(0.5, 0.7, 1.0);
+            let sky = (1.0 - t) * Vec3A::new(1.0, 1.0, 1.0) + t * Vec3A::new(0.5, 0.7, 1.0);
+            // Segment emission is already weighted; the sky pays the
+            // volume transmittance of the final segment.
+            terminal = vol_emit + vol_tr * sky;
             break;
         };
         let rec: HitRecord = hit.rec;
         let mat = hit.mat;
 
-        // Volume interaction sampling for scattering media (subsurface,
-        // participating volumes). If the sampled distance is closer than
-        // the surface hit, kick a scattering event and short-circuit the
-        // surface interaction.
-        if let Some(medium) = ray.medium() {
-            if medium.is_scattering() {
-                let sigma_t_max = medium.sigma_t_max().max(1e-4);
-                let t_scatter = -(sampler.next_1d().ln()) / sigma_t_max;
-                if t_scatter < rec.t {
-                    let pos = ray.at(t_scatter);
-                    let phase_uv = sampler.next_2d();
-                    let dir = sample_henyey_greenstein(
-                        ray.direction().normalize(),
-                        medium.g,
-                        phase_uv[0],
-                        phase_uv[1],
-                    );
-                    let albedo = medium.albedo();
-                    let medium = medium.clone();
-                    // Volume scattering events are not trained on — the
-                    // field guides surface bounces only. No emission
-                    // bookkeeping happened along this phase-scattered ray,
-                    // so the next hit's emission must count.
-                    records.push(VertexRec {
-                        atten: Vec3A::ONE,
-                        emit_here: Vec3A::ZERO,
-                        nee: Vec3A::ZERO,
-                        factor: albedo,
-                        next_emit: Vec3A::ZERO,
-                        next_emit_weight: 1.0,
-                        train: None,
-                    });
-                    beta *= albedo;
-                    ray = Ray::new_in_medium(pos, dir, medium);
-                    remaining -= 1;
-                    prev = None;
-                    continue;
-                }
+        // Attenuation across the arriving segment: volume-region
+        // transmittance times the carried medium's. For a *scattering*
+        // medium the surface arrival already paid e^{−σ̄·t} through the
+        // free-flight competition (t_med ≥ t_surf), so only the chromatic
+        // correction e^{(σ̄−σₜ)·t} remains — exactly ONE for gray media.
+        // Non-scattering media (glass tint) keep pure Beer-Lambert.
+        let med_arrival = match ray.medium() {
+            Some(m) if m.is_scattering() => {
+                let sigma_bar = m.sigma_t_max().max(1e-4);
+                let e = (Vec3A::splat(sigma_bar) - (m.sigma_a + m.sigma_s)) * rec.t;
+                Vec3A::new(e.x.exp(), e.y.exp(), e.z.exp())
             }
-        }
-
-        // Beer-Lambert attenuation across the segment travelled inside a
-        // participating medium (transmissive OpenPBR surfaces mark rays with
-        // `Some(medium)` on refraction; free-space rays are unaffected).
-        let atten = match ray.medium() {
             Some(m) => m.transmittance(rec.t),
             None => Vec3A::ONE,
         };
+        let atten = vol_tr * med_arrival;
 
-        // Emission accounting: a vertex reached by a surface bounce hands
-        // its emission to the previous vertex's record, MIS-weighted —
+        // Emission accounting: a vertex reached by a bounce hands its
+        // emission to the previous vertex's record, MIS-weighted —
         // counting it here too would double it. At the primary vertex and
-        // after volume scatters it counts here, in full.
+        // after carried-medium scatters it counts here, in full. Either
+        // way the emission pays the arriving segment's attenuation (an
+        // emitter seen through tinted glass or smoke must dim).
         let emitted = mat.emitted();
         let mut emit_here = Vec3A::ZERO;
         match &prev {
             Some(p) => {
                 if emitted.length_squared() > 0.0 {
                     let last = records.last_mut().expect("prev implies a record");
-                    last.next_emit = emitted;
+                    last.next_emit = atten * emitted;
                     last.next_emit_weight = bounce_emission_weight(p, lights, &hit);
                 }
             }
@@ -699,7 +933,9 @@ fn trace_path(
 
             let shadow_ray = Ray::new(rec.p, light_dir_unit);
 
-            if world.hit(&shadow_ray, 0.001, light_distance - 0.001).is_none() {
+            let shadow_tr =
+                shadow_transmittance(world, volumes, &shadow_ray, light_distance, sampler);
+            if shadow_tr != Vec3A::ZERO {
                 // Unsigned: lights behind the ray-facing normal are reachable
                 // through a continuous transmission lobe (opaque materials
                 // evaluate to zero there anyway).
@@ -726,13 +962,15 @@ fn trace_path(
                         _ => brdf_pdf,
                     };
                     let weight = utils::balance_heuristic(light_pdf, bounce_pdf);
-                    nee += light.emission() * brdf_value * cosine * weight / light_pdf;
+                    nee += light.emission() * brdf_value * cosine * shadow_tr * weight
+                        / light_pdf;
                 }
             }
         }
 
         let mut vrec = VertexRec {
             atten,
+            segment_emit: vol_emit,
             emit_here,
             nee,
             factor: Vec3A::ZERO,
@@ -785,14 +1023,14 @@ fn trace_path(
                     });
                 }
                 vrec.factor = factor;
-                prev = Some(PrevBounce {
+                prev = Some(PrevVertex::Surface(PrevBounce {
                     ray: ray.clone(),
                     rec,
                     mat,
                     dir,
                     pdf: sample.pdf,
                     delta: sample.delta,
-                });
+                }));
                 records.push(vrec);
                 ray = sample.ray;
                 remaining -= 1;
@@ -825,10 +1063,11 @@ fn trace_path(
                     .min(TRAIN_RADIANCE_CLAMP),
             });
         }
-        radiance = vrec.atten
-            * (vrec.emit_here
-                + vrec.nee
-                + vrec.factor * (vrec.next_emit * vrec.next_emit_weight + radiance));
+        radiance = vrec.segment_emit
+            + vrec.atten
+                * (vrec.emit_here
+                    + vrec.nee
+                    + vrec.factor * (vrec.next_emit * vrec.next_emit_weight + radiance));
     }
     radiance
 }

--- a/crates/crust-core/src/volume.rs
+++ b/crates/crust-core/src/volume.rs
@@ -1,0 +1,799 @@
+//! Free-standing participating volumes — smoke, fog, absorption, fire.
+//!
+//! A `VolumeRegion` is an oriented box (a prim's composed transform applied
+//! to a local cube) filled with a `DensityField`, carrying scattering /
+//! absorption / emission coefficients and a Henyey-Greenstein anisotropy.
+//! Regions live *outside* the surface BVH: the integrator asks the
+//! `Volumes` aggregate to sample an interaction along each path segment
+//! (weighted delta tracking with null collisions against a per-region
+//! majorant) and to estimate transmittance along shadow rays (ratio
+//! tracking, with an exact analytic fast path when every region crossed is
+//! homogeneous). Keeping volumes out of the BVH means their bounds never
+//! occlude shadow rays and no placeholder boundary material is needed.
+
+use crate::aabb::AABB;
+use crate::medium::hg_phase;
+use crate::ray::Ray;
+use glam::{Mat4, Vec3, Vec3A};
+use sampler::Sampler;
+
+/// Spatial density in local box coordinates, normalized to `[0, 1]^3`.
+/// Values are dimensionless multipliers on the region's coefficients.
+#[derive(Debug, Clone)]
+pub enum DensityField {
+    /// density == 1 everywhere inside the box.
+    Homogeneous,
+    /// Deterministic hash-based value-noise fBm — procedural smoke.
+    Noise {
+        /// Base frequency (cells across the unit box at octave 0).
+        scale: f32,
+        octaves: u32,
+        /// Per-octave amplitude falloff.
+        gain: f32,
+        /// Per-octave frequency growth.
+        lacunarity: f32,
+        /// density = max(0, fbm − threshold) / (1 − threshold); carves the
+        /// wispy holes that make noise read as smoke instead of haze.
+        threshold: f32,
+        seed: u32,
+    },
+    /// Explicit voxel grid: x-fastest layout `index = x + nx·(y + ny·z)`,
+    /// samples at voxel centers, trilinear interpolation, edge clamp.
+    Grid {
+        nx: usize,
+        ny: usize,
+        nz: usize,
+        data: Vec<f32>,
+    },
+}
+
+impl DensityField {
+    /// Density at `u` in `[0,1]^3` local box coordinates.
+    pub fn density(&self, u: Vec3A) -> f32 {
+        match self {
+            DensityField::Homogeneous => 1.0,
+            DensityField::Noise {
+                scale,
+                octaves,
+                gain,
+                lacunarity,
+                threshold,
+                seed,
+            } => {
+                let fbm = fbm_value_noise(u, *scale, *octaves, *gain, *lacunarity, *seed);
+                let t = threshold.clamp(0.0, 0.999);
+                ((fbm - t) / (1.0 - t)).max(0.0)
+            }
+            DensityField::Grid { nx, ny, nz, data } => {
+                grid_trilinear(u, *nx, *ny, *nz, data)
+            }
+        }
+    }
+
+    /// A bound on `density` over the box — the field majorant.
+    pub fn max_value(&self) -> f32 {
+        match self {
+            DensityField::Homogeneous => 1.0,
+            // fbm is normalized to [0,1]; the threshold remap keeps it ≤ 1.
+            DensityField::Noise { .. } => 1.0,
+            DensityField::Grid { data, .. } => {
+                data.iter().copied().fold(0.0f32, f32::max)
+            }
+        }
+    }
+}
+
+/// Integer hash → f32 in [0, 1). Pure integer mixing (no `std::hash`), so
+/// noise is bit-identical across platforms and runs.
+fn hash3(ix: i32, iy: i32, iz: i32, seed: u32) -> f32 {
+    let mut h = (ix as u32).wrapping_mul(0x8da6b343)
+        ^ (iy as u32).wrapping_mul(0xd8163841)
+        ^ (iz as u32).wrapping_mul(0xcb1ab31f)
+        ^ seed.wrapping_mul(0x9e3779b9);
+    h ^= h >> 15;
+    h = h.wrapping_mul(0x2c1b3c6d);
+    h ^= h >> 12;
+    h = h.wrapping_mul(0x297a2d39);
+    h ^= h >> 15;
+    (h >> 8) as f32 / (1u32 << 24) as f32
+}
+
+fn smoothstep(t: f32) -> f32 {
+    t * t * (3.0 - 2.0 * t)
+}
+
+/// Trilinearly smoothed value noise at frequency `freq`, in [0, 1).
+fn value_noise(p: Vec3A, freq: f32, seed: u32) -> f32 {
+    let q = p * freq;
+    let base = q.floor();
+    let (ix, iy, iz) = (base.x as i32, base.y as i32, base.z as i32);
+    let f = q - base;
+    let (fx, fy, fz) = (smoothstep(f.x), smoothstep(f.y), smoothstep(f.z));
+
+    let mut c = [0.0f32; 8];
+    for (n, v) in c.iter_mut().enumerate() {
+        let (dx, dy, dz) = ((n & 1) as i32, ((n >> 1) & 1) as i32, ((n >> 2) & 1) as i32);
+        *v = hash3(ix + dx, iy + dy, iz + dz, seed);
+    }
+    let x00 = c[0] + (c[1] - c[0]) * fx;
+    let x10 = c[2] + (c[3] - c[2]) * fx;
+    let x01 = c[4] + (c[5] - c[4]) * fx;
+    let x11 = c[6] + (c[7] - c[6]) * fx;
+    let y0 = x00 + (x10 - x00) * fy;
+    let y1 = x01 + (x11 - x01) * fy;
+    y0 + (y1 - y0) * fz
+}
+
+/// fBm over `octaves` octaves, normalized to [0, 1].
+fn fbm_value_noise(p: Vec3A, scale: f32, octaves: u32, gain: f32, lacunarity: f32, seed: u32) -> f32 {
+    let octaves = octaves.max(1);
+    let mut sum = 0.0;
+    let mut norm = 0.0;
+    let mut amp = 1.0;
+    let mut freq = scale;
+    for o in 0..octaves {
+        sum += amp * value_noise(p, freq, seed.wrapping_add(o));
+        norm += amp;
+        amp *= gain;
+        freq *= lacunarity;
+    }
+    sum / norm.max(1e-6)
+}
+
+/// Trilinear lookup with samples at voxel centers and edge clamping.
+fn grid_trilinear(u: Vec3A, nx: usize, ny: usize, nz: usize, data: &[f32]) -> f32 {
+    let lookup = |x: usize, y: usize, z: usize| data[x + nx * (y + ny * z)];
+    let coord = |v: f32, n: usize| -> (usize, usize, f32) {
+        let x = v * n as f32 - 0.5;
+        let i = x.floor();
+        let f = x - i;
+        let i0 = (i.max(0.0) as usize).min(n - 1);
+        let i1 = (i0 + 1).min(n - 1);
+        // Clamp the fraction too so points outside the sample lattice
+        // (v < half a voxel from the boundary) hold the edge value.
+        let f = if i < 0.0 { 0.0 } else { f.min(1.0) };
+        (i0, i1, f)
+    };
+    let (x0, x1, fx) = coord(u.x, nx);
+    let (y0, y1, fy) = coord(u.y, ny);
+    let (z0, z1, fz) = coord(u.z, nz);
+
+    let mut out = 0.0;
+    for (wz, z) in [(1.0 - fz, z0), (fz, z1)] {
+        for (wy, y) in [(1.0 - fy, y0), (fy, y1)] {
+            for (wx, x) in [(1.0 - fx, x0), (fx, x1)] {
+                out += wz * wy * wx * lookup(x, y, z);
+            }
+        }
+    }
+    out
+}
+
+/// An oriented box of participating medium in the scene.
+pub struct VolumeRegion {
+    /// Maps world points into the local box frame.
+    world_to_local: Mat4,
+    /// Local box is `[-half, +half]^3` per axis (a USD Cube's `size/2`).
+    half_extent: Vec3A,
+    /// Conservative world-space AABB of the 8 transformed corners.
+    world_aabb: AABB,
+    /// Per-channel scattering coefficient at density 1 (densityScale folded in).
+    pub sigma_s: Vec3A,
+    /// Per-channel absorption coefficient at density 1 (densityScale folded in).
+    pub sigma_a: Vec3A,
+    /// Henyey-Greenstein anisotropy, `g > 0` = forward scattering.
+    pub g: f32,
+    /// Emitted radiance; the source term is `σₐ(x) · emission` so emission
+    /// follows the density field (fire). ZERO = non-emissive.
+    pub emission: Vec3A,
+    field: DensityField,
+    /// `max_channel(σₐ + σₛ) · field.max_value()` — the tracking majorant.
+    majorant_sigma_t: f32,
+}
+
+impl VolumeRegion {
+    pub fn new(
+        local_to_world: Mat4,
+        half_extent: Vec3A,
+        sigma_s: Vec3A,
+        sigma_a: Vec3A,
+        g: f32,
+        emission: Vec3A,
+        density_scale: f32,
+        field: DensityField,
+    ) -> Self {
+        let sigma_s = sigma_s * density_scale;
+        let sigma_a = sigma_a * density_scale;
+        let mut min = Vec3A::splat(f32::INFINITY);
+        let mut max = Vec3A::splat(f32::NEG_INFINITY);
+        for n in 0..8 {
+            let corner = Vec3A::new(
+                if n & 1 == 0 { -half_extent.x } else { half_extent.x },
+                if n & 2 == 0 { -half_extent.y } else { half_extent.y },
+                if n & 4 == 0 { -half_extent.z } else { half_extent.z },
+            );
+            let w = local_to_world.transform_point3(Vec3::from(corner));
+            min = min.min(Vec3A::from(w));
+            max = max.max(Vec3A::from(w));
+        }
+        let majorant_sigma_t = (sigma_a + sigma_s).max_element() * field.max_value();
+        Self {
+            world_to_local: local_to_world.inverse(),
+            half_extent,
+            world_aabb: AABB::new(min, max),
+            sigma_s,
+            sigma_a,
+            g: g.clamp(-0.99, 0.99),
+            emission,
+            field,
+            majorant_sigma_t,
+        }
+    }
+
+    /// Density multiplier at a world point; 0 outside the box.
+    pub fn density(&self, p_world: Vec3A) -> f32 {
+        let p = Vec3A::from(self.world_to_local.transform_point3(Vec3::from(p_world)));
+        let h = self.half_extent;
+        if p.x.abs() > h.x || p.y.abs() > h.y || p.z.abs() > h.z {
+            return 0.0;
+        }
+        let u = (p + h) / (h * 2.0);
+        self.field.density(u)
+    }
+
+    /// Entry/exit distances of `ray` through the box, in world-ray
+    /// parameter units. The local direction is deliberately NOT
+    /// renormalized so the returned interval stays parameterized on the
+    /// world ray.
+    pub fn intersect(&self, ray: &Ray) -> Option<(f32, f32)> {
+        let o = Vec3A::from(self.world_to_local.transform_point3(Vec3::from(ray.origin())));
+        let d = Vec3A::from(self.world_to_local.transform_vector3(Vec3::from(ray.direction())));
+        let mut t0 = 0.0f32;
+        let mut t1 = f32::INFINITY;
+        for a in 0..3 {
+            let h = self.half_extent[a];
+            if d[a].abs() < 1e-9 {
+                if o[a].abs() > h {
+                    return None;
+                }
+                continue;
+            }
+            let inv = 1.0 / d[a];
+            let mut ta = (-h - o[a]) * inv;
+            let mut tb = (h - o[a]) * inv;
+            if ta > tb {
+                std::mem::swap(&mut ta, &mut tb);
+            }
+            t0 = t0.max(ta);
+            t1 = t1.min(tb);
+            if t1 <= t0 {
+                return None;
+            }
+        }
+        Some((t0, t1))
+    }
+
+    pub fn is_homogeneous(&self) -> bool {
+        matches!(self.field, DensityField::Homogeneous)
+    }
+
+    fn sigma_t_at_density(&self, d: f32) -> Vec3A {
+        (self.sigma_a + self.sigma_s) * d
+    }
+}
+
+/// The phase function at a scatter point — a σₛ-weighted mixture of the
+/// HG lobes of every region overlapping that point. One entry in the
+/// common single-region case. Sampling picks a lobe by weight and samples
+/// its HG exactly, so `pdf` (the mixture) equals the actual phase-function
+/// value and the two stay consistent for MIS by construction.
+#[derive(Debug, Clone)]
+pub struct PhaseMix {
+    /// `(weight, g)` pairs; weights sum to 1.
+    lobes: Vec<(f32, f32)>,
+}
+
+impl PhaseMix {
+    pub fn single(g: f32) -> Self {
+        Self { lobes: vec![(1.0, g)] }
+    }
+
+    /// Sample an outgoing direction given the incoming propagation
+    /// direction `wi` (normalized).
+    pub fn sample(&self, wi: Vec3A, sampler: &mut dyn Sampler) -> Vec3A {
+        let mut pick = sampler.next_1d();
+        let mut g = self.lobes[self.lobes.len() - 1].1;
+        for &(w, lg) in &self.lobes {
+            if pick < w {
+                g = lg;
+                break;
+            }
+            pick -= w;
+        }
+        let uv = sampler.next_2d();
+        crate::medium::sample_henyey_greenstein(wi, g, uv[0], uv[1])
+    }
+
+    /// Solid-angle pdf of `sample` — also the phase-function value.
+    pub fn pdf(&self, cos_theta: f32) -> f32 {
+        self.lobes
+            .iter()
+            .map(|&(w, g)| w * hg_phase(cos_theta, g))
+            .sum()
+    }
+}
+
+/// Result of sampling a path segment against the volume aggregate.
+pub enum VolumeEvent {
+    /// A real scattering collision inside some region.
+    Scatter {
+        /// Distance along the ray.
+        t: f32,
+        /// The collision point.
+        p: Vec3A,
+        /// Full path weight of the event: accumulated null-collision
+        /// weights × `σₛ(x) / (σ̄ · P_s)`. Already includes transmittance
+        /// up to `t`; multiplies everything at and beyond this vertex.
+        weight: Vec3A,
+        /// Phase function at the point (mixture under region overlap).
+        phase: PhaseMix,
+        /// Volume emission accumulated along `[0, t]`, pre-weighted by the
+        /// walk weights at each emission point. Must NOT be attenuated
+        /// again by the caller.
+        emitted: Vec3A,
+    },
+    /// The segment was crossed without a real collision.
+    Passthrough {
+        /// Transmittance estimate over the segment (exact for
+        /// all-homogeneous regions; a ratio-tracking sample otherwise).
+        transmittance: Vec3A,
+        /// Pre-weighted volume emission along the segment.
+        emitted: Vec3A,
+    },
+}
+
+/// All volume regions in the scene.
+#[derive(Default)]
+pub struct Volumes {
+    regions: Vec<VolumeRegion>,
+}
+
+impl Volumes {
+    pub fn new(regions: Vec<VolumeRegion>) -> Self {
+        Self { regions }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.regions.is_empty()
+    }
+
+    pub fn regions(&self) -> &[VolumeRegion] {
+        &self.regions
+    }
+
+    /// Clipped per-region intervals over `(t_eps, t_max)`, and the summed
+    /// majorant of the intersected regions. Summing majorants over the
+    /// union span majorizes the summed extinction everywhere on it
+    /// (superposed extinction of overlapping media is exact).
+    fn active_intervals(
+        &self,
+        ray: &Ray,
+        t_eps: f32,
+        t_max: f32,
+    ) -> (Vec<(usize, f32, f32)>, f32) {
+        let mut spans = Vec::new();
+        let mut majorant = 0.0f32;
+        for (i, region) in self.regions.iter().enumerate() {
+            if region.majorant_sigma_t <= 0.0 {
+                continue;
+            }
+            if !region.world_aabb.hit(ray, t_eps, t_max) {
+                continue;
+            }
+            if let Some((t0, t1)) = region.intersect(ray) {
+                let a = t0.max(t_eps);
+                let b = t1.min(t_max);
+                if b > a {
+                    spans.push((i, a, b));
+                    majorant += region.majorant_sigma_t;
+                }
+            }
+        }
+        (spans, majorant)
+    }
+
+    /// Sample one volume interaction along `ray` over `(t_eps, t_max)`,
+    /// where `t_max` is the distance to whatever event (surface hit,
+    /// carried-medium scatter) would otherwise terminate the segment.
+    pub fn sample_interaction(
+        &self,
+        ray: &Ray,
+        t_eps: f32,
+        t_max: f32,
+        sampler: &mut dyn Sampler,
+    ) -> VolumeEvent {
+        let (spans, majorant) = self.active_intervals(ray, t_eps, t_max);
+        if spans.is_empty() || majorant <= 0.0 {
+            return VolumeEvent::Passthrough {
+                transmittance: Vec3A::ONE,
+                emitted: Vec3A::ZERO,
+            };
+        }
+        let start = spans.iter().map(|s| s.1).fold(f32::INFINITY, f32::min);
+        let end = spans.iter().map(|s| s.2).fold(0.0f32, f32::max);
+
+        let mut t = start;
+        let mut w = Vec3A::ONE;
+        let mut emitted = Vec3A::ZERO;
+        loop {
+            t += -(1.0 - sampler.next_1d()).ln() / majorant;
+            if t >= end {
+                return VolumeEvent::Passthrough {
+                    transmittance: w,
+                    emitted,
+                };
+            }
+            let p = ray.at(t);
+
+            // Pointwise coefficients summed over regions covering `p`.
+            let mut sigma_s_x = Vec3A::ZERO;
+            let mut sigma_t_x = Vec3A::ZERO;
+            let mut lobes: Vec<(f32, f32)> = Vec::new();
+            for &(i, a, b) in &spans {
+                if t < a || t > b {
+                    continue;
+                }
+                let region = &self.regions[i];
+                let d = region.density(p);
+                if d <= 0.0 {
+                    continue;
+                }
+                let ss = region.sigma_s * d;
+                sigma_s_x += ss;
+                sigma_t_x += region.sigma_t_at_density(d);
+                emitted += w * (region.sigma_a * d) * region.emission / majorant;
+                let m = ss.max_element();
+                if m > 0.0 {
+                    lobes.push((m, region.g));
+                }
+            }
+
+            let p_scatter = (sigma_s_x.max_element() / majorant).clamp(0.0, 1.0);
+            if sampler.next_1d() < p_scatter {
+                let total: f32 = lobes.iter().map(|l| l.0).sum();
+                for l in &mut lobes {
+                    l.0 /= total;
+                }
+                return VolumeEvent::Scatter {
+                    t,
+                    p,
+                    weight: w * sigma_s_x / (majorant * p_scatter),
+                    phase: PhaseMix { lobes },
+                    emitted,
+                };
+            }
+            // Null/absorb combined: per-channel numerators are
+            // non-negative because the majorant bounds max-channel σₜ.
+            w *= (Vec3A::splat(majorant) - sigma_t_x) / (majorant * (1.0 - p_scatter));
+            if w.max_element() < 1e-5 {
+                return VolumeEvent::Passthrough {
+                    transmittance: Vec3A::ZERO,
+                    emitted,
+                };
+            }
+        }
+    }
+
+    /// Transmittance along `ray` over `(t_eps, t_max)` — ratio tracking,
+    /// with an exact analytic product when every region crossed is
+    /// homogeneous (noise-free fog shadows; exponents of overlapping
+    /// regions add, so the per-region product is exact).
+    pub fn transmittance(
+        &self,
+        ray: &Ray,
+        t_eps: f32,
+        t_max: f32,
+        sampler: &mut dyn Sampler,
+    ) -> Vec3A {
+        let (spans, majorant) = self.active_intervals(ray, t_eps, t_max);
+        if spans.is_empty() || majorant <= 0.0 {
+            return Vec3A::ONE;
+        }
+
+        if spans.iter().all(|&(i, _, _)| self.regions[i].is_homogeneous()) {
+            let mut tr = Vec3A::ONE;
+            for &(i, a, b) in &spans {
+                let e = self.regions[i].sigma_t_at_density(1.0) * (b - a);
+                tr *= Vec3A::new((-e.x).exp(), (-e.y).exp(), (-e.z).exp());
+            }
+            return tr;
+        }
+
+        let start = spans.iter().map(|s| s.1).fold(f32::INFINITY, f32::min);
+        let end = spans.iter().map(|s| s.2).fold(0.0f32, f32::max);
+        let mut t = start;
+        let mut w = Vec3A::ONE;
+        loop {
+            t += -(1.0 - sampler.next_1d()).ln() / majorant;
+            if t >= end {
+                return w;
+            }
+            let p = ray.at(t);
+            let mut sigma_t_x = Vec3A::ZERO;
+            for &(i, a, b) in &spans {
+                if t < a || t > b {
+                    continue;
+                }
+                let region = &self.regions[i];
+                sigma_t_x += region.sigma_t_at_density(region.density(p));
+            }
+            w *= (Vec3A::splat(majorant) - sigma_t_x) / majorant;
+            if w.max_element() < 1e-5 {
+                return Vec3A::ZERO;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sampler::RngSampler;
+
+    fn unit_region(sigma_s: Vec3A, sigma_a: Vec3A, g: f32, field: DensityField) -> VolumeRegion {
+        VolumeRegion::new(
+            Mat4::IDENTITY,
+            Vec3A::splat(0.5),
+            sigma_s,
+            sigma_a,
+            g,
+            Vec3A::ZERO,
+            1.0,
+            field,
+        )
+    }
+
+    fn x_ray() -> Ray {
+        Ray::new(Vec3A::new(-2.0, 0.0, 0.0), Vec3A::X)
+    }
+
+    #[test]
+    fn homogeneous_transmittance_is_exact_beer_lambert() {
+        let volumes = Volumes::new(vec![unit_region(
+            Vec3A::splat(0.7),
+            Vec3A::new(0.2, 0.4, 0.9),
+            0.0,
+            DensityField::Homogeneous,
+        )]);
+        let mut s = RngSampler::default();
+        let tr = volumes.transmittance(&x_ray(), 1e-3, 10.0, &mut s);
+        let sigma_t = Vec3A::splat(0.7) + Vec3A::new(0.2, 0.4, 0.9);
+        let expect = Vec3A::new(
+            (-sigma_t.x).exp(),
+            (-sigma_t.y).exp(),
+            (-sigma_t.z).exp(),
+        );
+        assert!((tr - expect).abs().max_element() < 1e-5, "{tr} vs {expect}");
+        // And again — the fast path is deterministic, zero variance.
+        let tr2 = volumes.transmittance(&x_ray(), 1e-3, 10.0, &mut s);
+        assert_eq!(tr, tr2);
+    }
+
+    #[test]
+    fn ratio_tracking_matches_analytic_on_grid() {
+        // A constant-valued grid is heterogeneous to the tracker but has a
+        // known analytic transmittance.
+        let d = 0.6f32;
+        let volumes = Volumes::new(vec![unit_region(
+            Vec3A::new(0.3, 0.5, 0.8),
+            Vec3A::splat(0.4),
+            0.0,
+            DensityField::Grid {
+                nx: 4,
+                ny: 4,
+                nz: 4,
+                data: vec![d; 64],
+            },
+        )]);
+        let mut s = RngSampler::default();
+        let n = 20_000;
+        let mut mean = Vec3A::ZERO;
+        for _ in 0..n {
+            mean += volumes.transmittance(&x_ray(), 1e-3, 10.0, &mut s);
+        }
+        mean /= n as f32;
+        let e = (Vec3A::new(0.3, 0.5, 0.8) + Vec3A::splat(0.4)) * d;
+        let expect = Vec3A::new((-e.x).exp(), (-e.y).exp(), (-e.z).exp());
+        assert!(
+            (mean - expect).abs().max_element() < 0.01,
+            "{mean} vs {expect}"
+        );
+    }
+
+    #[test]
+    fn delta_tracking_scatter_probability_matches_analytic() {
+        // Pure scattering (σa = 0), gray: P(scatter in slab) = 1 − e^{−σt·d}.
+        let sigma = 1.3f32;
+        let volumes = Volumes::new(vec![unit_region(
+            Vec3A::splat(sigma),
+            Vec3A::ZERO,
+            0.0,
+            DensityField::Homogeneous,
+        )]);
+        let mut s = RngSampler::default();
+        let n = 20_000;
+        let mut scatters = 0u32;
+        for _ in 0..n {
+            if let VolumeEvent::Scatter { weight, .. } =
+                volumes.sample_interaction(&x_ray(), 1e-3, 10.0, &mut s)
+            {
+                scatters += 1;
+                // Gray pure scattering: the event weight must be exactly 1.
+                assert!((weight - Vec3A::ONE).abs().max_element() < 1e-5);
+            }
+        }
+        let observed = scatters as f32 / n as f32;
+        let expect = 1.0 - (-sigma).exp();
+        assert!((observed - expect).abs() < 0.01, "{observed} vs {expect}");
+    }
+
+    #[test]
+    fn emission_walk_matches_analytic_slab() {
+        // Absorbing emissive slab: L = (σa/σt)·Le·(1 − e^{−σt·d}); here
+        // σs = 0 so σa/σt = 1.
+        let sigma_a = 0.8f32;
+        let le = Vec3A::new(4.0, 1.5, 0.3);
+        let region = VolumeRegion::new(
+            Mat4::IDENTITY,
+            Vec3A::splat(0.5),
+            Vec3A::ZERO,
+            Vec3A::splat(sigma_a),
+            0.0,
+            le,
+            1.0,
+            DensityField::Homogeneous,
+        );
+        let volumes = Volumes::new(vec![region]);
+        let mut s = RngSampler::default();
+        let n = 40_000;
+        let mut mean = Vec3A::ZERO;
+        for _ in 0..n {
+            match volumes.sample_interaction(&x_ray(), 1e-3, 10.0, &mut s) {
+                VolumeEvent::Passthrough { emitted, .. } => mean += emitted,
+                VolumeEvent::Scatter { emitted, .. } => mean += emitted,
+            }
+        }
+        mean /= n as f32;
+        let expect = le * (1.0 - (-sigma_a).exp());
+        assert!(
+            ((mean - expect) / expect).abs().max_element() < 0.03,
+            "{mean} vs {expect}"
+        );
+    }
+
+    #[test]
+    fn grid_trilinear_exact_at_centers() {
+        let data: Vec<f32> = (0..8).map(|i| i as f32).collect();
+        let field = DensityField::Grid {
+            nx: 2,
+            ny: 2,
+            nz: 2,
+            data: data.clone(),
+        };
+        // Voxel centers of a 2^3 grid sit at 0.25 and 0.75.
+        for z in 0..2usize {
+            for y in 0..2usize {
+                for x in 0..2usize {
+                    let u = Vec3A::new(
+                        0.25 + 0.5 * x as f32,
+                        0.25 + 0.5 * y as f32,
+                        0.25 + 0.5 * z as f32,
+                    );
+                    let expect = data[x + 2 * (y + 2 * z)];
+                    assert!((field.density(u) - expect).abs() < 1e-6);
+                }
+            }
+        }
+        // Box center is the mean of all 8 samples.
+        let center = field.density(Vec3A::splat(0.5));
+        assert!((center - 3.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn noise_deterministic_and_bounded_by_majorant() {
+        let field = DensityField::Noise {
+            scale: 4.0,
+            octaves: 4,
+            gain: 0.5,
+            lacunarity: 2.0,
+            threshold: 0.3,
+            seed: 42,
+        };
+        let m = field.max_value();
+        let mut prev = Vec::new();
+        for pass in 0..2 {
+            let mut vals = Vec::new();
+            for i in 0..1000 {
+                let u = Vec3A::new(
+                    hash3(i, 1, 2, 7),
+                    hash3(i, 3, 4, 7),
+                    hash3(i, 5, 6, 7),
+                );
+                let d = field.density(u);
+                assert!(d >= 0.0 && d <= m, "density {d} outside [0, {m}]");
+                vals.push(d);
+            }
+            if pass == 0 {
+                prev = vals;
+            } else {
+                assert_eq!(prev, vals, "noise is not deterministic");
+            }
+        }
+        // The field must not be trivially empty.
+        assert!(prev.iter().any(|&d| d > 0.0));
+    }
+
+    #[test]
+    fn oriented_box_interval_in_world_units() {
+        // Box scaled ×2 in x, translated to x = 5: world slab [3, 7].
+        let xf = Mat4::from_translation(Vec3::new(5.0, 0.0, 0.0))
+            * Mat4::from_scale(Vec3::new(2.0, 1.0, 1.0));
+        let region = VolumeRegion::new(
+            xf,
+            Vec3A::ONE,
+            Vec3A::ONE,
+            Vec3A::ZERO,
+            0.0,
+            Vec3A::ZERO,
+            1.0,
+            DensityField::Homogeneous,
+        );
+        let (t0, t1) = region.intersect(&x_ray()).expect("must hit");
+        assert!((t0 - 5.0).abs() < 1e-4 && (t1 - 9.0).abs() < 1e-4, "{t0} {t1}");
+        // Rotation: 45° about z, ray along x through origin-centered box.
+        let rot = Mat4::from_rotation_z(std::f32::consts::FRAC_PI_4);
+        let region = VolumeRegion::new(
+            rot,
+            Vec3A::ONE,
+            Vec3A::ONE,
+            Vec3A::ZERO,
+            0.0,
+            Vec3A::ZERO,
+            1.0,
+            DensityField::Homogeneous,
+        );
+        let (t0, t1) = region.intersect(&x_ray()).expect("must hit");
+        // The rotated unit-half box spans ±√2 along x through its center.
+        let s = 2.0f32.sqrt();
+        assert!((t0 - (2.0 - s)).abs() < 1e-4 && (t1 - (2.0 + s)).abs() < 1e-4);
+    }
+
+    #[test]
+    fn overlapping_regions_compose_exactly() {
+        // Two overlapping homogeneous boxes: transmittance is the product.
+        let a = unit_region(Vec3A::ZERO, Vec3A::splat(0.5), 0.0, DensityField::Homogeneous);
+        let b = VolumeRegion::new(
+            Mat4::from_translation(Vec3::new(0.25, 0.0, 0.0)),
+            Vec3A::splat(0.5),
+            Vec3A::ZERO,
+            Vec3A::splat(0.75),
+            0.0,
+            Vec3A::ZERO,
+            1.0,
+            DensityField::Homogeneous,
+        );
+        let volumes = Volumes::new(vec![a, b]);
+        let mut s = RngSampler::default();
+        let tr = volumes.transmittance(&x_ray(), 1e-3, 10.0, &mut s);
+        let expect = (-0.5f32 - 0.75).exp();
+        assert!((tr.x - expect).abs() < 1e-5, "{tr} vs {expect}");
+    }
+
+    #[test]
+    fn phase_mix_pdf_matches_single_lobe() {
+        let mix = PhaseMix::single(0.4);
+        for &mu in &[-0.9f32, -0.2, 0.0, 0.5, 0.99] {
+            assert!((mix.pdf(mu) - hg_phase(mu, 0.4)).abs() < 1e-7);
+        }
+    }
+}

--- a/crates/crust-core/tests/usd_scene.rs
+++ b/crates/crust-core/tests/usd_scene.rs
@@ -124,6 +124,87 @@ fn loads_rectlight_usda() {
     assert_eq!(scene.settings.get_dimensions(), (64, 64));
 }
 
+#[test]
+fn loads_fog_usda() {
+    let scene = Scene::from_usd(&sample("fog.usda")).expect("failed to open fog.usda");
+
+    // Room mesh BVH + ball sphere + two rect-light triangles; the Fog cube
+    // must import as a volume region, NOT as geometry.
+    assert_eq!(
+        scene.world.count(),
+        4,
+        "expected 4 hittables (room, ball, 2 light triangles), got {}",
+        scene.world.count()
+    );
+    assert_eq!(scene.lights.count(), 1);
+    assert_eq!(scene.volumes.len(), 1, "expected 1 volume region");
+
+    let fog = &scene.volumes[0];
+    assert!(fog.is_homogeneous());
+    assert!((fog.g - 0.3).abs() < 1e-6);
+    assert!((fog.sigma_s - crust_core::Vec3A::splat(0.15)).abs().max_element() < 1e-6);
+    // The homogeneous fast path must yield exact Beer-Lambert through the
+    // 4-unit room: e^{-(0.15+0.01)·4} in the red channel.
+    let mut s = sampler::RngSampler::default();
+    let volumes = crust_core::Volumes::new(scene.volumes);
+    let ray = crust_core::Ray::new(crust_core::Vec3A::new(0.0, 2.0, 10.0), -crust_core::Vec3A::Z);
+    let tr = volumes.transmittance(&ray, 1e-3, 100.0, &mut s);
+    let expect = (-(0.15f32 + 0.01) * 4.0).exp();
+    assert!(
+        (tr.x - expect).abs() < 1e-4,
+        "fog transmittance {} vs analytic {}",
+        tr.x,
+        expect
+    );
+}
+
+#[test]
+fn loads_smoke_usda() {
+    let scene = Scene::from_usd(&sample("smoke.usda")).expect("failed to open smoke.usda");
+
+    // Room mesh + two light triangles; all three volume cubes must import
+    // as regions, not geometry.
+    assert_eq!(
+        scene.world.count(),
+        3,
+        "expected 3 hittables (room, 2 light triangles), got {}",
+        scene.world.count()
+    );
+    assert_eq!(scene.lights.count(), 1);
+    assert_eq!(
+        scene.volumes.len(),
+        3,
+        "expected 3 volume regions (smoke, ember, grid puff)"
+    );
+
+    // Prim traversal order is an implementation detail — identify the
+    // regions by their properties instead.
+    let smoke = scene
+        .volumes
+        .iter()
+        .find(|v| !v.is_homogeneous() && (v.g - 0.2).abs() < 1e-6)
+        .expect("smoke plume region");
+    // densityScale is folded into the coefficients: σs = 0.8 · 12.
+    assert!((smoke.sigma_s.x - 9.6).abs() < 1e-4);
+
+    let ember = scene
+        .volumes
+        .iter()
+        .find(|v| v.emission.max_element() > 0.0)
+        .expect("emissive ember region");
+    assert!(ember.is_homogeneous());
+
+    // The grid puff has positive density at its center, zero at a corner.
+    let grid = scene
+        .volumes
+        .iter()
+        .find(|v| !v.is_homogeneous() && v.g.abs() < 1e-6)
+        .expect("grid puff region");
+    let center = crust_core::Vec3A::new(1.1, 2.6, -0.8);
+    assert!(grid.density(center) > 0.3);
+    assert!(grid.density(center + crust_core::Vec3A::splat(0.49)) < 1e-3);
+}
+
 /// Regression guard: every material in the ported showcase must decode to
 /// the `crust:openpbr` shader id, and every scene sphere must bind one of
 /// them. When this test drifts (renamed shader ids, missing material

--- a/crates/crust-render/src/main.rs
+++ b/crates/crust-render/src/main.rs
@@ -109,6 +109,7 @@ fn main() {
     let camera = scene.camera;
     let world = scene.world;
     let lights = scene.lights;
+    let volumes = scene.volumes;
     let settings = match cli.samples {
         Some(spp) => scene.settings.with_samples_per_pixel(spp),
         None => scene.settings,
@@ -121,7 +122,7 @@ fn main() {
     debug!("World loaded with {} objects", world.count());
     debug!("Lights loaded with {} objects", lights.count());
     // Camera
-    let renderer = Renderer::new(camera, world, lights, settings);
+    let renderer = Renderer::new(camera, world, lights, settings).with_volumes(volumes);
     info!("Let's start rendering...");
     if cli.bucket {
         info!("Bucket rendering is enabled");

--- a/openspec/specs/rendering/spec.md
+++ b/openspec/specs/rendering/spec.md
@@ -80,6 +80,37 @@ travelling in free space (no medium) SHALL be unaffected.
 - **WHEN** a ray carries no medium
 - **THEN** no Beer-Lambert attenuation is applied to its contribution
 
+### Requirement: Free-standing volume regions
+
+The renderer SHALL transport light through the scene's volume regions
+(smoke, fog, absorption and emissive volumes) held outside the surface BVH:
+distance sampling by weighted delta tracking against each region's
+extinction majorant, direct lighting with MIS at volume scatter vertices,
+and transmittance-aware shadow rays (stochastic ratio tracking for
+heterogeneous regions, exact Beer-Lambert for homogeneous ones). Scenes
+without volume regions SHALL render exactly as before.
+
+#### Scenario: Scatter event inside a volume region
+
+- **WHEN** a path segment crosses a volume region and the tracking walk
+  produces a real collision before the nearest surface
+- **THEN** the path scatters there via the Henyey-Greenstein phase function,
+  gathers direct lighting with the light/phase balance heuristic, and the
+  bounce-hit emission of the continuation is MIS-weighted against the same
+  light strategy
+
+#### Scenario: Shadow rays attenuate through volumes
+
+- **WHEN** an NEE shadow ray crosses a volume region without surface occlusion
+- **THEN** the direct-lighting contribution is multiplied by the volumetric
+  transmittance along the segment rather than treated as fully visible
+
+#### Scenario: Emissive volumes glow
+
+- **WHEN** a path segment crosses a region with nonzero emission
+- **THEN** the segment accumulates `σₐ·Lₑ` source radiance weighted by the
+  transmittance up to each emission point
+
 ### Requirement: Sky-gradient background
 
 The renderer SHALL return a vertical white-to-blue gradient based on ray

--- a/samples/fog.usda
+++ b/samples/fog.usda
@@ -1,0 +1,70 @@
+#usda 1.0
+(
+    doc = "Homogeneous fog in a grey room lit by a ceiling RectLight: god rays around an occluding ball. Exercises the crust:volume:* homogeneous import, volume NEE and the analytic (noise-free) transmittance fast path."
+    defaultPrim = "World"
+    upAxis = "Y"
+)
+
+def Xform "World"
+{
+    def Camera "Cam"
+    {
+        float focalLength = 24
+        float horizontalAperture = 20.955
+        double3 xformOp:translate = (0, 2, 8.5)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    # Five-sided grey room: floor, ceiling, back, left, right (front open).
+    def Mesh "Room"
+    {
+        int[] faceVertexCounts = [4, 4, 4, 4, 4]
+        int[] faceVertexIndices = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+        point3f[] points = [(-2, 0, -2), (2, 0, -2), (2, 0, 2), (-2, 0, 2), (-2, 4, -2), (2, 4, -2), (2, 4, 2), (-2, 4, 2), (-2, 0, -2), (2, 0, -2), (2, 4, -2), (-2, 4, -2), (-2, 0, -2), (-2, 0, 2), (-2, 4, 2), (-2, 4, -2), (2, 0, -2), (2, 0, 2), (2, 4, 2), (2, 4, -2)]
+    }
+
+    def Sphere "Ball"
+    {
+        double radius = 0.6
+        double3 xformOp:translate = (-0.7, 0.6, 0.3)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    # The fog: a Cube-shaped homogeneous region filling the room. Slightly
+    # blue-leaning absorption gives the beams a warm tint.
+    def Cube "Fog"
+    {
+        double size = 4
+        token crust:volume:type = "homogeneous"
+        color3f crust:volume:sigmaS = (0.15, 0.15, 0.15)
+        color3f crust:volume:sigmaA = (0.01, 0.015, 0.025)
+        float crust:volume:anisotropy = 0.3
+        double3 xformOp:translate = (0, 2, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    # Ceiling light, rotated so its local -Z emits downward.
+    def RectLight "CeilingLight"
+    {
+        float inputs:width = 1.6
+        float inputs:height = 1.6
+        color3f inputs:color = (10, 10, 10)
+        float inputs:intensity = 1.0
+        float xformOp:rotateX = -90
+        double3 xformOp:translate = (0, 3.98, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateX"]
+    }
+}
+
+def Scope "Render"
+{
+    def RenderSettings "settings"
+    {
+        int2 resolution = (320, 180)
+        int crust:samplesPerPixel = 64
+        int crust:maxDepth = 16
+        int crust:minSamplesPerPixel = 16
+        float crust:varianceThreshold = 0.05
+        int crust:frame = 0
+    }
+}

--- a/samples/smoke.usda
+++ b/samples/smoke.usda
@@ -1,0 +1,98 @@
+#usda 1.0
+(
+    doc = "Procedural noise smoke, an emissive ember volume (fire) and a tiny explicit density grid in a grey room under a ceiling RectLight. Exercises the smoke/grid crust:volume:* import paths, delta tracking, volume emission and transmittance shadow rays."
+    defaultPrim = "World"
+    upAxis = "Y"
+)
+
+def Xform "World"
+{
+    def Camera "Cam"
+    {
+        float focalLength = 24
+        float horizontalAperture = 20.955
+        double3 xformOp:translate = (0, 2, 8.5)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    # Five-sided grey room: floor, ceiling, back, left, right (front open).
+    def Mesh "Room"
+    {
+        int[] faceVertexCounts = [4, 4, 4, 4, 4]
+        int[] faceVertexIndices = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+        point3f[] points = [(-2, 0, -2), (2, 0, -2), (2, 0, 2), (-2, 0, 2), (-2, 4, -2), (2, 4, -2), (2, 4, 2), (-2, 4, 2), (-2, 0, -2), (2, 0, -2), (2, 4, -2), (-2, 4, -2), (-2, 0, -2), (-2, 0, 2), (-2, 4, 2), (-2, 4, -2), (2, 0, -2), (2, 0, 2), (2, 4, 2), (2, 4, -2)]
+    }
+
+    # A plume of procedural fBm smoke, stretched upward.
+    def Cube "Smoke"
+    {
+        double size = 2
+        token crust:volume:type = "smoke"
+        float crust:volume:densityScale = 12
+        color3f crust:volume:sigmaS = (0.8, 0.8, 0.8)
+        color3f crust:volume:sigmaA = (0.08, 0.08, 0.08)
+        float crust:volume:anisotropy = 0.2
+        float crust:volume:noiseScale = 4
+        int crust:volume:noiseOctaves = 4
+        float crust:volume:noiseGain = 0.5
+        float crust:volume:noiseLacunarity = 2
+        float crust:volume:noiseThreshold = 0.25
+        int crust:volume:noiseSeed = 42
+        float3 xformOp:scale = (0.9, 1.6, 0.9)
+        double3 xformOp:translate = (-0.4, 1.7, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+    }
+
+    # A small glowing ember: absorbing + emissive (fire).
+    def Cube "Ember"
+    {
+        double size = 0.5
+        token crust:volume:type = "homogeneous"
+        float crust:volume:densityScale = 4
+        color3f crust:volume:sigmaS = (0.05, 0.05, 0.05)
+        color3f crust:volume:sigmaA = (0.6, 0.35, 0.15)
+        color3f crust:volume:emission = (6, 2.2, 0.5)
+        double3 xformOp:translate = (0.9, 0.3, 0.4)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    # A tiny explicit 4x4x4 density grid (spherical blob), exercising the
+    # gridDims/gridData import and trilinear lookup.
+    def Cube "GridPuff"
+    {
+        double size = 1
+        token crust:volume:type = "grid"
+        float crust:volume:densityScale = 6
+        color3f crust:volume:sigmaS = (0.7, 0.7, 0.7)
+        color3f crust:volume:sigmaA = (0.05, 0.05, 0.05)
+        int[] crust:volume:gridDims = [4, 4, 4]
+        float[] crust:volume:gridData = [0.000, 0.092, 0.092, 0.000, 0.092, 0.309, 0.309, 0.092, 0.092, 0.309, 0.309, 0.092, 0.000, 0.092, 0.092, 0.000, 0.092, 0.309, 0.309, 0.092, 0.309, 0.639, 0.639, 0.309, 0.309, 0.639, 0.639, 0.309, 0.092, 0.309, 0.309, 0.092, 0.092, 0.309, 0.309, 0.092, 0.309, 0.639, 0.639, 0.309, 0.309, 0.639, 0.639, 0.309, 0.092, 0.309, 0.309, 0.092, 0.000, 0.092, 0.092, 0.000, 0.092, 0.309, 0.309, 0.092, 0.092, 0.309, 0.309, 0.092, 0.000, 0.092, 0.092, 0.000]
+        double3 xformOp:translate = (1.1, 2.6, -0.8)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    # Ceiling light, rotated so its local -Z emits downward.
+    def RectLight "CeilingLight"
+    {
+        float inputs:width = 1.6
+        float inputs:height = 1.6
+        color3f inputs:color = (10, 10, 10)
+        float inputs:intensity = 1.0
+        float xformOp:rotateX = -90
+        double3 xformOp:translate = (0, 3.98, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateX"]
+    }
+}
+
+def Scope "Render"
+{
+    def RenderSettings "settings"
+    {
+        int2 resolution = (320, 180)
+        int crust:samplesPerPixel = 64
+        int crust:maxDepth = 16
+        int crust:minSamplesPerPixel = 16
+        float crust:varianceThreshold = 0.05
+        int crust:frame = 0
+    }
+}


### PR DESCRIPTION
sample_henyey_greenstein applied PBRT's inversion formula directly to the
propagation direction, but PBRT's frame is built around the reversed
direction wo — so g > 0 scattered backward. Flip the sign so g > 0 peaks
forward along propagation, and add hg_phase (value == solid-angle pdf)
evaluated in the same convention. Histogram and quadrature tests pin both.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ETtF2gsbr9C53EYLvhTeMV