### PR TITLE
Fix stale/obsolete documentation across README, CLAUDE.md, and openspec specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,14 +18,15 @@ cargo run --release -- -i samples/cornellbox.usda
 cargo run --release                 # no -i → hard-coded procedural fallback (world::simple_scene)
 cargo run --release -- --bucket -i samples/cornellbox.usda   # tiled/bucket rendering
 
-# CLI flags: -i/--input, -o/--output (default output.exr), -l/--level (log level), -b/--bucket
+# CLI flags: -i/--input, -o/--output (default output.exr), -l/--level (log level),
+# -b/--bucket, -s/--samples (override spp), --strategy (power|balance|light|bsdf)
 
 # Tests (integration tests live in crust-core/tests/usd_scene.rs, load sample USD files)
 cargo test
 cargo test -p crust-core loads_cornellbox_usda     # run a single test by name
 
 # Benchmarks (criterion)
-cargo bench -p crust-core            # bench targets: "vec3 dot", "simple world"
+cargo bench -p crust-core            # bench targets: "vec3 dot", "simple world", "simple world guided"
 
 # CI runs: cargo build --verbose && cargo test --verbose
 ```
@@ -34,7 +35,7 @@ Logging uses `tracing`; set verbosity with `-l debug|info|warn|error|trace` (def
 
 ## Workspace layout
 
-Three crates under `crates/`:
+Four crates under `crates/`:
 
 - **`crust-core`** — the whole engine as a library (`crust_core`): renderer, integrator,
   materials, primitives, lights, BVH, USD import. Everything of substance lives here.
@@ -45,7 +46,12 @@ Three crates under `crates/`:
   `Renderer` (wiring an `indicatif` bar to the progress callback), writes the EXR and
   the tone-mapped PNG. `main.rs` is the only file.
 - **`utils`** — math/RNG helpers (`random*`, `random_cosine_direction`, `align_to_normal`,
-  `balance_heuristic`, `clamp`, `Lerp`). Depended on by `crust-core`.
+  `balance_heuristic`, `power_heuristic`, `clamp`, `Lerp`). Depended on by `crust-core`.
+- **`sampler`** — the `Sampler` trait plus its two implementations: `SobolSampler`
+  (Owen-scrambled Sobol via `sobol_burley`, the production sampler — per-pixel
+  decorrelated by hashing `(x, y, frame_seed)` into the scramble seed) and `RngSampler`
+  (`SmallRng` fallback for tests and once the dimension budget overflows). Depended on
+  by `crust-core` (materials, `guiding/`, `volume.rs`) for every stochastic draw.
 
 `crust-core/src/lib.rs` re-exports the public surface (`Renderer`, `Scene`, `Camera`, the
 material types, `simple_scene`, `get_settings`). Prefer importing from `crust_core::` roots.
@@ -175,8 +181,11 @@ material types, `simple_scene`, `get_settings`). Prefer importing from `crust_co
   double-counted. Emissive geometry with no light-list entry is handled: the bounce
   keeps its emission at full weight.
 
-Sampling uses **Correlated Multi-Jittered (CMJ)** patterns from `sampler.rs`
-(`generate_cmj_2d`) for camera and light rays, falling back to plain RNG past the CMJ budget.
+Sampling goes through the `sampler` crate's `Sampler` trait (`start_pixel` / `start_sample`
+/ `next_1d` / `next_2d`). The production sampler is `SobolSampler`, Owen-scrambled Sobol
+(Burley 2020) via `sobol_burley`, per-pixel decorrelated by hashing `(x, y, frame_seed)`
+into the scramble seed; `RngSampler` (`SmallRng`) is the fallback used by tests, benches,
+and once a path's dimension count outgrows `sobol_burley`'s 256-dimension window.
 
 ## USD import (`scene/usd_import.rs`)
 
@@ -214,8 +223,8 @@ Xform hierarchy into world matrices. Schema mapping:
   `balance` | `light` | `bsdf`). Missing attrs fall back to defaults (128 spp,
   depth 32, 640×360, power MIS) defined as consts at the top of the file.
 
