### PR TITLE
Align OpenPBR lobes with the MaterialX reference nodegraph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,8 +137,12 @@ material types, `simple_scene`, `get_settings`). Prefer importing from `crust_co
   and `emitted()`. Exactly two implementations: **`OpenPBR`**,
   the single übershader for all surfaces (with `diffuse`/`metal`/`glass`/`glossy` preset
   constructors used by `world.rs` and the USD fallback), and **`Emissive`**, a pure
-  emitter with no geometry knowledge. Shared microfacet helpers (aniso GGX VNDF sampling,
-  Schlick Fresnel, sheen, thin-film) live in `material/brdf.rs`.
+  emitter with no geometry knowledge. Shared shading helpers (aniso GGX VNDF sampling,
+  Schlick/F82 Fresnel, EON diffuse, Charlie sheen, thin-film, Cauchy dispersion) live in
+  `material/brdf.rs`. The OpenPBR formulas are aligned against the MaterialX nodegraph
+  and Adobe's `openpbr-bsdf` reference — the item-by-item alignment record (with the
+  remaining gaps, e.g. no LUT-based multiple-scattering compensation and no random-walk
+  SSS entry) is `docs/openpbr_reference_alignment.md`.
 - **`Light`** (`light.rs`) — `sample_point`/`pdf`/`emission`/`material`. The one
   implementation is **`AreaLight`**: a `LightShape` (pure emitting geometry —
   `SphereShape`, `RectShape`) paired with the `Arc<Emissive>` its scene geometry carries.
@@ -213,11 +217,13 @@ that mention a `usd` **feature flag** are stale — there is no such feature.
   continuous Walter et al. 2007 microfacet BTDF — sampled via VNDF + Snell, evaluable
   over the full sphere, and part of the NEE/guide mixtures (guide-chosen directions
   cross the interface via `Material::make_ray`, which tags the interior medium).
-  Dispersion is continuous per-channel: each RGB channel refracts with its own IOR,
-  sampling picks one channel's IOR uniformly, and evaluation runs three per-channel
+  Dispersion is continuous per-channel: each RGB channel refracts with its own
+  Cauchy/Abbe-derived IOR (`cauchy_ior`, anchored at the Fraunhofer d line), sampling
+  picks one channel's IOR uniformly, and evaluation runs three per-channel
   BTDF evaluations whose sampling pdfs average into the channel-mixture density. Only
   thin-walled transmission remains a per-sample delta lobe (`ScatterSample::delta`),
-  excluded from continuous mixtures. The guide-vs-BSDF selection probability is fixed (no learned α), and
+  excluded from continuous mixtures — carrying window-model energy
+  (`(1−R)/(1+R)` transmittance, boosted `2R/(1+R)` reflection, view-dependent tint). The guide-vs-BSDF selection probability is fixed (no learned α), and
   spatial lookups are not parallax-compensated.
 - **Volume regions** (`volume.rs`) have no OpenVDB / `UsdVolVolume` import (openusd 0.5
   ships no `vol` feature) — density is homogeneous, procedural fBm noise, or an inline

--- a/crates/crust-core/src/material/brdf.rs
+++ b/crates/crust-core/src/material/brdf.rs
@@ -298,7 +298,37 @@ pub fn coat_darkening_factor(base_color: Vec3A, coat_ior: f32, darkening: f32) -
 // primaries (R = 615 nm, G = 545 nm, B = 465 nm) — a 3-wavelength
 // approximation that captures the characteristic soap-bubble / oil-slick
 // look without full spectral rendering.
-const LAMBDA_RGB: [f32; 3] = [615.0, 545.0, 465.0];
+/// Representative wavelengths (nm) of the sRGB primaries, shared by the
+/// thin-film interference and dispersion models so per-channel spectral
+/// effects stay consistent.
+pub const LAMBDA_RGB: [f32; 3] = [615.0, 545.0, 465.0];
+
+// -------- Physical dispersion (Cauchy / Abbe) --------
+//
+// Following Adobe's OpenPBR BSDF reference (openpbr_dispersion_utils.h): a
+// dielectric is specified by its index n_d at the Fraunhofer d line plus an
+// Abbe number V_d = (n_d − 1)/(n_F − n_C), and the wavelength dependence is
+// reconstructed with the two-term Cauchy equation n(λ) = A + B/λ² — the
+// best fit available without partial-dispersion data.
+
+/// Fraunhofer C line (hydrogen), 656.3 nm — the long/red reference.
+pub const FRAUNHOFER_C_NM: f32 = 656.3;
+/// Fraunhofer d line (helium), 587.6 nm — where `n_d` is defined.
+pub const FRAUNHOFER_D_NM: f32 = 587.6;
+/// Fraunhofer F line (hydrogen), 486.1 nm — the short/blue reference.
+pub const FRAUNHOFER_F_NM: f32 = 486.1;
+
+/// Cauchy-fit refractive index at `lambda_nm` for a dielectric with index
+/// `n_d` (> 1) at the d line and Abbe number `v_d`. A and B are chosen so
+/// that `n(λ_d) = n_d` exactly and the fit's Abbe number is exactly `v_d`.
+pub fn cauchy_ior(n_d: f32, v_d: f32, lambda_nm: f32) -> f32 {
+    let b = (n_d - 1.0)
+        / (v_d
+            * (1.0 / (FRAUNHOFER_F_NM * FRAUNHOFER_F_NM)
+                - 1.0 / (FRAUNHOFER_C_NM * FRAUNHOFER_C_NM)));
+    let a = n_d - b / (FRAUNHOFER_D_NM * FRAUNHOFER_D_NM);
+    a + b / (lambda_nm * lambda_nm)
+}
 
 /// Airy-summation reflectance of the film stack at a single wavelength, for
 /// a base of (real) index `eta_2`. Returns 1.0 past a TIR boundary.

--- a/crates/crust-core/src/material/brdf.rs
+++ b/crates/crust-core/src/material/brdf.rs
@@ -28,16 +28,17 @@ pub fn f0_from_ior(ior: f32) -> f32 {
     r * r
 }
 
-/// Convert an isotropic roughness in [0, 1] plus a signed anisotropy in
-/// [-1, 1] to two microfacet slope alphas `(ax, ay)`. OpenPBR's convention:
-/// positive anisotropy stretches along the surface tangent. The mapping
-/// follows the "perceptually linear" convention used by Autodesk Standard
-/// Surface and the OpenPBR reference: `α = r²`, then split by anisotropy.
+/// Convert an isotropic roughness in [0, 1] plus an anisotropy in [0, 1] to
+/// two microfacet slope alphas `(ax, ay)`, stretching highlights along the
+/// surface tangent. This is the `open_pbr_anisotropy` graph from the OpenPBR
+/// MaterialX reference:
+///   `ax = r² · √(2 / (1 + (1 − a)²))`,  `ay = (1 − a) · ax`
+/// which reduces to `ax = ay = r²` at zero anisotropy.
 pub fn roughness_to_alpha_aniso(roughness: f32, anisotropy: f32) -> (f32, f32) {
     let a = roughness * roughness;
-    let aniso = anisotropy.clamp(-0.99, 0.99);
-    let ax = a * (1.0 + aniso).sqrt();
-    let ay = a * (1.0 - aniso).sqrt();
+    let inv = 1.0 - anisotropy.clamp(0.0, 1.0);
+    let ax = a * (2.0 / (1.0 + inv * inv)).sqrt();
+    let ay = inv * ax;
     (ax.max(1e-4), ay.max(1e-4))
 }
 
@@ -132,6 +133,21 @@ pub fn pdf_vndf_h_aniso_local(v_local: Vec3A, h_local: Vec3A, ax: f32, ay: f32) 
     d * g1 * v_dot_h / n_dot_v
 }
 
+/// "F82-tint" conductor Fresnel (Kutz et al., as adopted by the OpenPBR
+/// metal slab / MaterialX `generalized_schlick_bsdf` with `color0`/`color82`).
+/// Plain Schlick pinned at `f0` for normal incidence and white at grazing,
+/// with the reflectance at μ̄ = cos 82° ≈ 1/7 scaled by `tint` — the
+/// `specular_color` edge tint:
+///   `F(μ) = F_s(μ) − μ (1 − μ)⁶ · F_s(μ̄) (1 − tint) / (μ̄ (1 − μ̄)⁶)`
+pub fn fresnel_f82_tint(cos_theta: f32, f0: Vec3A, tint: Vec3A) -> Vec3A {
+    const MU_BAR: f32 = 1.0 / 7.0;
+    let mu = cos_theta.clamp(0.0, 1.0);
+    let f_schlick = |m: f32| f0 + (Vec3A::ONE - f0) * (1.0 - m).powf(5.0);
+    let denom = MU_BAR * (1.0 - MU_BAR).powi(6);
+    let a = f_schlick(MU_BAR) * (Vec3A::ONE - tint) / denom;
+    (f_schlick(mu) - a * mu * (1.0 - mu).powi(6)).clamp(Vec3A::ZERO, Vec3A::ONE)
+}
+
 /// Exact unpolarized dielectric Fresnel reflectance for an interface with
 /// incident-side IOR `eta_i` and transmitted-side IOR `eta_t`. `cos_i` is
 /// the (positive) cosine between the incident direction and the facet
@@ -209,25 +225,30 @@ pub fn coat_darkening_factor(base_color: Vec3A, coat_ior: f32, darkening: f32) -
 // primaries (R = 615 nm, G = 545 nm, B = 465 nm) — a 3-wavelength
 // approximation that captures the characteristic soap-bubble / oil-slick
 // look without full spectral rendering.
-pub fn thin_film_fresnel(
+const LAMBDA_RGB: [f32; 3] = [615.0, 545.0, 465.0];
+
+/// Airy-summation reflectance of the film stack at a single wavelength, for
+/// a base of (real) index `eta_2`. Returns 1.0 past a TIR boundary.
+fn thin_film_reflectance_lambda(
     cos_theta_1: f32,
     eta_1: f32,
     eta_film: f32,
     eta_2: f32,
     thickness_nm: f32,
-) -> Vec3A {
+    lambda_nm: f32,
+) -> f32 {
     let cos1 = cos_theta_1.clamp(0.0, 1.0);
     let sin2_1 = 1.0 - cos1 * cos1;
 
     let sin2_film = (eta_1 / eta_film).powi(2) * sin2_1;
     if sin2_film >= 1.0 {
-        return Vec3A::ONE;
+        return 1.0;
     }
     let cos_film = (1.0 - sin2_film).sqrt();
 
     let sin2_base = (eta_film / eta_2).powi(2) * sin2_film;
     if sin2_base >= 1.0 {
-        return Vec3A::ONE;
+        return 1.0;
     }
     let cos_base = (1.0 - sin2_base).sqrt();
 
@@ -239,21 +260,51 @@ pub fn thin_film_fresnel(
     // Optical path difference inside the film.
     let opd = 2.0 * eta_film * thickness_nm * cos_film;
 
-    const LAMBDA_RGB: [f32; 3] = [615.0, 545.0, 465.0];
-    let mut out = Vec3A::ZERO;
-    for i in 0..3 {
-        let phi = 2.0 * PI * opd / LAMBDA_RGB[i];
-        let cos_phi = phi.cos();
-        let num = r_a * r_a + 2.0 * r_a * r_b * cos_phi + r_b * r_b;
-        let den = 1.0 + 2.0 * r_a * r_b * cos_phi + (r_a * r_b).powi(2);
-        let r = (num / den.max(1e-8)).clamp(0.0, 1.0);
-        match i {
-            0 => out.x = r,
-            1 => out.y = r,
-            _ => out.z = r,
-        }
+    let phi = 2.0 * PI * opd / lambda_nm;
+    let cos_phi = phi.cos();
+    let num = r_a * r_a + 2.0 * r_a * r_b * cos_phi + r_b * r_b;
+    let den = 1.0 + 2.0 * r_a * r_b * cos_phi + (r_a * r_b).powi(2);
+    (num / den.max(1e-8)).clamp(0.0, 1.0)
+}
+
+pub fn thin_film_fresnel(
+    cos_theta_1: f32,
+    eta_1: f32,
+    eta_film: f32,
+    eta_2: f32,
+    thickness_nm: f32,
+) -> Vec3A {
+    let mut out = [0.0f32; 3];
+    for (i, lambda) in LAMBDA_RGB.into_iter().enumerate() {
+        out[i] =
+            thin_film_reflectance_lambda(cos_theta_1, eta_1, eta_film, eta_2, thickness_nm, lambda);
     }
-    out
+    Vec3A::from_array(out)
+}
+
+/// Thin-film reflectance over a metallic base described by its per-channel
+/// normal-incidence reflectance `f0` (the OpenPBR metal slab's
+/// `base_color · base_weight`). Each channel's F0 is converted to the
+/// equivalent real IOR `η = (1 + √F0) / (1 − √F0)` and the Airy summation is
+/// evaluated at that channel's wavelength — the same 3-wavelength
+/// approximation as `thin_film_fresnel`, mirroring the MaterialX
+/// `generalized_schlick_bsdf` thin-film variant used by `metal_bsdf_tf`.
+pub fn thin_film_fresnel_metal(
+    cos_theta_1: f32,
+    eta_1: f32,
+    eta_film: f32,
+    f0: Vec3A,
+    thickness_nm: f32,
+) -> Vec3A {
+    let mut out = [0.0f32; 3];
+    for (i, lambda) in LAMBDA_RGB.into_iter().enumerate() {
+        let f0_c = f0[i].clamp(0.0, 0.9999);
+        let sqrt_f0 = f0_c.sqrt();
+        let eta_2 = (1.0 + sqrt_f0) / (1.0 - sqrt_f0);
+        out[i] =
+            thin_film_reflectance_lambda(cos_theta_1, eta_1, eta_film, eta_2, thickness_nm, lambda);
+    }
+    Vec3A::from_array(out)
 }
 
 // Signed amplitude Fresnel — average of s/p, sign preserved (positive when

--- a/crates/crust-core/src/material/brdf.rs
+++ b/crates/crust-core/src/material/brdf.rs
@@ -133,6 +133,79 @@ pub fn pdf_vndf_h_aniso_local(v_local: Vec3A, h_local: Vec3A, ax: f32, ay: f32) 
     d * g1 * v_dot_h / n_dot_v
 }
 
+// -------- EON (energy-preserving Oren-Nayar) diffuse --------
+//
+// Portsmouth et al., "EON: A practical energy-preserving rough diffuse
+// BRDF" — the model the OpenPBR spec names for the base diffuse slab,
+// following the formulation in Adobe's OpenPBR BSDF reference: Fujii's
+// Oren-Nayar variant (single-scattering) plus an analytic
+// multiple-scattering lobe that restores the energy the single-scattering
+// term loses at high roughness. At `rho = 1` the total hemispherical albedo
+// is exactly 1 for any roughness; at zero roughness it reduces to Lambert.
+
+/// Fujii Oren-Nayar `A` constant: `1/(1 + A·r)` normalises the lobe.
+const EON_A: f32 = 0.5 - 2.0 / (3.0 * PI);
+/// Constant in the average (cosine-weighted) directional albedo
+/// `Ē = (1 + B·r) / (1 + A·r)`.
+const EON_B: f32 = 2.0 / 3.0 - 28.0 / (15.0 * PI);
+
+/// Fujii Oren-Nayar directional albedo, exact closed form. (Reference for
+/// the approximation below; used by tests to pin the fit.)
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn eon_albedo_exact(mu: f32, roughness: f32) -> f32 {
+    let mu = mu.clamp(1e-4, 1.0);
+    let af = 1.0 / (1.0 + EON_A * roughness);
+    let bf = roughness * af;
+    let si = (1.0 - mu * mu).max(0.0).sqrt();
+    let g = si * (mu.acos() - si * mu) + (2.0 / 3.0) * ((si / mu) * (1.0 - si * si * si) - si);
+    af + (bf / PI) * g
+}
+
+/// Fujii Oren-Nayar directional albedo, quartic polynomial fit (the runtime
+/// form used by the Adobe reference; agrees with the exact form to ~1e-2).
+pub fn eon_albedo_approx(mu: f32, roughness: f32) -> f32 {
+    let mucomp = 1.0 - mu.clamp(0.0, 1.0);
+    const G1: f32 = 0.057_108_529;
+    const G2: f32 = 0.491_881_87;
+    const G3: f32 = -0.332_181_44;
+    const G4: f32 = 0.071_442_995;
+    let g_over_pi = mucomp * (G1 + mucomp * (G2 + mucomp * (G3 + mucomp * G4)));
+    (1.0 + roughness * g_over_pi) / (1.0 + EON_A * roughness)
+}
+
+/// EON BRDF value (no cosine). `rho` is the single-scattering albedo
+/// (clamped to [0, 1] — the multiple-scattering series diverges beyond),
+/// `v_local`/`l_local` are unit view/light directions in the tangent frame.
+/// Reciprocal in `v`/`l`.
+pub fn eon_diffuse(rho: Vec3A, roughness: f32, v_local: Vec3A, l_local: Vec3A) -> Vec3A {
+    let rho = rho.clamp(Vec3A::ZERO, Vec3A::ONE);
+    let mu_i = v_local.z;
+    let mu_o = l_local.z;
+
+    // Single-scattering Fujii lobe.
+    let s = v_local.dot(l_local) - mu_i * mu_o;
+    let s_over_t = if s > 0.0 {
+        s / mu_i.max(mu_o).max(1e-6)
+    } else {
+        s
+    };
+    let af = 1.0 / (1.0 + EON_A * roughness);
+    let f_ss = rho * (af / PI) * (1.0 + roughness * s_over_t);
+
+    // Multiple-scattering compensation lobe: shaped like
+    // (1 − E(μ_o))(1 − E(μ_i)) / (1 − Ē), scaled by the geometric-series
+    // multi-bounce albedo ρ_ms — integrates to exactly the missing energy.
+    let e_o = eon_albedo_approx(mu_o, roughness);
+    let e_i = eon_albedo_approx(mu_i, roughness);
+    let avg_e = af * (1.0 + EON_B * roughness);
+    let rho_ms = (rho * rho) * avg_e / (Vec3A::ONE - rho * (1.0 - avg_e));
+    const EPS: f32 = 1.0e-7;
+    let f_ms =
+        rho_ms * (1.0 / PI) * ((1.0 - e_o).max(EPS) * (1.0 - e_i).max(EPS) / (1.0 - avg_e).max(EPS));
+
+    f_ss + f_ms
+}
+
 /// "F82-tint" conductor Fresnel (Kutz et al., as adopted by the OpenPBR
 /// metal slab / MaterialX `generalized_schlick_bsdf` with `color0`/`color82`).
 /// Plain Schlick pinned at `f0` for normal incidence and white at grazing,

--- a/crates/crust-core/src/material/brdf.rs
+++ b/crates/crust-core/src/material/brdf.rs
@@ -5,10 +5,6 @@ pub fn fresnel_schlick(cos_theta: f32, f0: Vec3A) -> Vec3A {
     f0 + (Vec3A::new(1.0, 1.0, 1.0) - f0) * f32::powf(1.0 - cos_theta, 5.0)
 }
 
-pub fn schlick_weight(cos_theta: f32) -> f32 {
-    (1.0 - cos_theta).powf(5.0)
-}
-
 // Clearcoat Fresnel approx
 pub fn fresnel_schlick_scalar(cos_theta: f32, f0: f32) -> f32 {
     f0 + (1.0 - f0) * (1.0 - cos_theta).powf(5.0)

--- a/crates/crust-core/src/material/material.rs
+++ b/crates/crust-core/src/material/material.rs
@@ -86,4 +86,15 @@ pub trait Material: Send + Sync {
     fn emitted(&self) -> Vec3A {
         Vec3A::new(0.0, 0.0, 0.0)
     }
+
+    /// Emitted radiance toward a direction making angle `θ` with the surface
+    /// normal (`cos_theta_o` ≥ 0). Defaults to the isotropic `emitted()`;
+    /// materials whose emission is view-dependent (e.g. OpenPBR's emission
+    /// seen through its coat) override this. The integrator uses it at hit
+    /// points, where the outgoing direction is known; `emitted()` remains
+    /// the direction-free radiance used by the light list.
+    fn emitted_directional(&self, cos_theta_o: f32) -> Vec3A {
+        let _ = cos_theta_o;
+        self.emitted()
+    }
 }

--- a/crates/crust-core/src/material/openpbr.rs
+++ b/crates/crust-core/src/material/openpbr.rs
@@ -540,15 +540,29 @@ fn pdf_all(m: &OpenPBR, pmf: &LobePmf, v_local: Vec3A, l_local: Vec3A, entering:
 // Transmission (Phase 3+4)
 // ---------------------------------------------------------------------------
 
-/// Per-channel IOR for a dispersive dielectric. Returns `(η_R, η_G, η_B)`.
-/// `dispersion_scale = 0` collapses to `(η_D, η_D, η_D)`.
+/// Per-channel IOR for a dispersive dielectric, `(η_R, η_G, η_B)` at the
+/// sRGB primary wavelengths, via the Cauchy/Abbe fit (`cauchy_ior`).
+/// `transmission_dispersion_scale` divides the authored Abbe number — the
+/// effective Abbe is `abbe / scale`, so scale 1 is the physical dispersion
+/// of a glass with that Abbe number, larger scales exaggerate it linearly,
+/// and 0 collapses to `(η_D, η_D, η_D)`. An IOR below 1 (interior less
+/// dense than the exterior) disperses via its reciprocal, keeping the
+/// model symmetric across the interface.
 fn dispersive_ior(n_d: f32, abbe: f32, dispersion_scale: f32) -> Vec3A {
-    if dispersion_scale <= 0.0 {
+    if dispersion_scale <= 0.0 || n_d == 1.0 {
         return Vec3A::splat(n_d);
     }
-    let v = abbe.max(1.0);
-    let spread = (n_d - 1.0) / v * dispersion_scale;
-    Vec3A::new(n_d - 0.3 * spread, n_d, n_d + 0.7 * spread)
+    let inverted = n_d < 1.0;
+    let n_above_one = if inverted { 1.0 / n_d } else { n_d };
+    // Realistic glasses span V_d ≈ 20–95; the floor keeps authored extremes
+    // (tiny Abbe, huge scale) from producing a runaway Cauchy B term.
+    let v_d = (abbe.max(1.0) / dispersion_scale).max(1.0);
+    let mut out = [0.0f32; 3];
+    for (c, lambda) in LAMBDA_RGB.into_iter().enumerate() {
+        let n = cauchy_ior(n_above_one, v_d, lambda);
+        out[c] = if inverted { 1.0 / n } else { n };
+    }
+    Vec3A::from_array(out)
 }
 
 /// Refract `v` (unit, pointing away from the surface) across the surface with
@@ -1235,6 +1249,53 @@ mod tests {
     }
 
     #[test]
+    fn cauchy_fit_hits_abbe_definition() {
+        // The fit must reproduce n_d exactly at the d line and have exactly
+        // the requested Abbe number V_d = (n_d − 1)/(n_F − n_C).
+        let (n_d, v_d) = (1.5f32, 30.0f32);
+        let n_at_d = cauchy_ior(n_d, v_d, FRAUNHOFER_D_NM);
+        assert!((n_at_d - n_d).abs() < 1e-6, "n(λ_d) = {n_at_d}");
+        let n_f = cauchy_ior(n_d, v_d, FRAUNHOFER_F_NM);
+        let n_c = cauchy_ior(n_d, v_d, FRAUNHOFER_C_NM);
+        let abbe = (n_d - 1.0) / (n_f - n_c);
+        assert!(
+            (abbe - v_d).abs() < 0.05,
+            "fit Abbe {abbe} != requested {v_d}"
+        );
+    }
+
+    #[test]
+    fn dispersion_scale_scales_spread_linearly() {
+        // The effective Abbe is abbe/scale, and the Cauchy B term (hence the
+        // per-channel spread) is proportional to 1/V_d — so doubling the
+        // scale doubles the R↔B spread.
+        let full = dispersive_ior(1.5, 40.0, 1.0);
+        let half = dispersive_ior(1.5, 40.0, 0.5);
+        let ratio = (full.z - full.x) / (half.z - half.x);
+        assert!((ratio - 2.0).abs() < 1e-3, "spread ratio {ratio}");
+        // And scale 1 gives the physical glass: green stays near n_d.
+        assert!((full.y - 1.5).abs() < 0.01, "green {} far from n_d", full.y);
+    }
+
+    #[test]
+    fn dispersive_ior_below_one_uses_reciprocal() {
+        // η < 1 disperses via its reciprocal: dispersive(1/n) = 1/dispersive(n)
+        // per channel, so the model is symmetric across the interface.
+        let n = dispersive_ior(1.5, 30.0, 1.0);
+        let inv = dispersive_ior(1.0 / 1.5, 30.0, 1.0);
+        for c in 0..3 {
+            assert!(
+                (inv[c] - 1.0 / n[c]).abs() < 1e-5,
+                "channel {c}: {} vs 1/{}",
+                inv[c],
+                n[c]
+            );
+        }
+        // Blue still bends more: reciprocal of a larger index is smaller.
+        assert!(inv.z < inv.y && inv.y < inv.x, "{inv}");
+    }
+
+    #[test]
     fn dispersive_glass_is_continuous_and_eval_consistent() {
         // Dispersive thick glass is a per-channel continuous BTDF: no delta
         // samples, and scatter_importance must agree with eval (three-channel
@@ -1297,7 +1358,10 @@ mod tests {
         rec.front_face = true;
         let dir_in = Vec3A::new(0.6, 0.0, -1.0).normalize();
         let r_in = Ray::new(-dir_in, dir_in);
-        let l_green = refract_dir(-dir_in, Vec3A::Z, 1.0 / 1.5).unwrap().normalize();
+        // The green channel's own IOR under the Cauchy fit (545 nm sits
+        // slightly blue of the d line where n_d is defined).
+        let eta_g = transmission_iors(&m).y;
+        let l_green = refract_dir(-dir_in, Vec3A::Z, 1.0 / eta_g).unwrap().normalize();
 
         let (v, pdf) = m.eval(&r_in, &rec, l_green).expect("evaluable");
         assert!(pdf > 0.0, "pdf = {pdf}");

--- a/crates/crust-core/src/material/openpbr.rs
+++ b/crates/crust-core/src/material/openpbr.rs
@@ -250,9 +250,11 @@ impl LobePmf {
         let base_luma = luma(m.base_color).max(0.02);
         let spec_luma = luma(m.specular_color).max(0.02);
         let fuzz_luma = luma(m.fuzz_color).max(0.02);
-        let coat_luma = luma(m.coat_color).max(0.02);
 
-        let w_metal = m.base_metalness * base_luma;
+        // Metal reflectivity is base_color · base_weight scaled by
+        // specular_weight (the reference's `metal_bsdf` weight input).
+        let w_metal =
+            m.base_metalness * m.specular_weight * luma(m.base_color * m.base_weight).max(0.02);
         let w_diel_spec = (1.0 - m.base_metalness) * m.specular_weight * spec_luma * f0_diel;
         let w_specular = (w_metal + w_diel_spec).max(1e-4);
 
@@ -266,7 +268,9 @@ impl LobePmf {
             * (1.0 - f0_diel))
             .max(1e-4);
 
-        let w_coat = (m.coat_weight * coat_luma * f0_coat).max(1e-6);
+        // The coat reflection is untinted — coat_color only attenuates the
+        // substrate — so its lobe weight ignores the color.
+        let w_coat = (m.coat_weight * f0_coat).max(1e-6);
         let w_fuzz = (m.fuzz_weight * fuzz_luma).max(1e-6);
 
         // Transmission: dominant when weight is high. When enabled it
@@ -385,33 +389,53 @@ fn eval_specular(
     let f0_diel_scalar = f0_from_ior(m.specular_ior);
     let f0_diel_base = m.specular_color * f0_diel_scalar * m.specular_weight;
 
-    // Thin-film interference (Phase 2): replaces the dielectric Fresnel with
-    // an iridescent one at 3 wavelengths, blended by thin_film_weight.
+    // OpenPBR spec places thin-film between coat and base; when there is
+    // no coat the outer medium is air.
+    let outer_ior = if m.coat_weight > 0.0 {
+        m.coat_ior
+    } else {
+        1.0
+    };
+    // OpenPBR thickness is in μm; the thin-film helpers want nm.
+    let tf_thickness_nm = m.thin_film_thickness * 1000.0;
+
+    // Thin-film interference (Phase 2): replaces the Fresnel with an
+    // iridescent one at 3 wavelengths, blended by thin_film_weight.
     let f_diel = if m.thin_film_weight > 0.0 {
         let f_normal = fresnel_schlick(v_dot_h, f0_diel_base);
-        // OpenPBR spec places thin-film between coat and base; when there is
-        // no coat the outer medium is air.
-        let outer_ior = if m.coat_weight > 0.0 {
-            m.coat_ior
-        } else {
-            1.0
-        };
         let f_iri = thin_film_fresnel(
             v_dot_h,
             outer_ior,
             m.thin_film_ior,
             m.specular_ior,
-            m.thin_film_thickness * 1000.0, // OpenPBR thickness is in μm; helper wants nm
+            tf_thickness_nm,
         );
         f_normal * (1.0 - m.thin_film_weight) + f_iri * m.thin_film_weight
     } else {
         fresnel_schlick(v_dot_h, f0_diel_base)
     };
 
-    let f_metal = fresnel_schlick(v_dot_h, m.base_color);
+    // Metal slab per the MaterialX reference `generalized_schlick_bsdf`:
+    // F0 = base_color · base_weight, F82 edge tint = specular_color, the
+    // whole lobe scaled by specular_weight — with its own thin-film variant
+    // (`metal_bsdf_tf`) blended in by thin_film_weight.
+    let metal_f0 = m.base_color * m.base_weight;
+    let f_metal_base = fresnel_f82_tint(v_dot_h, metal_f0, m.specular_color);
+    let f_metal = (if m.thin_film_weight > 0.0 {
+        let f_iri = thin_film_fresnel_metal(
+            v_dot_h,
+            outer_ior,
+            m.thin_film_ior,
+            metal_f0,
+            tf_thickness_nm,
+        );
+        f_metal_base * (1.0 - m.thin_film_weight) + f_iri * m.thin_film_weight
+    } else {
+        f_metal_base
+    }) * m.specular_weight;
 
     let brdf = d * g / (4.0 * n_dot_v * n_dot_l);
-    // Metal path: base_color-tinted Fresnel * brdf * metalness
+    // Metal path: F82-tinted Fresnel * brdf * metalness
     // Dielectric-specular path: F_dielectric * brdf * (1 - metalness)
     (f_metal * m.base_metalness + f_diel * (1.0 - m.base_metalness)) * brdf
 }
@@ -435,20 +459,28 @@ fn eval_coat(
     );
     let f = fresnel_schlick_scalar(v_dot_h, f0_from_ior(m.coat_ior));
     let brdf = d * g / (4.0 * n_dot_v * n_dot_l);
-    m.coat_color * (m.coat_weight * f * brdf)
+    // The coat reflection itself is untinted (the reference's `coat_bsdf`
+    // has no color input) — `coat_color` is absorption on the way *through*
+    // the coat and lives in `coat_attenuation`.
+    Vec3A::splat(m.coat_weight * f * brdf)
 }
 
-/// Directional attenuation the coat imposes on the layers beneath it, as a
-/// Fresnel-weighted transmission * multi-bounce darkening factor. Applied as
-/// a per-channel multiplier to (base_specular + base_diffuse).
+/// Directional attenuation the coat imposes on the layers beneath it:
+/// Fresnel-weighted transmission * coat absorption tint * multi-bounce
+/// darkening factor. Applied as a per-channel multiplier to
+/// (base_specular + base_diffuse). The tint term is the reference's
+/// `coat_attenuation` node — `lerp(white, coat_color, coat_weight)` — which
+/// puts `coat_color` on light transmitted through the coat, not on the
+/// coat's own reflection.
 fn coat_attenuation(m: &OpenPBR, cos_theta_h: f32) -> Vec3A {
     if m.coat_weight <= 0.0 {
         return Vec3A::ONE;
     }
     let f_coat = fresnel_schlick_scalar(cos_theta_h, f0_from_ior(m.coat_ior));
     let transmit = 1.0 - m.coat_weight * f_coat;
+    let absorb = Vec3A::ONE.lerp(m.coat_color, m.coat_weight);
     let dark = coat_darkening_factor(m.base_color, m.coat_ior, m.coat_darkening);
-    Vec3A::splat(transmit) * dark
+    Vec3A::splat(transmit) * absorb * dark
 }
 
 fn eval_fuzz(m: &OpenPBR, v_local: Vec3A, l_local: Vec3A, h_local: Vec3A) -> Vec3A {
@@ -678,7 +710,17 @@ fn eval_transmission_channel(
 /// and a pdf that averages the three per-channel sampling densities
 /// (matching `sample_transmission_rough`, which picks a channel uniformly).
 fn eval_transmission(m: &OpenPBR, v_local: Vec3A, l_local: Vec3A, entering: bool) -> (Vec3A, f32) {
-    let tint = m.transmission_color * (m.transmission_weight * (1.0 - m.base_metalness));
+    // The reference's `if_transmission_tint`: with `transmission_depth > 0`
+    // the interior Beer-Lambert medium owns the color (see
+    // `Medium::from_transmission`), so the interface BTDF is untinted —
+    // tinting both would apply `transmission_color` twice. Only at zero
+    // depth does the color act as a non-physical surface tint.
+    let color = if m.transmission_depth > 0.0 {
+        Vec3A::ONE
+    } else {
+        m.transmission_color
+    };
+    let tint = color * (m.transmission_weight * (1.0 - m.base_metalness));
     let iors = transmission_iors(m);
     if m.transmission_dispersion_scale <= 0.0 {
         let (btdf, pdf) = eval_transmission_channel(m, v_local, l_local, entering, iors.y);
@@ -894,6 +936,24 @@ impl Material for OpenPBR {
 
     fn emitted(&self) -> Vec3A {
         self.emission_color * self.emission_luminance
+    }
+
+    /// Emission seen through the coat, per the reference's `emission_edf`
+    /// mix: the coated branch tints the EDF by `coat_color` and modulates it
+    /// by a `generalized_schlick_edf` with `color0 = 1 − coat_F0`,
+    /// `color90 = 0`, exponent 5 — i.e. `(1 − F0)(1 − (1 − μ)⁵)` — the coat's
+    /// view-dependent Fresnel transmission. Blended with the uncoated EDF by
+    /// `coat_weight`.
+    fn emitted_directional(&self, cos_theta_o: f32) -> Vec3A {
+        let uncoated = self.emission_color * self.emission_luminance;
+        if self.coat_weight <= 0.0 {
+            return uncoated;
+        }
+        let f0_coat = f0_from_ior(self.coat_ior);
+        let mu = cos_theta_o.clamp(0.0, 1.0);
+        let schlick_transmit = (1.0 - f0_coat) * (1.0 - schlick_weight(mu));
+        let coated = uncoated * self.coat_color * schlick_transmit;
+        uncoated.lerp(coated, self.coat_weight)
     }
 }
 
@@ -1262,6 +1322,134 @@ mod tests {
         assert!(v.y > 0.0, "green channel dark at its own Snell direction: {v}");
         assert!(v.y > v.x, "green {} not > red {} at green Snell direction", v.y, v.x);
         assert!(v.y > v.z, "green {} not > blue {} at green Snell direction", v.y, v.z);
+    }
+
+    #[test]
+    fn deep_transmission_interface_is_untinted() {
+        // With transmission_depth > 0 the Beer-Lambert medium owns the color:
+        // the interface BTDF must be untinted (channel-uniform), or the color
+        // would apply twice. At zero depth the color is a surface tint.
+        let color = Vec3A::new(0.9, 0.4, 0.2);
+        let shallow = OpenPBR {
+            specular_roughness: 0.25,
+            transmission_color: color,
+            ..OpenPBR::glass(1.5)
+        };
+        let deep = OpenPBR {
+            transmission_depth: 1.0,
+            ..shallow.clone()
+        };
+        let mut rec = HitRecord::new();
+        rec.p = Vec3A::ZERO;
+        rec.normal = Vec3A::Z;
+        rec.front_face = true;
+        let dir_in = Vec3A::new(0.4, 0.0, -1.0).normalize();
+        let r_in = Ray::new(-dir_in, dir_in);
+        let wi = refract_dir(-dir_in, Vec3A::Z, 1.0 / 1.5).unwrap().normalize();
+
+        let (v_deep, _) = deep.eval(&r_in, &rec, wi).expect("evaluable");
+        assert!(v_deep.y > 0.0, "no transmission at the Snell direction");
+        assert!(
+            (v_deep.x - v_deep.y).abs() < 1e-5 && (v_deep.y - v_deep.z).abs() < 1e-5,
+            "deep transmission tinted at the interface: {v_deep}"
+        );
+
+        let (v_shallow, _) = shallow.eval(&r_in, &rec, wi).expect("evaluable");
+        let ratio = v_shallow.x / v_shallow.y;
+        assert!(
+            (ratio - color.x / color.y).abs() < 1e-3,
+            "zero-depth tint ratio {ratio} != color ratio {}",
+            color.x / color.y
+        );
+    }
+
+    #[test]
+    fn f82_metal_edge_tint() {
+        let f0 = Vec3A::new(0.9, 0.6, 0.3);
+        let tint = Vec3A::new(1.0, 0.5, 0.25);
+        // Normal incidence pins F0 regardless of tint.
+        let f_n = fresnel_f82_tint(1.0, f0, tint);
+        assert!((f_n - f0).abs().max_element() < 1e-5, "F(0°) = {f_n}");
+        // Grazing incidence goes to white.
+        let f_g = fresnel_f82_tint(0.0, f0, tint);
+        assert!((f_g - Vec3A::ONE).abs().max_element() < 1e-5, "F(90°) = {f_g}");
+        // At μ̄ = 1/7 the reflectance is exactly Schlick scaled by the tint.
+        let mu_bar = 1.0 / 7.0;
+        let with = fresnel_f82_tint(mu_bar, f0, tint);
+        let without = fresnel_f82_tint(mu_bar, f0, Vec3A::ONE);
+        assert!((with.y / without.y - tint.y).abs() < 1e-3, "{with} vs {without}");
+        assert!((with.z / without.z - tint.z).abs() < 1e-3, "{with} vs {without}");
+        assert!((with.x - without.x).abs() < 1e-5, "untinted channel moved");
+    }
+
+    #[test]
+    fn coat_color_tints_substrate_not_coat_reflection() {
+        let m = OpenPBR {
+            coat_weight: 1.0,
+            coat_color: Vec3A::new(0.9, 0.2, 0.2),
+            coat_darkening: 0.0, // isolate the absorption tint
+            ..OpenPBR::default()
+        };
+        // The coat reflection lobe itself is untinted.
+        let v = Vec3A::new(0.3, 0.0, 1.0).normalize();
+        let c = eval_coat(&m, v, v, v, 0.1, 0.1);
+        assert!(
+            (c.x - c.y).abs() < 1e-6 && (c.y - c.z).abs() < 1e-6,
+            "coat reflection tinted: {c}"
+        );
+        // The substrate attenuation carries the coat_color absorption.
+        let atten = coat_attenuation(&m, 0.9);
+        assert!(
+            (atten.x / atten.y - m.coat_color.x / m.coat_color.y).abs() < 1e-3,
+            "substrate attenuation not coat_color-tinted: {atten}"
+        );
+    }
+
+    #[test]
+    fn coated_emission_dims_and_tints() {
+        let uncoated = OpenPBR {
+            emission_luminance: 100.0,
+            ..OpenPBR::default()
+        };
+        // No coat: directional emission equals the isotropic EDF.
+        assert_eq!(uncoated.emitted_directional(0.3), uncoated.emitted());
+
+        let coated = OpenPBR {
+            coat_weight: 1.0,
+            coat_color: Vec3A::new(1.0, 0.2, 0.2),
+            ..uncoated.clone()
+        };
+        let e_n = coated.emitted_directional(1.0);
+        // Dimmed by the coat's Fresnel transmission (1 - F0 at normal).
+        assert!(e_n.x < 100.0, "coated emission not dimmed: {e_n}");
+        // Tinted by coat_color.
+        assert!((e_n.y / e_n.x - 0.2).abs() < 1e-3, "not coat-tinted: {e_n}");
+        // Grazing angles transmit less than normal incidence.
+        let e_g = coated.emitted_directional(0.05);
+        assert!(e_g.x < e_n.x, "grazing {e_g} not dimmer than normal {e_n}");
+    }
+
+    #[test]
+    fn aniso_matches_reference_remap() {
+        // The open_pbr_anisotropy graph: ax = r²·√(2/(1+(1−a)²)), ay = (1−a)·ax.
+        let (r, a) = (0.5f32, 0.8f32);
+        let (ax, ay) = roughness_to_alpha_aniso(r, a);
+        let inv = 1.0 - a;
+        let expect_ax = r * r * (2.0 / (1.0 + inv * inv)).sqrt();
+        assert!((ax - expect_ax).abs() < 1e-6, "ax {ax} != {expect_ax}");
+        assert!((ay - inv * expect_ax).abs() < 1e-6, "ay {ay} != {}", inv * expect_ax);
+    }
+
+    #[test]
+    fn thin_film_on_metal_is_bounded_and_active() {
+        let f0 = Vec3A::new(0.9, 0.7, 0.4);
+        let r = thin_film_fresnel_metal(0.8, 1.0, 1.4, f0, 500.0);
+        for c in [r.x, r.y, r.z] {
+            assert!((0.0..=1.0).contains(&c), "out of range: {r}");
+        }
+        // A visible film must actually change the metal Fresnel somewhere.
+        let plain = fresnel_f82_tint(0.8, f0, Vec3A::ONE);
+        assert!((r - plain).abs().max_element() > 1e-3, "film had no effect");
     }
 
     #[test]

--- a/crates/crust-core/src/material/openpbr.rs
+++ b/crates/crust-core/src/material/openpbr.rs
@@ -322,50 +322,32 @@ fn luma(c: Vec3A) -> f32 {
 // Lobe evaluations. Each returns a *linear-space* BRDF value (no cosine).
 // ---------------------------------------------------------------------------
 
-fn eval_diffuse(
-    m: &OpenPBR,
-    _v_local: Vec3A,
-    l_local: Vec3A,
-    h_local: Vec3A,
-    f_avg_diel: f32,
-) -> Vec3A {
-    // Disney diffuse re-parameterised for OpenPBR: `base_diffuse_roughness`
+fn eval_diffuse(m: &OpenPBR, v_local: Vec3A, l_local: Vec3A, f_avg_diel: f32) -> Vec3A {
+    // EON diffuse (energy-preserving Fujii Oren-Nayar) — the model the
+    // OpenPBR spec names for the base diffuse slab. `base_diffuse_roughness`
     // is the diffuse-only roughness (independent of specular_roughness).
-    let n_dot_l = l_local.z.max(0.0);
-    let n_dot_v = _v_local.z.max(0.0);
-    if n_dot_l <= 0.0 || n_dot_v <= 0.0 {
+    if l_local.z <= 0.0 || v_local.z <= 0.0 {
         return Vec3A::ZERO;
     }
-    let l_dot_h = l_local.dot(h_local).max(0.0);
 
     // Subsurface behaves as a colour-shifted diffuse when the walk length
-    // is short relative to feature size. The full random-walk BSSRDF —
-    // refracting in, HG walk in the medium, refracting out — is enabled
-    // when `subsurface_weight > 0` in the sampled event path (see
-    // `sample_subsurface`), which uses the Medium infrastructure. Here
-    // we surface the *directional* diffuse response with the SSS tint so
-    // the average colour matches, and rely on volume scattering for the
-    // multi-scattering softening.
+    // is short relative to feature size: surface the directional diffuse
+    // response with the SSS tint so the average colour matches (the full
+    // random-walk BSSRDF is future work — see the module header).
     let diffuse_color = m.base_color.lerp(m.subsurface_color, m.subsurface_weight);
 
-    let fd90 = 0.5 + 2.0 * l_dot_h * l_dot_h * m.base_diffuse_roughness;
-    let fl = schlick_weight(n_dot_l);
-    let fv = schlick_weight(n_dot_v);
-    let disney = diffuse_color
-        * (1.0 / PI)
-        * (1.0 + (fd90 - 1.0) * fl)
-        * (1.0 + (fd90 - 1.0) * fv);
-
-    // Energy left after specular reflection: `(1 - F_dielectric_avg) *
-    // (1 - metalness) * base_weight`. Using the directional Fresnel here
-    // would double-count with the specular lobe's own Fresnel — the
-    // average avoids that.
+    // Fold the presence weights into the EON albedo, as Adobe's reference
+    // does (`diffuse_albedo = base_color · base_weight · opaque-dielectric
+    // fraction`): the multiple-scattering term is nonlinear in ρ and should
+    // saturate with the *effective* albedo, not the raw color.
     // Transmission displaces the diffuse base — see `LobePmf::from_params`.