-Note: `openusd` is a hard dependency and USD is always compiled in. Docstrings in `scene.rs`
-that mention a `usd` **feature flag** are stale — there is no such feature.
+Note: `openusd` is a hard dependency and USD is always compiled in — there is no `usd`
+feature flag.
 
 ## Known incomplete work
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,15 @@ Completely in a vibe coding mood.
 - ⚡ **Adaptive Sampling**
   - Pixels stop early once their relative standard error drops below
     `crust:varianceThreshold` (after `crust:minSamplesPerPixel` samples)
+- 🌫️ **Volume Rendering**
+  - Free-standing smoke/fog/absorption/fire volume regions (homogeneous,
+    procedural fBm noise, or an inline voxel grid), with NEE + MIS at
+    scatter vertices and transmittance-aware shadow rays
 - 🧪 **Modular Design**
   - Clean separation between renderer, integrator, materials, scene
-- **Correlated Multi-Jittered (CMJ)**
-  - Use CMJ for camera and light rays
+- **Owen-Scrambled Sobol Sampling**
+  - Per-pixel decorrelated low-discrepancy sampling (Burley 2020) for
+    camera, light, and BSDF rays
 
 ---
 
@@ -81,9 +86,22 @@ Unbound geometry falls back to a grey diffuse OpenPBR.
 ### 💡 Lights
 
 `UsdLuxSphereLight` maps to an `Emissive` sphere that acts as both light and
-visible geometry (matching classic Cornell-box scene semantics). Other lux
-types (`RectLight`, `DiskLight`, `DistantLight`, `DomeLight`, `CylinderLight`)
-warn once and are skipped — follow-up work.
+visible geometry (matching classic Cornell-box scene semantics).
+`UsdLuxRectLight` maps to two emissive triangles + an `AreaLight` (local XY
+plane, emitting along -Z per UsdLux; effectively one-sided) — see
+`samples/rectlight.usda`. Other lux types (`DiskLight`, `DistantLight`,
+`DomeLight`, `CylinderLight`) warn once and are skipped — follow-up work.
+
+### 🌫️ Volumes
+
+Any prim carrying `crust:volume:type` imports as a free-standing
+`VolumeRegion` — an oriented box, outside the surface BVH so it never
+occludes shadow rays — with a `homogeneous`, `smoke` (procedural fBm noise),
+or `grid` (inline voxel data) density field and its own σₛ/σₐ/anisotropy/
+emission. Scatter vertices inside a region get NEE with MIS against the
+phase function, and shadow rays attenuate through volumes via ratio/Beer-
+Lambert transmittance. See `samples/fog.usda` (homogeneous god rays) and
+`samples/smoke.usda` (noise plume + emissive ember + explicit grid).
 
 ### 🎥 Camera & render settings
 

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -11,8 +11,10 @@ and writes the output image. This is the only user-facing surface of the tool.
 ### Requirement: Command-line argument parsing
 
 The CLI SHALL accept `-i/--input` (USD scene path), `-o/--output` (output path,
-default `output.exr`), `-l/--level` (log verbosity, default `info`), and
-`-b/--bucket` (tiled rendering, default off).
+default `output.exr`), `-l/--level` (log verbosity, default `info`),
+`-b/--bucket` (tiled rendering, default off), `-s/--samples` (override the
+scene's samples-per-pixel), and `--strategy` (override the scene's MIS
+sampling strategy: `power` | `balance` | `light` | `bsdf`).
 
 #### Scenario: Rendering a scene file
 
@@ -23,6 +25,12 @@ default `output.exr`), `-l/--level` (log verbosity, default `info`), and
 
 - **WHEN** `--bucket` is passed
 - **THEN** the renderer uses the tiled (bucket) strategy instead of scanline
+
+#### Scenario: Overriding samples and sampling strategy
+
+- **WHEN** `-s <n>` and/or `--strategy <mode>` are passed
+- **THEN** they override the scene's `crust:samplesPerPixel` /
+  `crust:samplingStrategy` values for this render only
 
 ### Requirement: Procedural fallback when no input is given
 

--- a/openspec/specs/image-output/spec.md
+++ b/openspec/specs/image-output/spec.md
@@ -4,7 +4,8 @@
 
 Persist the rendered pixel buffer to disk. The renderer writes a linear
 high-dynamic-range EXR, then converts it to a tone-mapped sRGB PNG for viewing.
-Covers EXR writing (`main.rs`) and the `convert()` step (`convert.rs`).
+Both steps live in `crust-render/src/main.rs`; the engine crate only produces
+the `Buffer`.
 
 ## Requirements
 
@@ -19,30 +20,25 @@ path (default `output.exr`).
 - **THEN** an EXR file is written at the requested output path with the rendered
   resolution
 
-### Requirement: Tone-mapped sRGB PNG conversion
+### Requirement: Tone-mapped sRGB PNG conversion next to the EXR
 
 After writing the EXR, the tool SHALL produce a viewable PNG by clamping linear
 values to [0,1], applying the sRGB transfer curve, and quantizing to 8-bit,
-saving a timestamped file under `./test_images/`.
+saving it next to the EXR at the same path with a `.png` extension.
 
 #### Scenario: PNG is produced from the render
 
-- **WHEN** the render's EXR has been written
-- **THEN** a timestamped tone-mapped sRGB PNG is saved under `./test_images/`
+- **WHEN** the render's EXR has been written at `-o` path `renders/foo.exr`
+- **THEN** a tone-mapped sRGB PNG is saved at `renders/foo.png`
 
-### Requirement: PNG conversion reads the default EXR path
+### Requirement: PNG path always tracks the EXR output path
 
-The PNG conversion step SHALL read a fixed `output.exr` input, independent of the
-`-o/--output` value. When a different output name is used, the EXR is still
-produced but the PNG step reads the fixed `output.exr` instead.
+The PNG conversion step SHALL derive its path from the `-o/--output` value
+(swapping the extension to `.png`), so a custom output name keeps the EXR and
+PNG in sync.
 
-#### Scenario: Default output keeps EXR and PNG consistent
-
-- **WHEN** the output path is left at the default `output.exr`
-- **THEN** the PNG is generated from the same EXR that was just written
-
-#### Scenario: Custom output name desynchronizes the PNG step
+#### Scenario: Custom output name keeps EXR and PNG in sync
 
 - **WHEN** the user renders with `-o some_other_name.exr`
-- **THEN** that EXR is written, but the PNG conversion still reads the fixed
-  `output.exr` (stale or missing) rather than the custom file
+- **THEN** that EXR is written, and the PNG is written to
+  `some_other_name.png` alongside it

--- a/openspec/specs/materials/spec.md
+++ b/openspec/specs/materials/spec.md
@@ -14,15 +14,17 @@ Lives in `crust-core/src/material/`.
 
 Every material SHALL implement a common `Material` trait providing
 importance-sampled scattering (`scatter_importance` returning an optional
-scattered ray, BRDF value, and PDF) and an emission query (`emitted`). Materials
-that do not implement importance sampling SHALL fall back to the default derived
-from `scatter`.
+`ScatterSample` — scattered ray, BRDF value, PDF, and a `delta` flag marking
+singular lobes such as transmission), a continuous-component evaluator
+(`eval(r_in, rec, wi) -> Option<(value, pdf)>`, used by NEE and guided MIS;
+`None` means no continuous component and must not depend on `wi`), and an
+emission query (`emitted`).
 
 #### Scenario: Integrator queries a material
 
 - **WHEN** the integrator interacts with a hit surface
-- **THEN** it obtains a scattered ray, BRDF value, and PDF via
-  `scatter_importance`, or `None` when the material absorbs the ray
+- **THEN** it obtains a `ScatterSample` (scattered ray, BRDF value, PDF, delta
+  flag) via `scatter_importance`, or `None` when the material absorbs the ray
 
 #### Scenario: Non-emissive material
 
@@ -31,24 +33,28 @@ from `scatter`.
 
 ### Requirement: Supported shading models
 
-The engine SHALL provide the following material models: Lambertian, Metal,
-Dielectric and ComplexDielectric, Blinn-Phong, Cook-Torrance, Disney Principled,
-OpenPBR, and Emissive.
+The engine SHALL provide exactly two material implementations: **`OpenPBR`**,
+a single übershader covering diffuse, metal, glass/transmission, coat, fuzz,
+thin-film, and subsurface (with `diffuse`/`metal`/`glass`/`glossy` Rust-side
+preset constructors), and **`Emissive`**, a pure emitter with no geometry
+knowledge.
 
 #### Scenario: A model is selected for a surface
 