-    disney
-        * (1.0 - f_avg_diel)
-        * (1.0 - m.base_metalness)
-        * (1.0 - m.transmission_weight)
-        * m.base_weight
+    let rho = diffuse_color
+        * (m.base_weight * (1.0 - m.base_metalness) * (1.0 - m.transmission_weight));
+
+    // Energy left after specular reflection: `1 - F_dielectric_avg`. Using
+    // the directional Fresnel here would double-count with the specular
+    // lobe's own Fresnel — the average avoids that.
+    eon_diffuse(rho, m.base_diffuse_roughness, v_local, l_local) * (1.0 - f_avg_diel)
 }
 
 fn eval_specular(
@@ -510,7 +492,7 @@ fn eval_all(m: &OpenPBR, v_local: Vec3A, l_local: Vec3A, entering: bool) -> Vec3
         roughness_to_alpha_aniso(m.coat_roughness, m.coat_roughness_anisotropy);
     let f_avg_diel = f0_from_ior(m.specular_ior);
 
-    let diffuse = eval_diffuse(m, v_local, l_local, h_local, f_avg_diel);
+    let diffuse = eval_diffuse(m, v_local, l_local, f_avg_diel);
     let specular = eval_specular(m, v_local, l_local, h_local, ax, ay);
     let coat = eval_coat(m, v_local, l_local, h_local, ax_coat, ay_coat);
     let fuzz = eval_fuzz(m, v_local, l_local, h_local);
@@ -1322,6 +1304,76 @@ mod tests {
         assert!(v.y > 0.0, "green channel dark at its own Snell direction: {v}");
         assert!(v.y > v.x, "green {} not > red {} at green Snell direction", v.y, v.x);
         assert!(v.y > v.z, "green {} not > blue {} at green Snell direction", v.y, v.z);
+    }
+
+    #[test]
+    fn eon_reduces_to_lambert_at_zero_roughness() {
+        let rho = Vec3A::new(0.8, 0.5, 0.3);
+        let v = Vec3A::new(0.3, 0.1, 0.9).normalize();
+        let l = Vec3A::new(-0.2, 0.4, 0.8).normalize();
+        let f = eon_diffuse(rho, 0.0, v, l);
+        let lambert = rho / PI;
+        assert!(
+            (f - lambert).abs().max_element() < 1e-4,
+            "EON at r=0 {f} != Lambert {lambert}"
+        );
+    }
+
+    #[test]
+    fn eon_is_reciprocal() {
+        let rho = Vec3A::new(0.9, 0.6, 0.2);
+        let v = Vec3A::new(0.5, -0.1, 0.6).normalize();
+        let l = Vec3A::new(-0.3, 0.2, 0.9).normalize();
+        for r in [0.2, 0.6, 1.0] {
+            let a = eon_diffuse(rho, r, v, l);
+            let b = eon_diffuse(rho, r, l, v);
+            assert!((a - b).abs().max_element() < 1e-5, "r={r}: {a} vs {b}");
+        }
+    }
+
+    #[test]
+    fn eon_albedo_approx_matches_exact() {
+        for i in 1..=20 {
+            let mu = i as f32 / 20.0;
+            for r in [0.0, 0.3, 0.7, 1.0] {
+                let exact = eon_albedo_exact(mu, r);
+                let approx = eon_albedo_approx(mu, r);
+                assert!(
+                    (exact - approx).abs() < 0.01,
+                    "albedo mismatch at mu={mu}, r={r}: {exact} vs {approx}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn eon_preserves_energy_at_high_roughness() {
+        // The defining property: at rho = 1 the hemispherical albedo
+        // (∫ f·cosθ dω) is 1 for any roughness — the single-scattering Fujii
+        // lobe alone loses well over 10% at roughness 1; the
+        // multiple-scattering lobe restores it. Quadrature over the
+        // hemisphere for a few view angles.
+        let n_theta = 128;
+        let n_phi = 128;
+        for view_z in [0.95f32, 0.6, 0.25] {
+            let v = Vec3A::new((1.0 - view_z * view_z).sqrt(), 0.0, view_z);
+            let mut integral = 0.0f32;
+            for it in 0..n_theta {
+                let theta = (it as f32 + 0.5) / n_theta as f32 * (PI / 2.0);
+                let (sin_t, cos_t) = theta.sin_cos();
+                for ip in 0..n_phi {
+                    let phi = (ip as f32 + 0.5) / n_phi as f32 * (2.0 * PI);
+                    let l = Vec3A::new(sin_t * phi.cos(), sin_t * phi.sin(), cos_t);
+                    let f = eon_diffuse(Vec3A::ONE, 1.0, v, l).x;
+                    integral += f * cos_t * sin_t;
+                }
+            }
+            integral *= (PI / 2.0) / n_theta as f32 * (2.0 * PI) / n_phi as f32;
+            assert!(
+                (0.97..=1.03).contains(&integral),
+                "white-furnace albedo {integral} at view_z {view_z}"
+            );
+        }
     }
 
     #[test]

--- a/crates/crust-core/src/material/openpbr.rs
+++ b/crates/crust-core/src/material/openpbr.rs
@@ -507,22 +507,48 @@ fn eval_coat(
     Vec3A::splat(m.coat_weight * f * brdf)
 }
 
+/// One-way passage factor through the coat for a direction making cosine
+/// `cos_theta` with the normal — the Adobe reference's
+/// `openpbr_coat_passage_color_multiplier × (1 − proportion reflected)`.
+/// The authored `coat_color` is defined as the *round-trip* absorption at
+/// normal incidence, so a single passage applies `√coat_color` raised to
+/// the relative in-coat path length `1/cos θ_refracted` (Snell at the coat
+/// IOR — slanted passages absorb more). The Fresnel term removes the
+/// energy the coat interface reflected away from this direction's passage.
+/// Both terms fade with `coat_weight` for partial coverage.
+fn coat_passage(m: &OpenPBR, cos_theta: f32) -> Vec3A {
+    let cos_i = cos_theta.clamp(1e-4, 1.0);
+    // Refracted angle inside the coat.
+    let eta = m.coat_ior.max(1e-4);
+    let sin2_t = (1.0 - cos_i * cos_i) / (eta * eta);
+    let cos_t = (1.0 - sin2_t).max(0.0).sqrt();
+    let path_length = 1.0 / cos_t.max(1e-3);
+
+    let one_passage = m
+        .coat_color
+        .clamp(Vec3A::ZERO, Vec3A::ONE)
+        .powf(0.5 * path_length);
+    let absorb = Vec3A::ONE.lerp(one_passage, m.coat_weight);
+
+    let f_coat = fresnel_schlick_scalar(cos_i, f0_from_ior(m.coat_ior));
+    absorb * (1.0 - m.coat_weight * f_coat)
+}
+
 /// Directional attenuation the coat imposes on the layers beneath it:
-/// Fresnel-weighted transmission * coat absorption tint * multi-bounce
-/// darkening factor. Applied as a per-channel multiplier to
-/// (base_specular + base_diffuse). The tint term is the reference's
-/// `coat_attenuation` node — `lerp(white, coat_color, coat_weight)` — which
-/// puts `coat_color` on light transmitted through the coat, not on the
-/// coat's own reflection.
-fn coat_attenuation(m: &OpenPBR, cos_theta_h: f32) -> Vec3A {
+/// light passes through the coat twice — in along the view direction, out
+/// along the light direction — and each passage pays its own
+/// Fresnel-weighted transmission and view-dependent absorption
+/// (`coat_passage`), times the multi-bounce darkening factor. Applied as a
+/// per-channel multiplier to (base_specular + base_diffuse). This is the
+/// incoming × outgoing base-layer scale of the Adobe reference coating
+/// lobe; at normal incidence the two passages recover exactly the authored
+/// round-trip `coat_color`.
+fn coat_attenuation(m: &OpenPBR, cos_v: f32, cos_l: f32) -> Vec3A {
     if m.coat_weight <= 0.0 {
         return Vec3A::ONE;
     }
-    let f_coat = fresnel_schlick_scalar(cos_theta_h, f0_from_ior(m.coat_ior));
-    let transmit = 1.0 - m.coat_weight * f_coat;
-    let absorb = Vec3A::ONE.lerp(m.coat_color, m.coat_weight);
     let dark = coat_darkening_factor(m.base_color, m.coat_ior, m.coat_darkening);
-    Vec3A::splat(transmit) * absorb * dark
+    coat_passage(m, cos_v) * coat_passage(m, cos_l) * dark
 }
 
 fn eval_fuzz(m: &OpenPBR, v_local: Vec3A, l_local: Vec3A, h_local: Vec3A) -> Vec3A {
@@ -559,8 +585,9 @@ fn eval_all(m: &OpenPBR, v_local: Vec3A, l_local: Vec3A, entering: bool) -> Vec3
 
     // Layered composition (top→bottom): fuzz over coat over base.
     //  throughput = fuzz + (1 - fuzz_weight) · (coat + coat_atten · base)
-    let v_dot_h = v_local.dot(h_local).max(0.0);
-    let coat_atten = coat_attenuation(m, v_dot_h);
+    // The coat attenuation is per-direction (view in, light out), evaluated
+    // against the normal cosines, not the half-vector.
+    let coat_atten = coat_attenuation(m, v_local.z, l_local.z);
     let base_atten = (1.0 - m.fuzz_weight).clamp(0.0, 1.0);
     fuzz + base_atten * (coat + coat_atten * (diffuse + specular))
 }
@@ -1020,22 +1047,18 @@ impl Material for OpenPBR {
         self.emission_color * self.emission_luminance
     }
 
-    /// Emission seen through the coat, per the reference's `emission_edf`
-    /// mix: the coated branch tints the EDF by `coat_color` and modulates it
-    /// by a `generalized_schlick_edf` with `color0 = 1 − coat_F0`,
-    /// `color90 = 0`, exponent 5 — i.e. `(1 − F0)(1 − (1 − μ)⁵)` — the coat's
-    /// view-dependent Fresnel transmission. Blended with the uncoated EDF by
-    /// `coat_weight`.
+    /// Emission seen through the coat: one outbound passage of the Adobe
+    /// reference coating model (`openpbr_compute_emission` scales emission
+    /// by the view-side base-layer factor) — `√coat_color` raised to the
+    /// refracted path length, the coat's directional Fresnel transmission,
+    /// and the multi-bounce darkening, all fading with `coat_weight`.
     fn emitted_directional(&self, cos_theta_o: f32) -> Vec3A {
         let uncoated = self.emission_color * self.emission_luminance;
         if self.coat_weight <= 0.0 {
             return uncoated;
         }
-        let f0_coat = f0_from_ior(self.coat_ior);
-        let mu = cos_theta_o.clamp(0.0, 1.0);
-        let schlick_transmit = (1.0 - f0_coat) * (1.0 - schlick_weight(mu));
-        let coated = uncoated * self.coat_color * schlick_transmit;
-        uncoated.lerp(coated, self.coat_weight)
+        let dark = coat_darkening_factor(self.base_color, self.coat_ior, self.coat_darkening);
+        uncoated * coat_passage(self, cos_theta_o) * dark
     }
 }
 
@@ -1688,12 +1711,56 @@ mod tests {
             (c.x - c.y).abs() < 1e-6 && (c.y - c.z).abs() < 1e-6,
             "coat reflection tinted: {c}"
         );
-        // The substrate attenuation carries the coat_color absorption.
-        let atten = coat_attenuation(&m, 0.9);
+        // The substrate attenuation carries the coat_color absorption. At
+        // normal incidence the in + out passages (√color each) recover the
+        // authored round-trip color exactly.
+        let atten = coat_attenuation(&m, 1.0, 1.0);
         assert!(
             (atten.x / atten.y - m.coat_color.x / m.coat_color.y).abs() < 1e-3,
             "substrate attenuation not coat_color-tinted: {atten}"
         );
+    }
+
+    #[test]
+    fn coat_round_trip_recovers_authored_color() {
+        // coat_color is the round-trip absorption at normal incidence: the
+        // two passages must give exactly color · (1 − F0)² there.
+        let m = OpenPBR {
+            coat_weight: 1.0,
+            coat_color: Vec3A::new(0.9, 0.4, 0.16),
+            coat_darkening: 0.0,
+            ..OpenPBR::default()
+        };
+        let atten = coat_attenuation(&m, 1.0, 1.0);
+        let f0 = f0_from_ior(m.coat_ior);
+        let expected = m.coat_color * (1.0 - f0) * (1.0 - f0);
+        assert!(
+            (atten - expected).abs().max_element() < 1e-4,
+            "{atten} != {expected}"
+        );
+    }
+
+    #[test]
+    fn coat_passage_darkens_and_saturates_at_grazing() {
+        // Slanted passages travel further through the coat (1/cosθ_t) and
+        // lose more to Fresnel: every channel dims, and the tinted channel
+        // dims relatively faster (color saturates with angle).
+        let m = OpenPBR {
+            coat_weight: 1.0,
+            coat_color: Vec3A::new(0.9, 0.3, 0.3),
+            ..OpenPBR::default()
+        };
+        let p_n = coat_passage(&m, 1.0);
+        let p_g = coat_passage(&m, 0.2);
+        assert!(p_g.x < p_n.x && p_g.y < p_n.y, "{p_g} not dimmer than {p_n}");
+        assert!(
+            p_g.y / p_g.x < p_n.y / p_n.x,
+            "tinted channel not saturating with angle: {p_g} vs {p_n}"
+        );
+        // And the full attenuation is view-dependent through both passages.
+        let a_n = coat_attenuation(&m, 1.0, 1.0);
+        let a_g = coat_attenuation(&m, 0.2, 0.2);
+        assert!(a_g.y < a_n.y);
     }
 
     #[test]
@@ -1713,8 +1780,12 @@ mod tests {
         let e_n = coated.emitted_directional(1.0);
         // Dimmed by the coat's Fresnel transmission (1 - F0 at normal).
         assert!(e_n.x < 100.0, "coated emission not dimmed: {e_n}");
-        // Tinted by coat_color.
-        assert!((e_n.y / e_n.x - 0.2).abs() < 1e-3, "not coat-tinted: {e_n}");
+        // Tinted by one outbound coat passage: √coat_color at normal
+        // incidence (the authored color is the round-trip absorption).
+        assert!(
+            (e_n.y / e_n.x - 0.2f32.sqrt()).abs() < 1e-3,
+            "not coat-tinted: {e_n}"
+        );
         // Grazing angles transmit less than normal incidence.
         let e_g = coated.emitted_directional(0.05);
         assert!(e_g.x < e_n.x, "grazing {e_g} not dimmer than normal {e_n}");

--- a/crates/crust-core/src/material/openpbr.rs
+++ b/crates/crust-core/src/material/openpbr.rs
@@ -2,21 +2,38 @@
 //!
 //! Full parameter set matches the OpenPBR MaterialX reference
 //! (https://academysoftwarefoundation.github.io/OpenPBR/). Every field
-//! defaults to the spec value, so RON scenes can specify only what they
-//! need.
+//! defaults to the spec value, so USD scenes can specify only what they
+//! need. Formulas are aligned against the MaterialX nodegraph and the
+//! Adobe OpenPBR BSDF reference (github.com/adobe/openpbr-bsdf) — the
+//! full alignment record, item by item with commits, lives in
+//! `docs/openpbr_reference_alignment.md`.
 //!
-//! ## Phase status
+//! ## Implemented
 //!
-//! - Phase 1 (done): base_diffuse + base_specular_dielectric + base_metal
-//!   + fuzz + emission, sampled with multi-lobe MIS.
-//! - Phase 2: coat + thin-film interference.
-//! - Phase 3: transmission (thin-walled + rough refraction) + dispersion.
-//! - Phase 4: `Ray` medium stack + Beer-Lambert in the tracer.
-//! - Phase 5: subsurface (random walk).
+//! - Base: EON diffuse (energy-preserving Fujii Oren-Nayar), F82-tint
+//!   metal, dielectric specular — anisotropic GGX with VNDF sampling,
+//!   multi-lobe one-sample MIS (`eval_all`/`pdf_all` are the single
+//!   shared composition, so eval/sample/pdf stay consistent).
+//! - Transmission: continuous Walter BTDF (thick), Cauchy/Abbe physical
+//!   dispersion per channel, thin-wall window model (delta, with
+//!   `(1−R)/(1+R)` energy and view-dependent tint).
+//! - Interior media: unified transmission + subsurface volume (van de
+//!   Hulst albedo inversion, `transmission_scatter`) carried by refracted
+//!   rays via `interior_medium`.
+//! - Coat: untinted reflection lobe + per-passage view-dependent
+//!   absorption (`√coat_color` per crossing, refracted path length),
+//!   multi-bounce darkening, coat-attenuated emission.
+//! - Fuzz (Charlie sheen) and 3-wavelength thin-film interference on both
+//!   the dielectric and metal Fresnel.
 //!
-//! Parameters for not-yet-wired features (transmission, subsurface, coat,
-//! thin_film, opacity) are accepted, deserialised, and preserved so scenes
-//! authored today continue to render correctly once later phases land.
+//! ## Not implemented (see the alignment doc for the full gap list)
+//!
+//! - Microfacet multiple-scattering energy compensation (Adobe uses LUTs;
+//!   crust couples diffuse↔specular with a flat `1 − F_avg`).
+//! - Random-walk subsurface entry: SSS without transmission renders as
+//!   tinted diffuse — its volume is only reachable through refraction.
+//! - `geometry_opacity` (host-renderer cutout) and authored geometry
+//!   normals/tangents.
 
 use crate::hittable::HitRecord;
 use crate::material::{Material, ScatterSample};

--- a/crates/crust-core/src/material/openpbr.rs
+++ b/crates/crust-core/src/material/openpbr.rs
@@ -187,6 +187,51 @@ impl OpenPBR {
             ..OpenPBR::default()
         }
     }
+
+    /// The unified interior medium of the closed surface, per Adobe's
+    /// reference (`openpbr_prepare_volume`): the transmission volume
+    /// (extinction from color/depth plus `transmission_scatter`) and the
+    /// subsurface volume (van de Hulst albedo inversion) blended by their
+    /// relative fractions of the dielectric base — transmission supersedes
+    /// subsurface, so the fractions are `t` and `(1 − t)·s`. Attached to
+    /// rays refracting into the front face; `None` when the interior
+    /// neither absorbs nor scatters (zero-depth clear glass), so inert
+    /// interiors skip medium tracking entirely.
+    fn interior_medium(&self) -> Option<Arc<Medium>> {
+        let trans_frac = self.transmission_weight;
+        let sss_frac = (1.0 - self.transmission_weight) * self.subsurface_weight;
+        let total = trans_frac + sss_frac;
+        if total <= 0.0 {
+            return None;
+        }
+        let trans_volume = Medium::from_transmission(
+            self.transmission_color,
+            self.transmission_depth,
+            self.transmission_scatter,
+            self.transmission_scatter_anisotropy,
+        );
+        let medium = if sss_frac > 0.0 {
+            let sss_volume = Medium::from_subsurface(
+                self.subsurface_color,
+                self.subsurface_radius,
+                self.subsurface_radius_scale,
+                self.subsurface_scatter_anisotropy,
+            );
+            Medium::blend(
+                &trans_volume,
+                trans_frac / total,
+                &sss_volume,
+                sss_frac / total,
+            )
+        } else {
+            trans_volume
+        };
+        if medium.sigma_t_max() <= 1e-6 {
+            None
+        } else {
+            Some(Arc::new(medium))
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -856,14 +901,11 @@ impl Material for OpenPBR {
                 let l_world = frame.to_world(l_local);
                 let pdf = pdf_all(self, &pmf, v_local, l_local, rec.front_face).max(1e-4);
                 let brdf = eval_all(self, v_local, l_local, rec.front_face);
-                let ray = if rec.front_face {
-                    let medium = Arc::new(Medium::from_transmission(
-                        self.transmission_color,
-                        self.transmission_depth,
-                    ));
-                    Ray::new_in_medium(rec.p + l_world * 1e-4, l_world, medium)
-                } else {
-                    Ray::new(rec.p + l_world * 1e-4, l_world)
+                let ray = match (rec.front_face, self.interior_medium()) {
+                    (true, Some(medium)) => {
+                        Ray::new_in_medium(rec.p + l_world * 1e-4, l_world, medium)
+                    }
+                    _ => Ray::new(rec.p + l_world * 1e-4, l_world),
                 };
                 return Some(ScatterSample {
                     ray,
@@ -965,11 +1007,9 @@ impl Material for OpenPBR {
         // origin offset and interior-medium tagging as a BSDF-sampled one.
         if transmission_is_continuous(self) && rec.normal.dot(wi) < 0.0 {
             if rec.front_face {
-                let medium = Arc::new(Medium::from_transmission(
-                    self.transmission_color,
-                    self.transmission_depth,
-                ));
-                return Ray::new_in_medium(rec.p + wi * 1e-4, wi, medium);
+                if let Some(medium) = self.interior_medium() {
+                    return Ray::new_in_medium(rec.p + wi * 1e-4, wi, medium);
+                }
             }
             return Ray::new(rec.p + wi * 1e-4, wi);
         }
@@ -1703,9 +1743,141 @@ mod tests {
         assert!((r - plain).abs().max_element() > 1e-3, "film had no effect");
     }
 
+    /// Draw transmission samples until one refracts into the surface, and
+    /// return the interior medium it carries (None if the ray has none).
+    fn sample_interior_medium(m: &OpenPBR) -> Option<Arc<Medium>> {
+        let mut sampler = s();
+        let mut rec = HitRecord::new();
+        rec.p = Vec3A::ZERO;
+        rec.normal = Vec3A::Z;
+        rec.front_face = true;
+        let r_in = Ray::new(Vec3A::new(0.3, -0.2, 1.0), Vec3A::new(-0.3, 0.2, -1.0).normalize());
+        for _ in 0..256 {
+            if let Some(sample) = m.scatter_importance(&r_in, &rec, &mut sampler) {
+                if sample.ray.direction().z < 0.0 {
+                    return sample.ray.medium().cloned();
+                }
+            }
+        }
+        panic!("material never transmitted");
+    }
+
+    #[test]
+    fn transmission_scatter_wires_into_interior_medium() {
+        // transmission_scatter/depth becomes the interior σₛ, the extinction
+        // stays -ln(color)/depth, and the anisotropy carries through.
+        let m = OpenPBR {
+            specular_roughness: 0.25,
+            transmission_color: Vec3A::new(0.5, 0.7, 0.9),
+            transmission_depth: 2.0,
+            // Kept below the per-channel extinction so σₐ = σₜ − σₛ stays
+            // non-negative without triggering the spec's gray shift.
+            transmission_scatter: Vec3A::new(0.2, 0.2, 0.1),
+            transmission_scatter_anisotropy: 0.5,
+            ..OpenPBR::glass(1.5)
+        };
+        let medium = sample_interior_medium(&m).expect("scattering glass must carry a medium");
+        assert!(medium.is_scattering());
+        let expected_sigma_s = Vec3A::new(0.2, 0.2, 0.1) / 2.0;
+        assert!(
+            (medium.sigma_s - expected_sigma_s).abs().max_element() < 1e-5,
+            "sigma_s {:?}",
+            medium.sigma_s
+        );
+        let expected_ext = Vec3A::new(-0.5f32.ln(), -0.7f32.ln(), -0.9f32.ln()) / 2.0;
+        let ext = medium.sigma_a + medium.sigma_s;
+        assert!(
+            (ext - expected_ext).abs().max_element() < 1e-5,
+            "extinction {ext:?} != {expected_ext:?}"
+        );
+        assert_eq!(medium.g, 0.5);
+    }
+
+    #[test]
+    fn transmission_scatter_negative_absorption_shifts_to_gray() {
+        // White transmission color → zero extinction; with scatter > 0 the
+        // raw σₐ = -σₛ is negative, and the spec shifts it by enough gray to
+        // be non-negative.
+        let m = Medium::from_transmission(Vec3A::ONE, 1.0, Vec3A::new(0.1, 0.2, 0.4), 0.0);
+        assert!(m.sigma_a.min_element() >= 0.0, "σₐ {:?}", m.sigma_a);
+        // The largest-scatter channel ends at zero absorption after the shift.
+        assert!(m.sigma_a.z.abs() < 1e-6, "σₐ {:?}", m.sigma_a);
+        assert!(m.sigma_a.x > m.sigma_a.y && m.sigma_a.y > m.sigma_a.z);
+    }
+
+    #[test]
+    fn van_de_hulst_inversion_boosts_single_scatter_albedo() {
+        // An observed (multi-scattering) albedo of 0.5 requires a
+        // single-scattering albedo of ≈ 0.91 (van de Hulst); the naive
+        // σₛ = σₜ·A mapping would give 0.5 and badly under-scatter.
+        let m = Medium::from_subsurface(Vec3A::splat(0.5), 1.0, Vec3A::ONE, 0.0);
+        let a = m.albedo();
+        assert!(
+            (a.x - 0.9117).abs() < 5e-3,
+            "α_ss {a} for observed 0.5, expected ≈ 0.9117"
+        );
+        // Monotonic in the observed albedo, saturating toward 1.
+        let hi = Medium::from_subsurface(Vec3A::splat(0.95), 1.0, Vec3A::ONE, 0.0).albedo();
+        let lo = Medium::from_subsurface(Vec3A::splat(0.05), 1.0, Vec3A::ONE, 0.0).albedo();
+        assert!(hi.x > 0.99, "α_ss({}) = {}", 0.95, hi.x);
+        assert!(lo.x < a.x && a.x < hi.x);
+        // Forward anisotropy raises the required single-scattering albedo.
+        let fwd = Medium::from_subsurface(Vec3A::splat(0.5), 1.0, Vec3A::ONE, 0.9).albedo();
+        assert!(fwd.x > a.x, "g=0.9 albedo {} not > g=0 {}", fwd.x, a.x);
+        // Extinction is the reciprocal mean free path.
+        assert!(((m.sigma_a + m.sigma_s).x - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn interior_medium_blends_subsurface_into_glass() {
+        // Transmission + subsurface: the interior blends both volumes by
+        // their dielectric fractions (t and (1-t)·s), and the phase
+        // anisotropy comes from the scattering (subsurface) component.
+        let m = OpenPBR {
+            specular_roughness: 0.25,
+            transmission_depth: 1.0,
+            subsurface_weight: 1.0,
+            subsurface_color: Vec3A::splat(0.5),
+            subsurface_radius: 0.1,
+            subsurface_radius_scale: Vec3A::ONE,
+            subsurface_scatter_anisotropy: 0.3,
+            ..OpenPBR::glass(1.5)
+        };
+        let m = OpenPBR {
+            transmission_weight: 0.5,
+            ..m
+        };
+        let medium = sample_interior_medium(&m).expect("sss interior must carry a medium");
+        // Clear transmission volume contributes nothing; the sss half does.
+        assert!(medium.is_scattering());
+        assert!((medium.g - 0.3).abs() < 1e-5, "g {}", medium.g);
+        // Half the sss volume's scattering (sss fraction (1-0.5)·1 = 0.5).
+        let full_sss =
+            Medium::from_subsurface(Vec3A::splat(0.5), 0.1, Vec3A::ONE, 0.3);
+        assert!(
+            (medium.sigma_s - full_sss.sigma_s * 0.5).abs().max_element() < 1e-3,
+            "sigma_s {:?}",
+            medium.sigma_s
+        );
+    }
+
+    #[test]
+    fn inert_glass_attaches_no_medium() {
+        // Zero-depth clear glass has nothing to absorb or scatter: the
+        // refracted ray should carry no medium at all.
+        let m = OpenPBR {
+            specular_roughness: 0.25,
+            ..OpenPBR::glass(1.5)
+        };
+        assert!(
+            sample_interior_medium(&m).is_none(),
+            "inert interior should not carry a medium"
+        );
+    }
+
     #[test]
     fn medium_transmittance_full_at_zero_depth() {
-        let m = Medium::from_transmission(Vec3A::new(0.5, 0.5, 0.5), 0.0);
+        let m = Medium::from_transmission(Vec3A::new(0.5, 0.5, 0.5), 0.0, Vec3A::ZERO, 0.0);
         let t = m.transmittance(1.0);
         // Zero-depth medium: no absorption, transmittance identically 1.
         assert!((t - Vec3A::ONE).length() < 1e-4);
@@ -1713,7 +1885,7 @@ mod tests {
 
     #[test]
     fn medium_transmittance_attenuates_with_distance() {
-        let m = Medium::from_transmission(Vec3A::new(0.5, 0.7, 0.9), 1.0);
+        let m = Medium::from_transmission(Vec3A::new(0.5, 0.7, 0.9), 1.0, Vec3A::ZERO, 0.0);
         let t_short = m.transmittance(0.1);
         let t_long = m.transmittance(2.0);
         assert!(t_long.x < t_short.x);

--- a/crates/crust-core/src/material/openpbr.rs
+++ b/crates/crust-core/src/material/openpbr.rs
@@ -397,6 +397,21 @@ fn eval_specular(
         fresnel_schlick(v_dot_h, f0_diel_base)
     };
 
+    // Thin-walled window reflectance: the transmissive fraction of a thin
+    // sheet reflects from both surfaces including all internal bounces —
+    // `R_window = 2R/(1+R)` (Adobe reference `openpbr_thin_wall_fresnel`)
+    // instead of the single-interface `R`. Scale the dielectric Fresnel by
+    // the physical boost `2/(1+R)`, blended by how transmissive the sheet
+    // is; together with the `(1−R)/(1+R)` window transmittance a clear
+    // sheet reflects + transmits exactly unit energy.
+    let f_diel = if m.geometry_thin_walled && m.transmission_weight > 0.0 {
+        let f_phys = fresnel_schlick_scalar(v_dot_h, f0_diel_scalar);
+        let boost = 2.0 / (1.0 + f_phys);
+        f_diel * (1.0 + (boost - 1.0) * m.transmission_weight)
+    } else {
+        f_diel
+    };
+
     // Metal slab per the MaterialX reference `generalized_schlick_bsdf`:
     // F0 = base_color · base_weight, F82 edge tint = specular_color, the
     // whole lobe scaled by specular_weight — with its own thin-film variant
@@ -581,16 +596,47 @@ fn refract_dir(v: Vec3A, n: Vec3A, eta: f32) -> Option<Vec3A> {
     Some(-v * eta + n * (eta * cos_i - cos_t))
 }
 
-/// Thin-walled delta transmission: straight through, no bending, no medium.
+/// Thin-walled delta transmission — the window model of the Adobe OpenPBR
+/// reference: straight through with no bending (the front and back
+/// refractions of an infinitesimally thin sheet cancel), but with proper
+/// window energy. The transmitted fraction accounts for both interfaces
+/// *plus all internal bounces*: `T = 1 − 2R/(1+R) = (1−R)/(1+R)` with `R`
+/// the single-interface dielectric Fresnel at the view angle
+/// (`openpbr_thin_wall_fresnel`). The authored `transmission_color` — the
+/// transmittance at *normal* incidence — is raised to the relative in-sheet
+/// path length `1/cos θ_refracted` (Beer-Lambert along the slanted path).
 /// Returns (world-space scattered ray, throughput, placeholder pdf).
 fn sample_transmission_thin(m: &OpenPBR, r_in: &Ray, rec: &HitRecord) -> (Ray, Vec3A, f32) {
-    let l_world = r_in.direction().normalize();
+    let dir = r_in.direction().normalize();
+    let l_world = dir;
+    // Thin walls are double-sided: always treated as hit from outside.
+    let cos_i = (-dir).dot(rec.normal).clamp(0.0, 1.0);
+    let eta = m.specular_ior.max(1e-4);
+
+    // Refracted angle inside the sheet (Snell); η < 1 sheets can TIR.
+    let sin2_t = (1.0 - cos_i * cos_i) / (eta * eta);
+    if sin2_t >= 1.0 {
+        return (Ray::new(rec.p, l_world), Vec3A::ZERO, 1.0);
+    }
+    let cos_t = (1.0 - sin2_t).sqrt();
+
+    // Window transmittance: both surfaces and every internal bounce.
+    let f = fresnel_dielectric(cos_i, 1.0, eta);
+    let window_transmittance = (1.0 - f) / (1.0 + f);
+
+    // View-dependent absorption along the refracted path.
+    let path_length = 1.0 / cos_t.max(1e-4);
+    let tint = m
+        .transmission_color
+        .clamp(Vec3A::ZERO, Vec3A::ONE)
+        .powf(path_length);
+
     // No cosine in a delta lobe; we ape the codebase convention by
-    // returning throughput = tint (the tracer's cosine multiply is
+    // returning the throughput directly (the tracer's cosine multiply is
     // strictly incorrect for delta lobes but matches the rest of the
     // renderer's estimator).
-    let throughput = m.transmission_color * m.transmission_weight;
-    // Delta pdf: use 1.0 so tracer's `brdf / pdf` returns the tint
+    let throughput = tint * (window_transmittance * m.transmission_weight);
+    // Delta pdf: use 1.0 so tracer's `brdf / pdf` returns the throughput
     // unmodified. Direct-light MIS won't hit a delta lobe.
     (Ray::new(rec.p, l_world), throughput, 1.0)
 }
@@ -1132,6 +1178,95 @@ mod tests {
         // And its eval must report zero continuous density below the horizon.
         let (ev, _) = m.eval(&r_in, &rec, -Vec3A::Z).unwrap();
         assert_eq!(ev, Vec3A::ZERO);
+    }
+
+    #[test]
+    fn thin_wall_window_transmittance_matches_formula() {
+        // Clear thin glass: throughput must be exactly (1−R)/(1+R) at the
+        // view angle, and the R/T window pair must sum to unit energy.
+        let m = OpenPBR {
+            geometry_thin_walled: true,
+            ..OpenPBR::glass(1.5)
+        };
+        let mut rec = HitRecord::new();
+        rec.p = Vec3A::ZERO;
+        rec.normal = Vec3A::Z;
+        rec.front_face = true;
+        let dir = Vec3A::new(0.6, 0.0, -1.0).normalize();
+        let ray = Ray::new(-dir, dir);
+
+        let (_, thr, _) = sample_transmission_thin(&m, &ray, &rec);
+        let cos_i = -dir.z / dir.length();
+        let f = fresnel_dielectric(cos_i, 1.0, 1.5);
+        let expected = (1.0 - f) / (1.0 + f);
+        assert!(
+            (thr - Vec3A::splat(expected)).abs().max_element() < 1e-5,
+            "throughput {thr} != window transmittance {expected}"
+        );
+        // Energy: window reflectance + window transmittance = 1.
+        let r_window = 2.0 * f / (1.0 + f);
+        assert!((r_window + expected - 1.0).abs() < 1e-6);
+
+        // Grazing rays transmit less than normal-incidence rays.
+        let down = Ray::new(Vec3A::Z, -Vec3A::Z);
+        let (_, thr_n, _) = sample_transmission_thin(&m, &down, &rec);
+        let grazing_dir = Vec3A::new(6.0, 0.0, -1.0).normalize();
+        let grazing = Ray::new(-grazing_dir, grazing_dir);
+        let (_, thr_g, _) = sample_transmission_thin(&m, &grazing, &rec);
+        assert!(thr_g.x < thr_n.x, "grazing {thr_g} not < normal {thr_n}");
+    }
+
+    #[test]
+    fn thin_wall_tint_darkens_with_angle() {
+        // transmission_color is the normal-incidence transmittance; slanted
+        // paths travel 1/cosθ_t through the sheet, so darker channels darken
+        // faster with angle than lighter ones.
+        let m = OpenPBR {
+            geometry_thin_walled: true,
+            transmission_color: Vec3A::new(0.4, 0.8, 0.9),
+            ..OpenPBR::glass(1.5)
+        };
+        let mut rec = HitRecord::new();
+        rec.p = Vec3A::ZERO;
+        rec.normal = Vec3A::Z;
+        rec.front_face = true;
+
+        let down = Ray::new(Vec3A::Z, -Vec3A::Z);
+        let (_, thr_n, _) = sample_transmission_thin(&m, &down, &rec);
+        // Normal incidence: path length 1, tint is the authored color.
+        assert!(
+            (thr_n.x / thr_n.z - 0.4 / 0.9).abs() < 1e-4,
+            "normal-incidence tint ratio off: {thr_n}"
+        );
+        let oblique_dir = Vec3A::new(2.0, 0.0, -1.0).normalize();
+        let oblique = Ray::new(-oblique_dir, oblique_dir);
+        let (_, thr_o, _) = sample_transmission_thin(&m, &oblique, &rec);
+        assert!(
+            thr_o.x / thr_o.z < thr_n.x / thr_n.z,
+            "oblique tint {thr_o} not relatively darker in the dark channel than {thr_n}"
+        );
+    }
+
+    #[test]
+    fn thin_wall_reflection_boosted_by_internal_bounces() {
+        // A thin-walled transmissive sheet reflects 2R/(1+R) — strictly more
+        // than the single-interface R of the same thick glass.
+        let thick = OpenPBR {
+            specular_roughness: 0.25,
+            ..OpenPBR::glass(1.5)
+        };
+        let thin = OpenPBR {
+            geometry_thin_walled: true,
+            ..thick.clone()
+        };
+        let v = Vec3A::new(0.4, 0.0, 1.0).normalize();
+        let l = Vec3A::new(-0.4, 0.0, 1.0).normalize(); // mirror direction
+        let r_thick = eval_all(&thick, v, l, true);
+        let r_thin = eval_all(&thin, v, l, true);
+        assert!(
+            r_thin.x > r_thick.x * 1.5,
+            "thin-wall reflection {r_thin} not boosted over {r_thick}"
+        );
     }
 
     #[test]

--- a/crates/crust-core/src/medium.rs
+++ b/crates/crust-core/src/medium.rs
@@ -6,13 +6,16 @@
 //! sample volume scattering events for participating volumes.
 //!
 //! For an OpenPBR transmissive surface, the medium is derived from
-//! `transmission_color` and `transmission_depth`:
+//! `transmission_color`, `transmission_depth` and `transmission_scatter`:
 //!
-//!   σₐ = -ln(transmission_color) / max(transmission_depth, ε)
+//!   σₜ = -ln(transmission_color) / depth,   σₛ = transmission_scatter / depth
 //!
-//! `transmission_depth = 0` collapses to a purely tinting delta transmission
-//! (Beer-Lambert becomes identity), which is what artists usually want for
-//! thin coloured glass.
+//! with `σₐ = σₜ − σₛ` shifted by enough gray to stay non-negative (per the
+//! OpenPBR spec). `transmission_depth = 0` collapses to a purely tinting
+//! delta transmission (the tint applies at the interface instead), which is
+//! what artists usually want for thin coloured glass. Subsurface interiors
+//! invert the observed albedo to a single-scattering albedo with the van de
+//! Hulst mapping.
 
 use glam::Vec3A;
 
@@ -28,35 +31,83 @@ pub struct Medium {
 }
 
 impl Medium {
-    /// Build a Medium from OpenPBR-style tint + depth. `depth = 0` yields
-    /// zero absorption (identity transmittance regardless of `tint`).
-    pub fn from_transmission(tint: Vec3A, depth: f32) -> Self {
-        let sigma_a = if depth <= 1e-6 {
-            Vec3A::ZERO
-        } else {
-            // Per-channel: σₐ = -ln(tint) / depth, clamped so a fully-black
-            // channel doesn't blow up.
-            let t = tint.max(Vec3A::splat(1e-4)).min(Vec3A::ONE);
-            Vec3A::new(-t.x.ln(), -t.y.ln(), -t.z.ln()) / depth
-        };
+    /// Build a Medium from OpenPBR-style transmission parameters. The color
+    /// sets the *extinction* (`σₜ = -ln(color)/depth`), `scatter` sets the
+    /// scattering coefficient (`σₛ = scatter/depth` — honey, murky water,
+    /// milky glass), and the absorption is the difference, shifted by
+    /// enough gray to stay non-negative per the OpenPBR spec. `depth = 0`
+    /// yields an inert medium (the tint applies at the interface instead).
+    pub fn from_transmission(tint: Vec3A, depth: f32, scatter: Vec3A, anisotropy: f32) -> Self {
+        if depth <= 1e-6 {
+            return Self {
+                sigma_a: Vec3A::ZERO,
+                sigma_s: Vec3A::ZERO,
+                g: 0.0,
+            };
+        }
+        // Per-channel extinction, clamped so a fully-black channel doesn't
+        // blow up.
+        let t = tint.clamp(Vec3A::splat(1e-4), Vec3A::ONE);
+        let extinction = Vec3A::new(-t.x.ln(), -t.y.ln(), -t.z.ln()) / depth;
+        let sigma_s = scatter.max(Vec3A::ZERO) / depth;
+        let mut sigma_a = extinction - sigma_s;
+        // "If any component of σₐ is negative, σₐ is shifted by enough gray
+        // to make all the components positive" (OpenPBR spec).
+        let min = sigma_a.min_element();
+        if min < 0.0 {
+            sigma_a -= Vec3A::splat(min);
+        }
         Self {
             sigma_a,
-            sigma_s: Vec3A::ZERO,
-            g: 0.0,
+            sigma_s,
+            g: anisotropy.clamp(-0.999, 0.999),
         }
     }
 
-    /// Build a scattering Medium for subsurface scattering — the
-    /// "artist-friendly" parameterisation from Chiang et al. 2016 as adapted
-    /// by OpenPBR (`subsurface_color` = albedo, `radius * radius_scale` =
-    /// mean free path per channel).
+    /// Build a scattering Medium for subsurface scattering from OpenPBR's
+    /// artist-friendly parameters: `subsurface_color` is the *observed*
+    /// (multiple-scattering) albedo and `radius · radius_scale` the
+    /// per-channel mean free path. The observed albedo is inverted to the
+    /// single-scattering albedo with the van de Hulst mapping used by the
+    /// OpenPBR spec and Adobe's reference — the naive `σₛ = σₜ·A` mapping
+    /// badly under-scatters (an observed albedo of 0.5 needs a
+    /// single-scattering albedo of ≈ 0.91).
     pub fn from_subsurface(albedo: Vec3A, radius: f32, radius_scale: Vec3A, g: f32) -> Self {
-        let mfp = (Vec3A::splat(radius) * radius_scale).max(Vec3A::splat(1e-4));
+        let mfp = (Vec3A::splat(radius) * radius_scale).max(Vec3A::splat(1e-3));
         let sigma_t = Vec3A::ONE / mfp;
-        let a = albedo.clamp(Vec3A::splat(1e-4), Vec3A::splat(0.999));
-        let sigma_s = sigma_t * a;
+        let g = g.clamp(-0.999, 0.999);
+        let a = albedo.clamp(Vec3A::ZERO, Vec3A::ONE);
+
+        // Van de Hulst inversion (the spec's anisotropy-compensated form):
+        //   s(A) = 4.09712 + 4.20863·A − √(9.59217 + 41.6808·A + 17.7126·A²)
+        //   α_ss = (1 − s²) / (1 − g·s²)
+        let inner = Vec3A::splat(9.59217) + 41.6808 * a + 17.7126 * a * a;
+        let sqrt_inner = Vec3A::new(inner.x.sqrt(), inner.y.sqrt(), inner.z.sqrt());
+        let s = Vec3A::splat(4.09712) + 4.20863 * a - sqrt_inner;
+        let s2 = s * s;
+        let alpha_ss =
+            ((Vec3A::ONE - s2) / (Vec3A::ONE - g * s2)).clamp(Vec3A::ZERO, Vec3A::ONE);
+
+        let sigma_s = sigma_t * alpha_ss;
         let sigma_a = sigma_t - sigma_s;
         Self { sigma_a, sigma_s, g }
+    }
+
+    /// Weighted blend of two media (Adobe reference `openpbr_add_volumes`):
+    /// coefficients combine linearly; the phase anisotropy is the
+    /// scattering-weighted mixture of the two, so a non-scattering
+    /// component never drags `g` toward zero.
+    pub fn blend(a: &Medium, wa: f32, b: &Medium, wb: f32) -> Medium {
+        let sigma_a = a.sigma_a * wa + b.sigma_a * wb;
+        let sigma_s = a.sigma_s * wa + b.sigma_s * wb;
+        let avg = |v: Vec3A| (v.x + v.y + v.z) / 3.0;
+        let (sa, sb) = (avg(a.sigma_s) * wa, avg(b.sigma_s) * wb);
+        let g = if sa + sb > 1e-8 {
+            (a.g * sa + b.g * sb) / (sa + sb)
+        } else {
+            0.0
+        };
+        Medium { sigma_a, sigma_s, g }
     }
 
     /// Beer–Lambert transmittance across a segment of length `t`.

--- a/crates/crust-core/src/tracer.rs
+++ b/crates/crust-core/src/tracer.rs
@@ -688,7 +688,8 @@ fn trace_path(
             // attenuating through any media the final segment crosses.
             if let Some(p) = &prev {
                 if let Some(hit) = world.hit(&ray, 0.001, f32::INFINITY) {
-                    let mut emitted = hit.mat.emitted();
+                    let cos_o = ray.direction().normalize().dot(hit.rec.normal).abs();
+                    let mut emitted = hit.mat.emitted_directional(cos_o);
                     if emitted.length_squared() > 0.0 {
                         if let Some(m) = ray.medium() {
                             emitted *= m.transmittance(hit.rec.t);
@@ -898,7 +899,8 @@ fn trace_path(
         // after carried-medium scatters it counts here, in full. Either
         // way the emission pays the arriving segment's attenuation (an
         // emitter seen through tinted glass or smoke must dim).
-        let emitted = mat.emitted();
+        let cos_o = ray.direction().normalize().dot(rec.normal).abs();
+        let emitted = mat.emitted_directional(cos_o);
         let mut emit_here = Vec3A::ZERO;
         match &prev {
             Some(p) => {

--- a/docs/openpbr_reference_alignment.md
+++ b/docs/openpbr_reference_alignment.md
@@ -1,0 +1,148 @@
+# OpenPBR reference alignment
+
+This document records the alignment work done on `crust-core`'s OpenPBR
+übershader (`crates/crust-core/src/material/openpbr.rs` +
+`material/brdf.rs` + `medium.rs`) against the two public references:
+
+- **MaterialX nodegraph** — the normative surface-shader graph shipped with
+  the [OpenPBR specification](https://academysoftwarefoundation.github.io/OpenPBR/)
+  (`open_pbr_surface` nodedef, v1.1.1). Defines *what* the layers compute,
+  but not sampling.
+- **Adobe OpenPBR BSDF** — [adobe/openpbr-bsdf](https://github.com/adobe/openpbr-bsdf)
+  (Apache 2.0), the production OpenPBR 1.1 eval/sample/pdf implementation
+  extracted from Adobe's Eclair renderer. Defines *how* a real path tracer
+  evaluates and importance-samples the model, and is the source for every
+  formula cited below.
+
+Crust's architecture was already the same shape as Adobe's — a fixed set of
+lobes, one-sample MIS with heuristic lobe-selection weights, and a full
+mixture value/pdf recombination on every sample (`eval_all` / `pdf_all`
+mirror Adobe's aggregate-lobe combine step). The work below closed the
+formula-level gaps.
+
+## Phase 1 — MaterialX nodegraph divergences (commit `ea69a4e`)
+
+Five divergences from the reference graph, fixed to match:
+
+| # | Divergence | Fix |
+|---|------------|-----|
+| 4 | `transmission_color` applied at the interface *and* as Beer-Lambert absorption when `transmission_depth > 0` (double color) | Interface BTDF is untinted when a medium owns the color (`if_transmission_tint`) |
+| 5 | Metal Fresnel was plain Schlick on `base_color`; no F82 edge tint, no `base_weight`/`specular_weight`, no thin film on metal | F82-tint model (`fresnel_f82_tint`, `F0 = base_color·base_weight`, edge tint `specular_color`, lobe scaled by `specular_weight`) + per-channel-IOR thin film on the metal path |
+| 6 | `coat_color` tinted the coat *reflection* | Coat reflection is untinted; `coat_color` attenuates light transmitted to the substrate |
+| 7 | Emission ignored the coat | View-dependent coated emission via `Material::emitted_directional` (later upgraded in Phase 5 below) |
+| 8 | Ad-hoc anisotropy remap (signed ±1) | Spec formula: `αₓ = r²·√(2/(1+(1−a)²))`, `αᵧ = (1−a)·αₓ`, `a ∈ [0,1]` |
+
+The F82-tint formula and the anisotropy remap were later verified to be
+*identical* to Adobe's `openpbr_metal_schlick_with_f82_tint` and
+`openpbr_compute_anisotropic_alpha`.
+
+## Phase 2 — the ranked Adobe list (all five items complete)
+
+Ranked by effort-to-payoff during the Adobe comparison, then implemented in
+order:
+
+### 1. EON diffuse (`1304253`)
+
+The base diffuse slab is the **EON** model (energy-preserving Fujii
+Oren-Nayar, Portsmouth et al.) that the spec names — replacing Disney
+retro-reflection. Single-scattering Fujii lobe plus the analytic
+multiple-scattering compensation lobe
+`ρ_ms/π · (1−E(μ_o))(1−E(μ_i))/(1−Ē)`; a white-albedo surface reflects
+exactly unit energy at any roughness (pinned by hemisphere-quadrature
+test). Runtime uses the quartic directional-albedo fit; the exact closed
+form is kept as a test reference. Presence weights fold *into* the EON
+albedo (as Adobe does) because the multi-scatter term is nonlinear in ρ.
+Sampling stays cosine-hemisphere, matching the reference.
+
+### 2. Cauchy/Abbe physical dispersion (`3ecf0f7`)
+
+`dispersive_ior` evaluates a two-term Cauchy fit `n(λ) = A + B/λ²`,
+anchored so `n(λ_d) = n_d` exactly at the Fraunhofer d line (587.6 nm) and
+the fit's Abbe number `(n_d−1)/(n_F−n_C)` equals
+`transmission_dispersion_abbe_number`, evaluated at the sRGB primary
+wavelengths (615/545/465 nm, shared with thin film).
+`transmission_dispersion_scale` divides the Abbe number (scale 1 =
+physical glass). IORs below 1 disperse via their reciprocal. Replaces the
+former linear `(n_d−1)/V` spread. Note green is *not* pinned to `n_d`
+(545 nm sits blue of the d line) — physically correct.
+
+### 3. Thin-wall window model (`98b8a1e`)
+
+Thin-walled transmission was a straight-through delta with a flat tint. It
+now carries window energy: transmittance `(1−R)/(1+R)` (both interfaces
+plus all internal bounces, exact dielectric Fresnel at the view angle),
+the matching reflection boost `2R/(1+R)` on the dielectric-specular side
+(a clear sheet reflects + transmits exactly unit energy), and
+`transmission_color` interpreted as normal-incidence transmittance raised
+to the in-sheet path length `1/cos θ_refracted`. The lobe stays delta
+(front/back refractions cancel).
+
+### 4. `transmission_scatter` + van de Hulst subsurface (`ae1287b`)
+
+Two previously ignored parameter groups now reach the carried-medium
+transport:
+
+- `Medium::from_transmission` takes `transmission_scatter` /
+  `transmission_scatter_anisotropy`: `σₜ = −ln(color)/depth`,
+  `σₛ = scatter/depth`, absorption shifted by gray to stay non-negative
+  (per spec), anisotropy drives the HG phase.
+- `Medium::from_subsurface` inverts the observed albedo with the **van de
+  Hulst** mapping (`α_ss = (1−s²)/(1−g·s²)`) — the naive `σₛ = σₜ·A`
+  under-scattered badly (observed 0.5 needs α_ss ≈ 0.91).
+- `OpenPBR::interior_medium` blends both volumes by their dielectric
+  fractions `t` and `(1−t)·s` (transmission supersedes subsurface) with
+  scattering-weighted phase anisotropy, exactly as Adobe's
+  `openpbr_prepare_volume`. Inert interiors attach no medium at all.
+
+Scope note: the subsurface volume is entered *through the refractive
+interface*, i.e. on materials that also have `transmission_weight > 0`.
+Pure SSS without transmission still renders as tinted diffuse (random-walk
+entry is future work — see gaps below).
+
+### 5. Coat passage model (`fd6592b`)
+
+`coat_color` is the *round-trip* absorption at normal incidence: each
+passage applies `√coat_color` raised to the refracted in-coat path length
+`1/cos θ_t` (Snell at the coat IOR), times that direction's Fresnel
+transmission. The base attenuation is `passage(view) · passage(light) ·
+darkening` — per-direction and view-dependent, so tinted coats saturate
+toward grazing; at normal incidence the round trip recovers exactly
+`coat_color·(1−F0)²`. Coated emission reuses one outbound passage
+(matching `openpbr_compute_emission`), replacing the earlier MaterialX
+`generalized_schlick_edf` approximation.
+
+## Remaining gaps vs. the Adobe reference
+
+Known, deliberate, and recorded here so nobody rediscovers them:
+
+- **Microfacet multiple-scattering energy compensation** — Adobe adds
+  LUT-driven MMS lobes (dielectric + metal) and scales diffuse by a
+  *directional* specular energy complement; crust uses a flat
+  `(1 − F_avg)` coupling. Closing this means porting the Apache-2.0 LUT
+  data tables. This is the largest remaining quality gap at high roughness.
+- **Random-walk subsurface entry** — non-transmissive SSS materials never
+  refract into their interior; they use the tinted-diffuse (EON)
+  approximation. Needs an interface refraction event for the SSS fraction
+  and an exit strategy (module header "Phase 5").
+- **`specular_weight` semantics** — crust scales F0 directly; Adobe remaps
+  F0 back to an IOR (`ior_from_f0`), which also moves the TIR angle.
+  Related: the coat-aware base-IOR ratio (TIR fix) and coat-induced
+  specular roughening are skipped.
+- **Fuzz** — Charlie sheen D × Imageworks visibility with a scalar
+  `(1 − fuzz_weight)` layer approximation, vs. Adobe's Zeltner LTC sheen
+  with fuzz↔coat roughness cross-coupling.
+- **Interior hits** — emission is not suppressed when a closed surface is
+  hit from inside, and the coat is not reduced to transmission-tint-only
+  there.
+- **`geometry_opacity`** — unconsumed, by design on both sides: Adobe
+  documents opacity as the host renderer's job (stochastic cutout); the
+  tracer doesn't implement cutout yet.
+- **Geometry inputs** — no normal mapping and no user tangents
+  (`geometry_normal/tangent/coat_normal/coat_tangent`); frames are
+  auto-generated (Duff et al.), so anisotropy has no authored orientation
+  (Adobe additionally offers a (cos, sin) anisotropy-rotation extension).
+- **Thin film + thin wall** — thin film applies to reflection only, not to
+  thin-walled transmission (Adobe documents the same limitation).
+
+Every item above is test-pinned where implemented; the shader's regression
+suite lives in `openpbr.rs` (`cargo test -p crust-core`).


### PR DESCRIPTION
Fixes five divergences from the reference OpenPBR surface graph:

- Transmission tint: with transmission_depth > 0 the interior
  Beer-Lambert medium owns the color (the reference's
  if_transmission_tint), so the interface BTDF is now untinted there —
  colored thick glass no longer pays transmission_color twice.
- Metal Fresnel: plain Schlick on base_color is replaced by the F82-tint
  model (generalized_schlick_bsdf with color0 = base_color * base_weight,
  color82 = specular_color), the lobe is scaled by specular_weight, and
  thin-film interference now applies to the metal path too (metal_bsdf_tf),
  using per-channel F0-equivalent base IORs in the Airy summation.
- coat_color moved to the correct side of the coat layer: the coat
  reflection lobe is untinted and coat_color now attenuates light
  transmitted to the substrate (lerp(white, coat_color, coat_weight)),
  matching the reference's coat_attenuation node.
- Emission through the coat: new Material::emitted_directional hook
  (default = emitted()) implements the reference emission_edf mix — the
  coated branch is tinted by coat_color and modulated by the Schlick EDF
  (1 - coat_F0)(1 - (1 - mu)^5), blended by coat_weight. The tracer's two
  bounce-emission sites use it; the light list (Emissive) is unchanged.
- Anisotropy remap now matches open_pbr_anisotropy exactly:
  ax = r^2 * sqrt(2 / (1 + (1 - a)^2)), ay = (1 - a) * ax, with anisotropy
  clamped to the spec's [0, 1] range (previously a signed +/-1 variant).

The lobe-selection PMF follows suit (metal weight includes base_weight
and specular_weight; coat weight drops the now-irrelevant coat_color
luminance). Six new regression tests pin each behavior.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015A9RqFrkW6X8mZu9bX7eLc