-- **WHEN** a surface is assigned one of the supported material models
-- **THEN** rays scatter according to that model's BRDF and parameters
+- **WHEN** a surface is assigned a material
+- **THEN** rays scatter according to `OpenPBR`'s layered BSDF and parameters,
+  or the surface is a pure `Emissive` light
 
 ### Requirement: Shared microfacet BRDF helpers
 
-Microfacet materials SHALL share GGX helpers: visible-normal (VNDF) GGX sampling
-and its PDF, Schlick Fresnel, and the Schlick-GGX geometry term. Lives in
-`material/brdf.rs`.
+`OpenPBR` lobes SHALL share GGX helpers from `material/brdf.rs`: anisotropic
+visible-normal (VNDF) GGX sampling and its PDF, Schlick/F82 Fresnel, EON
+(energy-preserving Oren-Nayar) diffuse, Charlie sheen, thin-film, and Cauchy
+dispersion.
 
-#### Scenario: Microfacet material samples a direction
+#### Scenario: Microfacet lobe samples a direction
 
-- **WHEN** a GGX-based material scatters a ray
+- **WHEN** a GGX-based lobe of `OpenPBR` scatters a ray
 - **THEN** the outgoing direction is drawn via VNDF sampling and weighted by
   Fresnel and geometry terms
 
@@ -61,3 +67,13 @@ same surface to serve as both visible geometry and a light source.
 
 - **WHEN** a ray hits an emissive surface
 - **THEN** the surface contributes its emission color to the path
+
+### Requirement: Unbound geometry falls back to grey OpenPBR
+
+Geometry with no resolvable bound material SHALL be assigned a default grey
+`OpenPBR` material, not a separate shading model.
+
+#### Scenario: Unbound geometry
+
+- **WHEN** a mesh or sphere has no resolvable bound material
+- **THEN** it renders with a default grey diffuse `OpenPBR` material

--- a/openspec/specs/rendering/spec.md
+++ b/openspec/specs/rendering/spec.md
@@ -11,38 +11,67 @@ parallel execution strategies. It is the core of `crust-core` (`tracer.rs`).
 
 ### Requirement: Path-traced integration with Multiple Importance Sampling
 
-The renderer SHALL estimate per-pixel radiance by recursively path tracing
-camera rays, combining direct light sampling and BRDF sampling with the balance
-heuristic (MIS) at each surface interaction.
+The renderer SHALL estimate per-pixel radiance by path tracing camera rays
+(an iterative two-pass walk: a forward pass recording one vertex per bounce,
+then a backward gather), combining direct light sampling (NEE) and BSDF
+sampling at each surface interaction via a selectable `SamplingStrategy`
+(`crust:samplingStrategy` scene attribute / `--strategy` CLI override):
+`power` (β=2 power heuristic, the default), `balance` (balance heuristic), and
+the diagnostic single-strategy modes `light` (NEE only) and `bsdf` (BSDF
+sampling only, no shadow rays). All four strategies are unbiased.
 
 #### Scenario: Direct and indirect lighting are combined
 
 - **WHEN** a camera ray hits a non-emissive surface from which a light is visible
 - **THEN** the pixel radiance includes a direct-lighting term (from sampling the
-  light and casting a shadow ray) and an indirect term (from a BRDF-sampled
-  bounce), each weighted by the balance heuristic over the light PDF and BRDF PDF
+  light and casting a shadow ray) and an indirect term (from a BSDF-sampled
+  bounce), each weighted by the active sampling strategy over the light PDF and
+  BSDF PDF
 
 #### Scenario: Recursion is bounded by max depth
 
 - **WHEN** the bounce depth for a path reaches `max_depth`
 - **THEN** the path terminates and contributes no further radiance (returns black)
 
+#### Scenario: Russian roulette terminates long paths probabilistically
+
+- **WHEN** a path reaches its 4th vertex or beyond
+- **THEN** survival is sampled from the path's throughput (with a minimum
+  survival probability floor), and the throughput is divided by the survival
+  probability on paths that continue
+
 #### Scenario: Emissive surfaces contribute their emission
 
 - **WHEN** a ray hits a surface whose material emits light
 - **THEN** the surface's emitted radiance is added to the path contribution
 
-### Requirement: Anti-aliasing via multi-sampling with CMJ
+### Requirement: Anti-aliasing via multi-sampling with low-discrepancy sampling
 
-The renderer SHALL average `samples_per_pixel` samples per pixel, using
-Correlated Multi-Jittered (CMJ) sub-pixel offsets within the CMJ budget and
-falling back to uniform random offsets once the budget is exhausted.
+The renderer SHALL average `samples_per_pixel` samples per pixel, drawing
+sub-pixel offsets and all other per-sample randomness through the `Sampler`
+trait — Owen-scrambled Sobol (`SobolSampler`, per-pixel decorrelated) in
+production, falling back to a seeded RNG (`RngSampler`) once the Sobol
+dimension budget is exhausted.
 
 #### Scenario: Samples are averaged per pixel
 
 - **WHEN** `samples_per_pixel` is N
-- **THEN** each pixel value is the mean of N traced samples with jittered
-  sub-pixel offsets
+- **THEN** each pixel value is the mean of N traced samples with
+  low-discrepancy sub-pixel offsets
+
+### Requirement: Adaptive sampling stops pixels early
+
+The renderer SHALL stop sampling a pixel once it holds at least
+`crust:minSamplesPerPixel` samples and the relative standard error of the
+pixel mean drops below `crust:varianceThreshold` (0 disables adaptive
+sampling). This applies to the main/final render pass, never to path-guiding
+training passes.
+
+#### Scenario: A converged pixel stops early
+
+- **WHEN** a pixel has accumulated at least the minimum sample count and its
+  relative standard error is below the variance threshold
+- **THEN** no further samples are traced for that pixel
 
 ### Requirement: Parallel scanline and bucket rendering
 
@@ -110,6 +139,31 @@ without volume regions SHALL render exactly as before.
 - **WHEN** a path segment crosses a region with nonzero emission
 - **THEN** the segment accumulates `σₐ·Lₑ` source radiance weighted by the
   transmittance up to each emission point
+
+### Requirement: Opt-in path guiding
+
+When `crust:pathGuiding` is set on the scene's render settings, the renderer
+SHALL run `render_guided()`: a pure-Rust Practical Path Guiding SD-tree
+(`GuidingField`) trained over progressive passes at geometrically growing spp
+budgets, then a final pass sampling secondary bounces by one-sample MIS
+between the trained field and the BSDF. All passes (training and final) SHALL
+be blended into the output, weighted by inverse variance. Scenes without
+`crust:pathGuiding` SHALL render via the ungated path (no SD-tree, no extra
+training passes).
+
+#### Scenario: Guiding trains then renders
+
+- **WHEN** `crust:pathGuiding = true` on the render settings
+- **THEN** the renderer runs geometrically-growing training passes that splat
+  samples into the SD-tree, then a final pass that mixes guided and
+  BSDF-sampled directions at secondary bounces
+
+#### Scenario: Delta lobes and untrained regions fall back to the BSDF
+
+- **WHEN** a scattering event has no continuous BSDF component (a delta lobe)
+  or lands in an untrained region of the field
+- **THEN** the direction is sampled from the BSDF alone, and the estimate
+  stays unbiased
 
 ### Requirement: Sky-gradient background
 

--- a/openspec/specs/usd-scene-import/spec.md
+++ b/openspec/specs/usd-scene-import/spec.md
@@ -48,7 +48,7 @@ remains a linear list; BVH acceleration is built only per imported mesh.
 The importer SHALL resolve a bound material via `MaterialBindingAPI` and dispatch
 on the surface shader's `info:id`: `UsdPreviewSurface` maps into `OpenPBR`
 (portable field mapping), `crust:openpbr` decodes 1:1 into `OpenPBR`, and any
-geometry without a resolvable bound material falls back to a grey `Lambertian`.
+geometry without a resolvable bound material falls back to a default grey `OpenPBR`.
 
 #### Scenario: UsdPreviewSurface binding
 
@@ -64,31 +64,62 @@ geometry without a resolvable bound material falls back to a grey `Lambertian`.
 #### Scenario: Unbound geometry
 
 - **WHEN** geometry has no resolvable bound material
-- **THEN** it is assigned a grey Lambertian material
+- **THEN** it is assigned a default grey `OpenPBR` material
 
 ### Requirement: Light schema mapping
 
 The importer SHALL map `UsdLuxSphereLight` to an `Emissive` sphere that is both a
-light and visible geometry. Other lux schemas (`RectLight`, `DiskLight`,
-`DistantLight`, `DomeLight`, `CylinderLight`) SHALL warn once and be skipped.
+light and visible geometry, and `UsdLuxRectLight` to two emissive triangles
+plus an `AreaLight(RectShape)` (local XY plane, emitting along -Z per UsdLux —
+effectively one-sided). Other lux schemas (`DiskLight`, `DistantLight`,
+`DomeLight`, `CylinderLight`) SHALL warn once and be skipped.
 
 #### Scenario: Sphere light
 
 - **WHEN** a `UsdLuxSphereLight` prim is traversed
 - **THEN** it becomes an emissive sphere added to both the light list and the world
 
+#### Scenario: Rect light
+
+- **WHEN** a `UsdLuxRectLight` prim is traversed
+- **THEN** it becomes two emissive triangles added to both the light list and
+  the world
+
 #### Scenario: Unsupported lux light
 
-- **WHEN** a non-sphere lux light prim is traversed
+- **WHEN** a `DiskLight`, `DistantLight`, `DomeLight`, or `CylinderLight` prim
+  is traversed
 - **THEN** a warning is emitted and the light is skipped
+
+### Requirement: Volume region import
+
+Any prim carrying a `crust:volume:type` attribute SHALL import as a
+free-standing `VolumeRegion` rather than geometry — checked before the
+mesh/sphere/light dispatch, so its bounds never occlude shadow rays. The
+region's box comes from the prim's `size` (when it is a `Cube`) or the unit
+cube, oriented and scaled by the composed prim transform, with density
+(`homogeneous` | `smoke` procedural fBm noise | `grid` inline voxel data) and
+σₛ/σₐ/anisotropy/emission read from `crust:volume:*` attributes.
+
+#### Scenario: Volume prim
+
+- **WHEN** a prim authors `crust:volume:type`
+- **THEN** it is added to the scene's volume regions, not to world geometry
+
+#### Scenario: Missing grid data
+
+- **WHEN** a `grid`-type volume's `gridData` length does not match
+  `gridDims`' `nx·ny·nz`
+- **THEN** a warning is emitted and the volume is skipped
 
 ### Requirement: Render settings from USD with defaults
 
 The importer SHALL read `resolution` from `UsdRenderSettings` and per-render
 params from custom attributes in the `crust:` namespace (`crust:samplesPerPixel`,
 `crust:maxDepth`, `crust:minSamplesPerPixel`, `crust:varianceThreshold`,
-`crust:frame`). Missing attributes SHALL fall back to defaults (128 spp, depth
-32, 640×360).
+`crust:frame`, `crust:samplingStrategy`, `crust:pathGuiding`,
+`crust:guidingTrainIterations`, `crust:guidingProb`). Missing attributes SHALL
+fall back to defaults (128 spp, depth 32, 640×360, power MIS, guiding off).
 
 #### Scenario: Authored settings
 


### PR DESCRIPTION
Replaces the obsolete CMJ sampling description (README.md, CLAUDE.md) with
the actual Sobol-based `sampler` crate, which was also missing entirely from
CLAUDE.md's workspace layout. Adds the undocumented volume-rendering feature
to README.md and RectLight support to the Lights sections.

Rewrites the openspec specs, which predated several major changes and no
longer matched the code:
- materials/spec.md described eight material models; only OpenPBR and
  Emissive exist.
- image-output/spec.md described a `test_images/` timestamped-PNG path and a
  PNG/EXR desync bug; main.rs writes the PNG next to the -o path.
- cli/spec.md was missing -s/--samples and --strategy.
- rendering/spec.md described balance-heuristic-only MIS and CMJ sampling;
  adds the power/balance/light/bsdf strategy selection, Russian roulette,
  adaptive sampling, Sobol sampling, and path guiding, none of which were
  covered.
- usd-scene-import/spec.md listed RectLight as skipped (it's supported) and
  didn't cover volume-region import at all.

Also drops a CLAUDE.md note about a stale `scene.rs` docstring that no
longer exists.