### PR TITLE
Widen the kernel's SIMD: mask-driven BVH4 traversal and 4-wide triangle packets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,29 @@ Xform hierarchy into world matrices. Schema mapping:
 - `UsdGeomBasisCurves` → an instanced `rt::Geometry::RoundCurves` batch: `linear` curves
   directly, `cubic` (bezier | bspline | catmullRom) flattened at 8 samples per span; widths
   (USD diameters) resolve per-vertex / per-curve / constant by array length.
+- **Instancing** — both USD mechanisms reduce to the same thing, and share one code path
+  (`collect_proto_parts` → `attach_proto_parts`): build a prototype's geometry *once*, then
+  place it by transform. A prototype becomes a `Vec<ProtoPart>` — one part per bound leaf
+  geometry, each a committed local-space `rt::Scene` plus its prototype-relative transform,
+  material and ray mask. It is split per *part* rather than per prototype because `World`
+  maps materials by top-level `geom_id`: a prototype binding two materials must become two
+  instances or one material is lost. Prototypes are memoized by path in `ImportCaches`.
+  - `UsdGeomPointInstancer` → one instance per entry of the per-instance arrays. The
+    transform is USD's `translate ∘ orient ∘ scale`, under the instancer's own world
+    matrix; `orientationsf` (quatf) wins over `orientations` (quath); `invisibleIds`
+    prunes by `ids` (array index where `ids` is absent). The instancer's children are
+    **not** traversed — prototypes are conventionally authored beneath it and are drawn
+    only through it. Nested instancers and volumes inside prototypes warn and are skipped.
+  - Native instancing (`instanceable = true` + a composition arc) → the prim's prototype
+    (`/__Prototype_N`) is built once and shared by every instance; the instance's own proxy
+    subtree is never descended into. Without this the importer re-read and re-hashed each
+    instance's geometry (~30% of load time on a 2000-instance scene).
+  - `class` prims are abstract and never drawn on their own — only reached through the
+    prototypes that reference them. `collect_proto_parts` deliberately ignores that rule,
+    since naming a class as a prototype is how "geometry that exists only to be instanced"
+    is authored. Sample scene: `samples/instancing.usda`.
+  - Non-invertible instance placements (a zero scale — a common "hide this" idiom) are
+    skipped: `rt::Geometry::Instance` requires an invertible transform.
 - Any geometry prim may author `crust:rayMask` (int; bit 0 camera, bit 1 shadow, bit 2
   indirect — default all) to hide from ray categories, and `crust:motion:translate`
   (float3, world-space) to streak through that translation over the shutter (transform
@@ -318,9 +341,18 @@ feature flag.
   cubic spans to polylines (no exact cubic intersector) and lerps widths across a span in
   parameter; the rounded-cone can report an interior sphere surface for rays *starting
   inside* the hull (irrelevant for opaque hair). Mesh-BVH sharing needs identical
-  points/topology *and* material binding — `UsdGeomPointInstancer` and `instanceable`
-  composition arcs are not consumed. Emissive curves/instances are not light-list entries
-  (BSDF-sampled only, like emissive volumes).
+  points/topology *and* material binding. Emissive curves/instances are not light-list
+  entries (BSDF-sampled only, like emissive volumes).
+
+- **Instancing caveats.** Single-level only, as the kernel is: a prototype containing a
+  nested `PointInstancer` warns and skips it (an instance of an instance would need the
+  kernel's `Instance` to nest). Volumes inside prototypes are skipped — they live outside
+  the surface BVH by design and cannot ride an instance transform. `PointInstancer`
+  `velocities` / `accelerations` / `angularVelocities` are ignored, so vectorized instances
+  do not motion-blur (`crust:motion:translate` still works on ordinary prims), and all
+  per-instance arrays are read at the default time sample. Top-level `UsdGeomSphere` prims
+  still bake their centre into world space and so ignore scale; spheres *inside* a
+  prototype go through the instanced path and scale correctly.
 
 - **SIMD stops at 128 bits** (`docs/simd.md` has the audit and the numbers). Everything
   vectorized — `glam`'s `Vec3A`/`Vec4`, the BVH4 slab test, `Tri4` leaf packets — is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,11 @@ cargo test -p crust-core loads_cornellbox_usda     # run a single test by name
 
 # Benchmarks (criterion)
 cargo bench -p crust-core            # bench targets: "vec3 dot", "simple world", "simple world guided"
+cargo bench -p crust-rt              # kernel traversal: intersect/occluded over 3 scene kinds + build
+
+# Perf probes (better than criterion for kernel A/B: min-of-N, not a drifting mean)
+cargo run --release -p crust-rt --example ray_throughput          # Mray/s per scene & query
+cargo run --release -p crust-render --example exr_diff -- a.exr b.exr   # did the image change?
 
 # CI runs: cargo build --verbose && cargo test --verbose
 ```
@@ -191,10 +196,23 @@ material types, `simple_scene`, `get_settings`). Prefer importing from `crust_co
   SAH + spatial splits gated by the α-overlap test, references clipped via exact
   Sutherland-Hodgman for triangles and duplicated across children), runs subtrees in
   parallel via `rayon::join` above 4096 refs, is **deterministic** (input-only
-  decisions, pinned by a build-twice test), and is then **collapsed to BVH4**: 4-wide
-  SoA nodes whose slab tests run on `Vec4` lanes (`safe_inv` keeps zero-direction
-  components NaN-free; closest-hit traversal orders lanes near-to-far, occlusion
-  traversal early-exits).
+  decisions, pinned by a build-twice test), and is then **collapsed to BVH4**: 128-byte
+  4-wide SoA nodes whose slab tests run on `Vec4` lanes (`safe_inv3` keeps
+  zero-direction components NaN-free; closest-hit traversal orders lanes near-to-far,
+  occlusion traversal early-exits). Traversal is mask-driven: `RaySlab` pre-splats the
+  ray once per query, `cmple(..).bitmask()` yields all four lane verdicts at once, and
+  a validity nibble in `WideNode::flags` masks unused lanes (they cannot just be given
+  empty bounds — the slab test's per-axis min/max un-inverts an inverted box).
+  Leaf payloads live in a side `Leaf` table (keeping the node at two cache lines), and
+  each leaf's triangles are packed into **4-wide `Tri4` SIMD packets**: the Woop shear
+  is per-*ray* (`RayShear`, derived once per traversal), so four triangles are
+  intersected per vector round, with lanes whose edge functions come out exactly `0.0`
+  handed back to the scalar path for its f64 tie-break — watertightness intact. The
+  packet and scalar intersectors are **bit-identical** (pinned by
+  `simd_matches_scalar_bitwise`); change one and you must change the other.
+  `MIN_LEAF_PACKED` (4) is the leaf floor for all-triangle ranges so packets fill,
+  while non-packable prims keep `MIN_LEAF` (2) — see `docs/simd.md` for the audit,
+  the measurements, and why `std::simd` is not used (nightly-only on stable).
 - **`Material`** (`material/material.rs`) —
   `scatter_importance(r_in, rec) -> Option<ScatterSample>` used by the integrator
   (`ScatterSample.delta` marks singular lobes like transmission: never mixed with a
@@ -299,6 +317,17 @@ feature flag.
   points/topology *and* material binding — `UsdGeomPointInstancer` and `instanceable`
   composition arcs are not consumed. Emissive curves/instances are not light-list entries
   (BSDF-sampled only, like emissive volumes).
+
+- **SIMD stops at 4 lanes** (`docs/simd.md`). Everything vectorized — `glam`'s `Vec3A`/
+  `Vec4`, the BVH4 slab test, `Tri4` leaf packets — is SSE2-width, because `std::simd` is
+  still nightly-only and crust builds on stable; 8-wide (AVX2) nodes or packets would
+  need the `wide` crate or `core::arch` + `#[target_feature]` runtime dispatch. Only
+  *triangles* pack: sphere, curve and instance leaves still run scalar (no `Sphere4`).
+  Rays are traced one at a time — there is no coherent ray-packet tracing, which would
+  need the integrator restructured, not just the kernel. `-C target-cpu` is left at the
+  baseline so the binary stays distributable. And the checked-in sample scenes are
+  shading-bound, so kernel speedups barely show up there — use
+  `scripts/gen_stress_scene.py` to benchmark traversal changes end to end.
 
 - **Upstream `openusd` xformOp bug, worked around locally.** `openusd` 0.5.0 (latest as
   of 2026-06) composes multi-op `xformOpOrder` stacks in the wrong order (the authored

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,10 @@ cargo bench -p crust-rt              # kernel traversal: intersect/occluded over
 cargo run --release -p crust-rt --example ray_throughput          # Mray/s per scene & query
 cargo run --release -p crust-render --example exr_diff -- a.exr b.exr   # did the image change?
 
+# Kernel correctness is stated in exact float bits, so it must hold under every
+# codegen: runs the suite with AVX/AVX2/AVX-512 off, with AVX2+FMA, and native.
+scripts/test_simd_matrix.sh -p crust-rt
+
 # CI runs: cargo build --verbose && cargo test --verbose
 ```
 
@@ -318,15 +322,21 @@ feature flag.
   composition arcs are not consumed. Emissive curves/instances are not light-list entries
   (BSDF-sampled only, like emissive volumes).
 
-- **SIMD stops at 4 lanes** (`docs/simd.md`). Everything vectorized — `glam`'s `Vec3A`/
-  `Vec4`, the BVH4 slab test, `Tri4` leaf packets — is SSE2-width, because `std::simd` is
-  still nightly-only and crust builds on stable; 8-wide (AVX2) nodes or packets would
-  need the `wide` crate or `core::arch` + `#[target_feature]` runtime dispatch. Only
-  *triangles* pack: sphere, curve and instance leaves still run scalar (no `Sphere4`).
-  Rays are traced one at a time — there is no coherent ray-packet tracing, which would
-  need the integrator restructured, not just the kernel. `-C target-cpu` is left at the
-  baseline so the binary stays distributable. And the checked-in sample scenes are
-  shading-bound, so kernel speedups barely show up there — use
+- **SIMD stops at 128 bits** (`docs/simd.md` has the audit and the numbers). Everything
+  vectorized — `glam`'s `Vec3A`/`Vec4`, the BVH4 slab test, `Tri4` leaf packets — is
+  SSE2/NEON-width, because `std::simd` is still nightly-only and crust builds on stable.
+  Current practice says target AVX2 instead, so the reasons not to are recorded: merely
+  *enabling* AVX2 codegen is worth 2–4% (LLVM cannot widen a 4-lane algorithm), and
+  8-wide leaf packets would buy exactly nothing because no leaf holds more than 4
+  triangles — pinned by `eight_wide_packets_would_not_reduce_vector_rounds`. **BVH8
+  nodes** are the one place 256-bit vectors would still pay, and that is a project
+  decision, not just an optimization: reaching 256 bits at *runtime* needs `unsafe`
+  `core::arch` intrinsics (against this crate's "100% safe Rust" claim), a new
+  dependency (`wide`/`multiversion`), or a non-distributable `-C target-cpu`.
+  Also: only *triangles* pack — sphere, curve and instance leaves still run scalar (no
+  `Sphere4`); rays are traced one at a time, so there is no coherent ray-packet tracing
+  (that needs the integrator restructured, not just the kernel); and the checked-in
+  sample scenes are shading-bound, so kernel speedups barely show up there — use
   `scripts/gen_stress_scene.py` to benchmark traversal changes end to end.
 
 - **Upstream `openusd` xformOp bug, worked around locally.** `openusd` 0.5.0 (latest as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Five crates under `crates/`:
 - **`crust-rt`** (lib name `crust_rt`) — the intersection kernel, factored out the way
   `openqmc-rs` was, behind a deliberately **Embree-shaped API**: `Geometry` values
   (triangle meshes with optional per-vertex shading normals, analytic spheres, round
-  curve segments, single-level `Instance`s with transform motion blur) attach to a
+  curve segments, `Instance`s — which nest — with transform motion blur) attach to a
   `SceneBuilder` with per-geometry visibility masks; `commit()` builds the acceleration
   structure; `Scene::intersect`/`Scene::occluded` mirror `rtcIntersect1`/`rtcOccluded1`.
   Hits are plain `Copy` `RayHit`s carrying `geom_id`/`prim_id` — the kernel never sees
@@ -290,6 +290,14 @@ Xform hierarchy into world matrices. Schema mapping:
     (`/__Prototype_N`) is built once and shared by every instance; the instance's own proxy
     subtree is never descended into. Without this the importer re-read and re-hashed each
     instance's geometry (~30% of load time on a 2000-instance scene).
+  - **Nesting.** A `PointInstancer` inside a prototype expands into real nested sub-scenes
+    (`nested_instancer_parts`), one part per (prototype, part) so the grouping stays
+    per-material: M nested placements of a K-part prototype become K parts, each a
+    committed scene holding M instances. Flattening instead would multiply the outer
+    instance count by the inner one — the blow-up instancing exists to prevent. The kernel
+    nests to arbitrary depth. A nested *native* instance is skipped (upstream bug, below).
+    Sample scene: `samples/nested_instancing.usda`. `MAX_INSTANCE_NESTING` (8) is a
+    backstop against a malformed stage describing an instancing cycle.
   - `class` prims are abstract and never drawn on their own — only reached through the
     prototypes that reference them. `collect_proto_parts` deliberately ignores that rule,
     since naming a class as a prototype is how "geometry that exists only to be instanced"
@@ -344,10 +352,16 @@ feature flag.
   points/topology *and* material binding. Emissive curves/instances are not light-list
   entries (BSDF-sampled only, like emissive volumes).
 
-- **Instancing caveats.** Single-level only, as the kernel is: a prototype containing a
-  nested `PointInstancer` warns and skips it (an instance of an instance would need the
-  kernel's `Instance` to nest). Volumes inside prototypes are skipped — they live outside
-  the surface BVH by design and cannot ride an instance transform. `PointInstancer`
+- **Instancing caveats.** The kernel nests instances to arbitrary depth (transforms
+  compose, normals map back through every level, masks gate per level — pinned by
+  `instances_nest`, `nested_instances_compose_transforms_and_normals` and
+  `nested_instances_respect_masks_at_each_level` in `crust-rt`), and the importer expands
+  a `PointInstancer` inside a prototype into real nested sub-scenes. What is *not*
+  supported is a natively-instanced (`instanceable`) prim inside another instance's
+  prototype: `openusd` 0.5 cannot read its contents at all (see the upstream bug below),
+  so the importer skips it with a warning. Volumes inside prototypes are skipped — they
+  live outside the surface BVH by design and cannot ride an instance transform.
+  `PointInstancer`
   `velocities` / `accelerations` / `angularVelocities` are ignored, so vectorized instances
   do not motion-blur (`crust:motion:translate` still works on ordinary prims), and all
   per-instance arrays are read at the default time sample. Top-level `UsdGeomSphere` prims
@@ -381,6 +395,22 @@ feature flag.
   composition — with a warning — only for op kinds it cannot decode. Regression test:
   `cornellbox_transforms_compose_correctly`. If upstream fixes the bug, the fallback
   (`local_matrix_via_openusd`) and possibly the whole composer can be dropped.
+
+- **Upstream `openusd` nested-native-instancing bug, skipped locally.** An `instanceable`
+  prim *inside another instance's prototype* cannot be read with `openusd` 0.5.0.
+  Resolving its prototype — or reading the type name of any prim beneath it — reaches
+  `pcp/instancing.rs::materialize_prototype`, whose `debug_assert!` ("materialized
+  prototype root's instanceable must be inert") fires: debug builds abort, release builds
+  have the assertion compiled out. The instance prim itself is safe to inspect
+  (`is_instance`, `children`, `type_name` all succeed); only its *contents* are
+  unreachable, so there is no proxy-traversal fallback either. It reproduces in four lines
+  of USDA with `class` or `def` prototypes alike, and is independent of crust. Single-level
+  native instancing and nested `PointInstancer`s are unaffected. `collect_proto_parts`
+  therefore tests `is_instance()` **before** any schema lookup (a schema `get()` reads the
+  type name, which is what aborts) and skips such prims with a warning. Regression test:
+  `nested_native_instance_degrades_gracefully`. When upstream is fixed, delete that arm and
+  splice the inner prototype's parts in with composed transforms — a native instance is a
+  single placement, so it needs no extra level of kernel indirection.
 - USD lux light schemas beyond `SphereLight`/`RectLight` are skipped (see above). Disk
   lights need a disk primitive; distant/dome lights need non-area `Light` impls and
   integrator support for lights without scene geometry.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,19 @@ glam = { version = "0.30.8", features = ["serde"] }
 tracing = {version = "0.1.41", default-features = false}
 exr = "1.73.0"
 rand = "0.9.2"
+
+# The hot loops are spread across crates: the integrator in `crust-core`
+# calls the kernel in `crust-rt`, which calls `glam`'s SIMD vector ops.
+# Every one of those is a small `#[inline]` function whose whole point is
+# to disappear into its caller — with the default 16 codegen units and no
+# LTO, cross-crate calls survive as real calls and the vectorized bodies
+# never fuse. LTO + a single codegen unit is what lets the SIMD already in
+# the code actually reach the machine code.
+[profile.release]
+lto = "thin"
+codegen-units = 1
+
+# Benchmarks and tests inherit `release`, so they measure the same codegen.
+[profile.bench]
+lto = "thin"
+codegen-units = 1

--- a/crates/crust-core/src/material/brdf.rs
+++ b/crates/crust-core/src/material/brdf.rs
@@ -1,13 +1,19 @@
 use glam::Vec3A;
 use std::f32::consts::PI;
 
+// `powi(5)` rather than `powf(_, 5.0)`: an integer exponent lowers to a
+// multiply chain in registers, where `powf` is an opaque libm call that
+// costs tens of cycles *and* acts as a barrier the surrounding vector code
+// cannot be optimized across. Same idiom as the `powi(6)` in
+// `fresnel_f82_tint` below. Fresnel is evaluated on every glossy lobe of
+// every shading event, so this sits in the hottest loop in the renderer.
 pub fn fresnel_schlick(cos_theta: f32, f0: Vec3A) -> Vec3A {
-    f0 + (Vec3A::new(1.0, 1.0, 1.0) - f0) * f32::powf(1.0 - cos_theta, 5.0)
+    f0 + (Vec3A::ONE - f0) * (1.0 - cos_theta).powi(5)
 }
 
 // Clearcoat Fresnel approx
 pub fn fresnel_schlick_scalar(cos_theta: f32, f0: f32) -> f32 {
-    f0 + (1.0 - f0) * (1.0 - cos_theta).powf(5.0)
+    f0 + (1.0 - f0) * (1.0 - cos_theta).powi(5)
 }
 
 // -------- OpenPBR helpers --------
@@ -211,7 +217,7 @@ pub fn eon_diffuse(rho: Vec3A, roughness: f32, v_local: Vec3A, l_local: Vec3A) -
 pub fn fresnel_f82_tint(cos_theta: f32, f0: Vec3A, tint: Vec3A) -> Vec3A {
     const MU_BAR: f32 = 1.0 / 7.0;
     let mu = cos_theta.clamp(0.0, 1.0);
-    let f_schlick = |m: f32| f0 + (Vec3A::ONE - f0) * (1.0 - m).powf(5.0);
+    let f_schlick = |m: f32| f0 + (Vec3A::ONE - f0) * (1.0 - m).powi(5);
     let denom = MU_BAR * (1.0 - MU_BAR).powi(6);
     let a = f_schlick(MU_BAR) * (Vec3A::ONE - tint) / denom;
     (f_schlick(mu) - a * mu * (1.0 - mu).powi(6)).clamp(Vec3A::ZERO, Vec3A::ONE)

--- a/crates/crust-core/src/rt_world.rs
+++ b/crates/crust-core/src/rt_world.rs
@@ -105,6 +105,16 @@ impl World {
         self.materials.len()
     }
 
+    /// Number of top-level primitives in the acceleration structure.
+    ///
+    /// An instance counts as **one** primitive however much geometry it
+    /// references, so comparing this against a scene's triangle count is
+    /// how you tell instanced geometry from baked geometry: an instanced
+    /// import stays flat as placements multiply, a baked one does not.
+    pub fn primitive_count(&self) -> usize {
+        self.scene.primitive_count()
+    }
+
     /// The material bound to a geometry.
     pub fn material(&self, geom_id: u32) -> &dyn Material {
         self.materials[geom_id as usize].as_ref()

--- a/crates/crust-core/src/scene/usd_import.rs
+++ b/crates/crust-core/src/scene/usd_import.rs
@@ -23,7 +23,7 @@ use glam::{Affine3A, Vec3, Vec3A};
 use openusd::gf::{Matrix4d, Vec3f};
 use openusd::schemas::geom::{
     BasisCurves as UsdBasisCurves, Camera as UsdCamera, Curves as UsdCurves, Mesh as UsdMesh,
-    PointBased, Sphere as UsdSphere, Xform, Xformable,
+    PointBased, PointInstancer, Sphere as UsdSphere, Xform, Xformable,
 };
 use openusd::schemas::lux::{
     CylinderLight, DiskLight, DistantLight, DomeLight, Light as UsdLight, RectLight, SphereLight,
@@ -64,15 +64,49 @@ pub(crate) fn load_scene(path: &Path) -> Result<Scene, crate::Error> {
     // identical local geometry + material share one committed kernel
     // scene through instancing — N placements of a mesh cost one copy of
     // its triangles.
-    let mut materials = MaterialCache::default();
-    let mut meshes: HashMap<MeshKey, Arc<RtScene>> = HashMap::new();
+    let mut caches = ImportCaches::default();
 
     let mut stack: Vec<(Prim, GMat4)> = vec![(stage.prim_at(sdf::Path::abs_root()), GMat4::IDENTITY)];
 
     while let Some((prim, parent_world)) = stack.pop() {
+        // `class` prims (and their descendants) describe geometry that
+        // exists only to be referenced or instanced — they are never
+        // rendered in their own right. Prototypes reach the same prims
+        // through `collect_proto_parts`, which deliberately does not apply
+        // this rule.
+        if prim.is_abstract().unwrap_or(false) {
+            debug!("Skipping abstract (class) prim {}", prim.path());
+            continue;
+        }
+
         let local = local_matrix_at(&stage, &prim);
         let resets = resets_xform_stack_at(&stage, &prim);
         let this_world = if resets { local } else { parent_world * local };
+
+        // Native instancing: an `instanceable` prim with a composition arc
+        // shares one prototype with every other instance of it. Take the
+        // geometry from the prototype and place it — never descend into
+        // the instance's own (proxy) subtree, which would rebuild the same
+        // triangles once per instance.
+        if prim.is_instance().unwrap_or(false) {
+            match prim.prototype() {
+                Ok(Some(proto_path)) => {
+                    emit_native_instance(
+                        &stage,
+                        &mut world,
+                        &prim,
+                        &proto_path,
+                        this_world,
+                        &mut caches,
+                    );
+                    continue;
+                }
+                _ => warn!(
+                    "Prim {} is instanceable but has no prototype — importing directly",
+                    prim.path()
+                ),
+            }
+        }
 
         // Dispatch by schema. Volume prims are checked first: a prim
         // carrying `crust:volume:type` imports as a participating-media
@@ -80,16 +114,21 @@ pub(crate) fn load_scene(path: &Path) -> Result<Scene, crate::Error> {
         // shadow rays. Otherwise order matters only for Meshes vs Sphere
         // prims — both check first so we don't recurse into their
         // materials as prims.
-        if custom_token(&prim, "crust:volume:type").is_some() {
+        if let Ok(Some(instancer)) = PointInstancer::get(&stage, prim.path().clone()) {
+            emit_point_instancer(&stage, &mut world, &prim, &instancer, this_world, &mut caches);
+            // Prototypes are conventionally authored beneath the
+            // instancer; they are drawn through it, never on their own.
+            continue;
+        } else if custom_token(&prim, "crust:volume:type").is_some() {
             emit_volume(&prim, this_world, &mut volumes);
         } else if let Ok(Some(mesh)) = UsdMesh::get(&stage, prim.path().clone()) {
-            let mat = resolve_material(&stage, &prim, &mut materials);
-            emit_mesh(&mut world, &prim, &mesh, this_world, mat, &mut meshes);
+            let mat = resolve_material(&stage, &prim, &mut caches.materials);
+            emit_mesh(&mut world, &prim, &mesh, this_world, mat, &mut caches.meshes);
         } else if let Ok(Some(sphere)) = UsdSphere::get(&stage, prim.path().clone()) {
-            let mat = resolve_material(&stage, &prim, &mut materials);
+            let mat = resolve_material(&stage, &prim, &mut caches.materials);
             emit_sphere(&mut world, &prim, &sphere, this_world, mat);
         } else if let Ok(Some(curves)) = UsdBasisCurves::get(&stage, prim.path().clone()) {
-            let mat = resolve_material(&stage, &prim, &mut materials);
+            let mat = resolve_material(&stage, &prim, &mut caches.materials);
             emit_curves(&mut world, &prim, &curves, this_world, mat);
         } else if UsdCamera::get(&stage, prim.path().clone())
             .ok()
@@ -498,43 +537,12 @@ fn emit_mesh(
     material: Arc<dyn Material>,
     meshes: &mut HashMap<MeshKey, Arc<RtScene>>,
 ) {
-    let points: Option<Vec<Vec3f>> = mesh
-        .points_attr()
-        .get::<sdf::Value>()
-        .ok()
-        .flatten()
-        .and_then(|v| match v {
-            sdf::Value::Vec3fVec(v) => Some(v),
-            _ => None,
-        });
-    let counts: Option<Vec<i32>> = mesh
-        .face_vertex_counts_attr()
-        .get::<sdf::Value>()
-        .ok()
-        .flatten()
-        .and_then(|v| match v {
-            sdf::Value::IntVec(v) => Some(v),
-            _ => None,
-        });
-    let indices: Option<Vec<i32>> = mesh
-        .face_vertex_indices_attr()
-        .get::<sdf::Value>()
-        .ok()
-        .flatten()
-        .and_then(|v| match v {
-            sdf::Value::IntVec(v) => Some(v),
-            _ => None,
-        });
-
-    let (points, counts, indices) = match (points, counts, indices) {
-        (Some(p), Some(c), Some(i)) => (p, c, i),
-        _ => {
-            debug!(
-                "Mesh at {} missing points / faceVertexCounts / faceVertexIndices — skipped",
-                prim.path()
-            );
-            return;
-        }
+    let Some((points, counts, indices)) = mesh_arrays(mesh) else {
+        debug!(
+            "Mesh at {} missing points / faceVertexCounts / faceVertexIndices — skipped",
+            prim.path()
+        );
+        return;
     };
 
     let mask = prim_ray_mask(prim);
@@ -580,28 +588,8 @@ fn emit_mesh(
     // The mesh's kernel scene is built in the prim's *local* space and
     // shared by every prim with identical geometry + material; the
     // Instance geometry carries the placement.
-    let key = MeshKey::new(&points, &counts, &indices, &material);
-    let inner = match meshes.get(&key) {
-        Some(shared) => {
-            debug!("Mesh at {} shares geometry with an earlier prim", prim.path());
-            shared.clone()
-        }
-        None => {
-            let verts: Vec<Vec3A> = points.iter().map(|p| Vec3A::new(p.x, p.y, p.z)).collect();
-            let Some(tris) = triangulate(&counts, &indices, verts.len()) else {
-                debug!("Mesh at {} produced no triangles", prim.path());
-                return;
-            };
-            let mut b = RtSceneBuilder::new();
-            b.attach(Geometry::TriangleMesh {
-                vertices: verts,
-                indices: tris,
-                normals: None,
-            });
-            let scene = Arc::new(b.commit());
-            meshes.insert(key, scene.clone());
-            scene
-        }
+    let Some(inner) = shared_mesh_scene(prim, &points, &counts, &indices, &material, meshes) else {
+        return;
     };
 
     let l2w = Affine3A::from_mat4(world_xf);
@@ -614,6 +602,56 @@ fn emit_mesh(
         material,
         mask,
     );
+}
+
+/// Reads a mesh prim's authored arrays. `None` when any of the three
+/// required attributes is missing.
+fn mesh_arrays(mesh: &UsdMesh) -> Option<(Vec<Vec3f>, Vec<i32>, Vec<i32>)> {
+    let int_vec = |v: sdf::Value| match v {
+        sdf::Value::IntVec(v) => Some(v),
+        _ => None,
+    };
+    let points = match mesh.points_attr().get::<sdf::Value>().ok().flatten()? {
+        sdf::Value::Vec3fVec(v) => v,
+        _ => return None,
+    };
+    let counts = int_vec(mesh.face_vertex_counts_attr().get::<sdf::Value>().ok().flatten()?)?;
+    let indices = int_vec(mesh.face_vertex_indices_attr().get::<sdf::Value>().ok().flatten()?)?;
+    Some((points, counts, indices))
+}
+
+/// The mesh's triangles as a committed kernel scene in the prim's *local*
+/// space, shared with every earlier prim whose points/topology/material
+/// match. This is the unit of geometry sharing: N placements of a mesh —
+/// whether by repeated authoring, by a `PointInstancer`, or by native
+/// instancing — cost one copy of its triangles and one BVH.
+fn shared_mesh_scene(
+    prim: &Prim,
+    points: &[Vec3f],
+    counts: &[i32],
+    indices: &[i32],
+    material: &Arc<dyn Material>,
+    meshes: &mut HashMap<MeshKey, Arc<RtScene>>,
+) -> Option<Arc<RtScene>> {
+    let key = MeshKey::new(points, counts, indices, material);
+    if let Some(shared) = meshes.get(&key) {
+        debug!("Mesh at {} shares geometry with an earlier prim", prim.path());
+        return Some(shared.clone());
+    }
+    let verts: Vec<Vec3A> = points.iter().map(|p| Vec3A::new(p.x, p.y, p.z)).collect();
+    let Some(tris) = triangulate(counts, indices, verts.len()) else {
+        debug!("Mesh at {} produced no triangles", prim.path());
+        return None;
+    };
+    let mut b = RtSceneBuilder::new();
+    b.attach(Geometry::TriangleMesh {
+        vertices: verts,
+        indices: tris,
+        normals: None,
+    });
+    let scene = Arc::new(b.commit());
+    meshes.insert(key, scene.clone());
+    Some(scene)
 }
 
 /// Fan-triangulates the faces into an index-triple list; `None` if
@@ -649,14 +687,9 @@ fn triangulate(counts: &[i32], indices: &[i32], n_verts: usize) -> Option<Vec<[u
 // Sphere
 // -----------------------------------------------------------------------
 
-fn emit_sphere(
-    world: &mut WorldBuilder,
-    prim: &Prim,
-    sphere: &UsdSphere,
-    world_xf: GMat4,
-    material: Arc<dyn Material>,
-) {
-    let radius = sphere
+/// The authored `radius`, defaulting to USD's 1.0.
+fn sphere_radius(sphere: &UsdSphere) -> f32 {
+    sphere
         .radius_attr()
         .get::<sdf::Value>()
         .ok()
@@ -666,7 +699,17 @@ fn emit_sphere(
             sdf::Value::Float(f) => Some(f),
             _ => None,
         })
-        .unwrap_or(1.0);
+        .unwrap_or(1.0)
+}
+
+fn emit_sphere(
+    world: &mut WorldBuilder,
+    prim: &Prim,
+    sphere: &UsdSphere,
+    world_xf: GMat4,
+    material: Arc<dyn Material>,
+) {
+    let radius = sphere_radius(sphere);
     let center_world = world_xf.transform_point3(Vec3::ZERO);
     let center = Vec3A::new(center_world.x, center_world.y, center_world.z);
     debug!(
@@ -695,6 +738,394 @@ fn emit_sphere(
         None => {
             world.attach_masked(Geometry::Sphere { center, radius }, material, mask);
         }
+    }
+}
+
+// -----------------------------------------------------------------------
+// Instancing: prototypes
+//
+// Both instancing mechanisms — `UsdGeomPointInstancer` and native
+// `instanceable` prims — reduce to the same thing: build a prototype's
+// geometry *once*, then place it many times by transform. The shared
+// currency is a [`ProtoPart`]: one leaf geometry of the prototype, held as
+// a committed kernel scene in its own local space.
+//
+// The split into parts (rather than one scene per prototype) exists
+// because `World` maps materials per top-level geometry: a prototype whose
+// subtree binds two materials has to become two instances, or one of the
+// materials would be lost. Instances are cheap — a transform and a
+// pointer — so this costs a little top-level BVH and buys correct shading.
+// -----------------------------------------------------------------------
+
+/// The importer's memoization, threaded through geometry import.
+///
+/// All three caches exist for the same reason — authored geometry should
+/// be turned into kernel geometry exactly once, however many prims,
+/// instances or prototypes refer to it.
+#[derive(Default)]
+struct ImportCaches {
+    /// Material path (memoized) → shared material.
+    materials: MaterialCache,
+    /// Mesh content + material → the mesh's local-space kernel scene.
+    meshes: HashMap<MeshKey, Arc<RtScene>>,
+    /// Prototype path → its parts, for both instancing mechanisms.
+    protos: HashMap<String, Arc<Vec<ProtoPart>>>,
+}
+
+/// One leaf geometry of a prototype: a committed kernel scene in its own
+/// local space, the transform placing it relative to the prototype root,
+/// and the material and visibility mask authored on it.
+#[derive(Clone)]
+struct ProtoPart {
+    scene: Arc<RtScene>,
+    /// Prototype-root-relative placement. An instance's world transform is
+    /// composed onto the left of this.
+    local: GMat4,
+    material: Arc<dyn Material>,
+    mask: u32,
+}
+
+/// Walks a prototype subtree and builds its [`ProtoPart`]s, in the
+/// prototype root's local space (the root itself contributes no
+/// transform — an instance supplies the placement).
+///
+/// Abstract (`class`) prims are *not* skipped here, unlike in the main
+/// traversal: naming a class as a prototype is exactly how one authors
+/// "geometry that exists only to be instanced".
+fn collect_proto_parts(stage: &Stage, root: &Prim, caches: &mut ImportCaches) -> Vec<ProtoPart> {
+    let mut parts = Vec::new();
+    let mut stack: Vec<(Prim, GMat4)> = vec![(root.clone(), GMat4::IDENTITY)];
+
+    while let Some((prim, parent_local)) = stack.pop() {
+        // The prototype root's own transform is deliberately excluded: a
+        // `PointInstancer` prototype is placed entirely by its per-instance
+        // transform, and a native prototype root carries none.
+        let this_local = if prim.path() == root.path() {
+            GMat4::IDENTITY
+        } else if resets_xform_stack_at(stage, &prim) {
+            local_matrix_at(stage, &prim)
+        } else {
+            parent_local * local_matrix_at(stage, &prim)
+        };
+
+        let mask = prim_ray_mask(&prim);
+        if let Ok(Some(mesh)) = UsdMesh::get(stage, prim.path().clone()) {
+            let material = resolve_material(stage, &prim, &mut caches.materials);
+            if let Some((points, counts, indices)) = mesh_arrays(&mesh)
+                && let Some(scene) = shared_mesh_scene(
+                    &prim,
+                    &points,
+                    &counts,
+                    &indices,
+                    &material,
+                    &mut caches.meshes,
+                )
+            {
+                parts.push(ProtoPart {
+                    scene,
+                    local: this_local,
+                    material,
+                    mask,
+                });
+            }
+        } else if let Ok(Some(sphere)) = UsdSphere::get(stage, prim.path().clone()) {
+            let material = resolve_material(stage, &prim, &mut caches.materials);
+            let radius = sphere_radius(&sphere);
+            let mut b = RtSceneBuilder::new();
+            // Local-space sphere at the origin: unlike the top-level
+            // sphere path, which bakes the centre into world space, this
+            // lets the instance transform scale it (a non-uniform scale
+            // correctly yields an ellipsoid, since rays enter local space).
+            b.attach(Geometry::Sphere {
+                center: Vec3A::ZERO,
+                radius,
+            });
+            parts.push(ProtoPart {
+                scene: Arc::new(b.commit()),
+                local: this_local,
+                material,
+                mask,
+            });
+        } else if let Ok(Some(curves)) = UsdBasisCurves::get(stage, prim.path().clone()) {
+            let material = resolve_material(stage, &prim, &mut caches.materials);
+            if let Some(segments) = curve_segments(&prim, &curves) {
+                let mut b = RtSceneBuilder::new();
+                b.attach(Geometry::RoundCurves { segments });
+                parts.push(ProtoPart {
+                    scene: Arc::new(b.commit()),
+                    local: this_local,
+                    material,
+                    mask,
+                });
+            }
+        } else if custom_token(&prim, "crust:volume:type").is_some() {
+            // Volumes live outside the surface BVH entirely (their bounds
+            // must not occlude shadow rays), so they cannot ride an
+            // instance transform. Say so rather than dropping silently.
+            warn!(
+                "Volume at {} is inside a prototype — volumes cannot be instanced, skipped",
+                prim.path()
+            );
+        } else if PointInstancer::get(stage, prim.path().clone())
+            .ok()
+            .flatten()
+            .is_some()
+        {
+            warn!(
+                "Nested PointInstancer at {} inside a prototype — not expanded",
+                prim.path()
+            );
+        }
+
+        if let Ok(children) = prim.children() {
+            for child in children {
+                stack.push((child, this_local));
+            }
+        }
+    }
+    parts
+}
+
+/// Imports one natively-instanced prim (`instanceable = true` plus a
+/// composition arc) by placing its shared prototype's parts.
+///
+/// This is the mechanism Moana-scale scenes rely on, and the reason it
+/// matters is memory: without it the importer walks each instance's proxy
+/// subtree and re-reads its geometry, so cost scales with the *instance*
+/// count. Here every instance of a prototype shares one set of committed
+/// kernel scenes, and costs only its transforms.
+fn emit_native_instance(
+    stage: &Stage,
+    world: &mut WorldBuilder,
+    prim: &Prim,
+    proto_path: &sdf::Path,
+    world_xf: GMat4,
+    caches: &mut ImportCaches,
+) {
+    let key = proto_path.to_string();
+    let parts = match caches.protos.get(&key) {
+        Some(parts) => parts.clone(),
+        None => {
+            let root = stage.prim_at(proto_path.clone());
+            let parts = Arc::new(collect_proto_parts(stage, &root, caches));
+            debug!(
+                "Built prototype {key} for instance {} ({} part(s))",
+                prim.path(),
+                parts.len()
+            );
+            if parts.is_empty() {
+                warn!(
+                    "Prototype {key} (instanced at {}) contributed no geometry",
+                    prim.path()
+                );
+            }
+            caches.protos.insert(key, parts.clone());
+            parts
+        }
+    };
+    attach_proto_parts(world, &parts, world_xf, "native instance");
+}
+
+/// Attaches every part of a prototype at `placement`, one instance each.
+/// Non-invertible placements are skipped: the kernel's instance transform
+/// must be invertible, and a zero scale is a common "hide this instance"
+/// idiom rather than an error.
+fn attach_proto_parts(
+    world: &mut WorldBuilder,
+    parts: &[ProtoPart],
+    placement: GMat4,
+    what: &str,
+) -> usize {
+    let mut attached = 0;
+    for part in parts {
+        let xf = placement * part.local;
+        if xf.determinant().abs() < 1e-12 {
+            debug!("{what}: non-invertible instance transform — skipped");
+            continue;
+        }
+        world.attach_masked(
+            Geometry::Instance {
+                scene: part.scene.clone(),
+                transform: Affine3A::from_mat4(xf),
+                transform_end: None,
+            },
+            part.material.clone(),
+            part.mask,
+        );
+        attached += 1;
+    }
+    attached
+}
+
+/// Imports a `UsdGeomPointInstancer`: every entry of the per-instance
+/// arrays places the prototype selected by `protoIndices`.
+///
+/// The per-instance transform is USD's `translate ∘ orient ∘ scale`
+/// (spec: scale first, then orientation, then position), composed under
+/// the instancer's own world transform. `invisibleIds` prunes instances by
+/// `ids`; where `ids` is absent the array index is the id, as USD
+/// specifies.
+///
+/// Memory is what this is for: N instances of a prototype cost one copy of
+/// its geometry plus N transforms, instead of N baked copies.
+fn emit_point_instancer(
+    stage: &Stage,
+    world: &mut WorldBuilder,
+    prim: &Prim,
+    instancer: &PointInstancer,
+    world_xf: GMat4,
+    caches: &mut ImportCaches,
+) {
+    let targets = match instancer.prototypes_rel().targets() {
+        Ok(t) if !t.is_empty() => t,
+        _ => {
+            warn!(
+                "PointInstancer at {} has no `prototypes` targets — skipped",
+                prim.path()
+            );
+            return;
+        }
+    };
+
+    let proto_indices = match instancer.proto_indices_attr().get::<sdf::Value>() {
+        Ok(Some(sdf::Value::IntVec(v))) => v,
+        _ => {
+            warn!(
+                "PointInstancer at {} has no `protoIndices` — skipped",
+                prim.path()
+            );
+            return;
+        }
+    };
+
+    let positions = value_vec3f_array(&instancer.positions_attr()).unwrap_or_default();
+    let scales = value_vec3f_array(&instancer.scales_attr());
+    let orientations = instance_orientations(instancer);
+    let ids = match instancer.ids_attr().get::<sdf::Value>() {
+        Ok(Some(sdf::Value::Int64Vec(v))) => Some(v),
+        _ => None,
+    };
+    let invisible: std::collections::HashSet<i64> =
+        match instancer.invisible_ids_attr().get::<sdf::Value>() {
+            Ok(Some(sdf::Value::Int64Vec(v))) => v.into_iter().collect(),
+            _ => Default::default(),
+        };
+
+    if positions.len() < proto_indices.len() {
+        warn!(
+            "PointInstancer at {}: {} protoIndices but only {} positions — extra instances skipped",
+            prim.path(),
+            proto_indices.len(),
+            positions.len()
+        );
+    }
+
+    // Build each prototype once, keyed by path so several instancers (and
+    // repeated targets) share the work.
+    let mut proto_parts: Vec<Arc<Vec<ProtoPart>>> = Vec::with_capacity(targets.len());
+    for target in &targets {
+        let key = target.to_string();
+        let parts = match caches.protos.get(&key) {
+            Some(p) => p.clone(),
+            None => {
+                let root = stage.prim_at(target.clone());
+                let parts = Arc::new(collect_proto_parts(stage, &root, caches));
+                if parts.is_empty() {
+                    warn!("PointInstancer prototype {key} contributed no geometry");
+                }
+                caches.protos.insert(key, parts.clone());
+                parts
+            }
+        };
+        proto_parts.push(parts);
+    }
+
+    let mut instances = 0usize;
+    let mut hidden = 0usize;
+    for (i, &proto_index) in proto_indices.iter().enumerate() {
+        let Some(pos) = positions.get(i) else { break };
+
+        let id = ids.as_ref().map_or(i as i64, |ids| {
+            ids.get(i).copied().unwrap_or(i as i64)
+        });
+        if invisible.contains(&id) {
+            hidden += 1;
+            continue;
+        }
+
+        let Some(parts) = usize::try_from(proto_index)
+            .ok()
+            .and_then(|k| proto_parts.get(k))
+        else {
+            warn!(
+                "PointInstancer at {}: protoIndices[{i}] = {proto_index} is out of range — instance skipped",
+                prim.path()
+            );
+            continue;
+        };
+
+        // USD's instance transform: scale, then orient, then translate.
+        let scale = scales
+            .as_ref()
+            .and_then(|s| s.get(i))
+            .map_or(Vec3::ONE, |s| Vec3::new(s.x, s.y, s.z));
+        let rotation = orientations
+            .as_ref()
+            .and_then(|q| q.get(i).copied())
+            .unwrap_or(glam::Quat::IDENTITY);
+        let instance_xf = world_xf
+            * GMat4::from_scale_rotation_translation(
+                scale,
+                rotation,
+                Vec3::new(pos.x, pos.y, pos.z),
+            );
+
+        instances += attach_proto_parts(world, parts, instance_xf, "PointInstancer instance");
+    }
+
+    info!(
+        "Imported PointInstancer at {} ({} instances of {} prototype(s), {} geometries attached{})",
+        prim.path(),
+        proto_indices.len() - hidden,
+        targets.len(),
+        instances,
+        if hidden > 0 {
+            format!(", {hidden} hidden by invisibleIds")
+        } else {
+            String::new()
+        }
+    );
+}
+
+/// A `point3f[]` / `float3[]` attribute as a plain vector.
+fn value_vec3f_array(attr: &openusd::usd::Attribute) -> Option<Vec<Vec3f>> {
+    match attr.get::<sdf::Value>() {
+        Ok(Some(sdf::Value::Vec3fVec(v))) => Some(v),
+        _ => None,
+    }
+}
+
+/// Per-instance rotations, preferring single-precision `orientationsf`
+/// over half-precision `orientations` as USD specifies.
+fn instance_orientations(instancer: &PointInstancer) -> Option<Vec<glam::Quat>> {
+    let quat = |w: f32, x: f32, y: f32, z: f32| glam::Quat::from_xyzw(x, y, z, w).normalize();
+    if let Ok(Some(sdf::Value::QuatfVec(v))) = instancer.orientationsf_attr().get::<sdf::Value>() {
+        return Some(v.iter().map(|q| quat(q.w, q.x, q.y, q.z)).collect());
+    }
+    match instancer.orientations_attr().get::<sdf::Value>() {
+        Ok(Some(sdf::Value::QuathVec(v))) => Some(
+            v.iter()
+                .map(|q| {
+                    quat(
+                        q.w.to_f32(),
+                        q.x.to_f32(),
+                        q.y.to_f32(),
+                        q.z.to_f32(),
+                    )
+                })
+                .collect(),
+        ),
+        _ => None,
     }
 }
 
@@ -742,13 +1173,10 @@ const CURVE_FLATTEN_SEGS: usize = 8;
 /// span. Widths (diameters, per USD) may be authored per point (`vertex`),
 /// per curve, or constant; anything else falls back to the first value.
 /// The segments live in local space under an `Instance`, like meshes.
-fn emit_curves(
-    world: &mut WorldBuilder,
-    prim: &Prim,
-    curves: &UsdBasisCurves,
-    world_xf: GMat4,
-    material: Arc<dyn Material>,
-) {
+/// The curve batch flattened into round segments, in the prim's *local*
+/// space. Shared by the top-level emitter and the prototype collector; the
+/// caller supplies the placement.
+fn curve_segments(prim: &Prim, curves: &UsdBasisCurves) -> Option<Vec<CurveSegment>> {
     let points: Option<Vec<Vec3f>> = curves
         .points_attr()
         .get::<sdf::Value>()
@@ -774,7 +1202,7 @@ fn emit_curves(
                 "BasisCurves at {} missing points / curveVertexCounts — skipped",
                 prim.path()
             );
-            return;
+            return None;
         }
     };
     let pts: Vec<Vec3A> = points.iter().map(|p| Vec3A::new(p.x, p.y, p.z)).collect();
@@ -803,7 +1231,7 @@ fn emit_curves(
                 prim.path(),
                 other
             );
-            return;
+            return None;
         }
     };
 
@@ -880,7 +1308,7 @@ fn emit_curves(
 
     if segments.is_empty() {
         debug!("BasisCurves at {} produced no segments", prim.path());
-        return;
+        return None;
     }
     info!(
         "Imported BasisCurves at {} ({} {} curves, {} segments)",
@@ -889,7 +1317,19 @@ fn emit_curves(
         ty,
         segments.len()
     );
+    Some(segments)
+}
 
+fn emit_curves(
+    world: &mut WorldBuilder,
+    prim: &Prim,
+    curves: &UsdBasisCurves,
+    world_xf: GMat4,
+    material: Arc<dyn Material>,
+) {
+    let Some(segments) = curve_segments(prim, curves) else {
+        return;
+    };
     if world_xf.determinant().abs() < 1e-12 {
         warn!(
             "BasisCurves at {} has a non-invertible transform — skipped",

--- a/crates/crust-core/src/scene/usd_import.rs
+++ b/crates/crust-core/src/scene/usd_import.rs
@@ -42,6 +42,11 @@ const DEFAULT_VARIANCE: f32 = 0.05;
 const DEFAULT_FRAME: isize = 0;
 const DEFAULT_GUIDING_TRAIN_ITERATIONS: u32 = 4;
 const DEFAULT_GUIDING_PROB: f32 = 0.5;
+/// How deep prototypes may nest before the importer gives up. USD forbids
+/// an instancing cycle, but a malformed stage can still describe one, and
+/// each level multiplies traversal cost — so this is a backstop, set far
+/// above any plausible authoring depth.
+const MAX_INSTANCE_NESTING: usize = 8;
 
 pub(crate) fn load_scene(path: &Path) -> Result<Scene, crate::Error> {
     let path_str = path
@@ -792,8 +797,20 @@ struct ProtoPart {
 /// Abstract (`class`) prims are *not* skipped here, unlike in the main
 /// traversal: naming a class as a prototype is exactly how one authors
 /// "geometry that exists only to be instanced".
-fn collect_proto_parts(stage: &Stage, root: &Prim, caches: &mut ImportCaches) -> Vec<ProtoPart> {
+fn collect_proto_parts(
+    stage: &Stage,
+    root: &Prim,
+    caches: &mut ImportCaches,
+    depth: usize,
+) -> Vec<ProtoPart> {
     let mut parts = Vec::new();
+    if depth > MAX_INSTANCE_NESTING {
+        warn!(
+            "Prototype {} exceeds {MAX_INSTANCE_NESTING} levels of instance nesting — not expanded",
+            root.path()
+        );
+        return parts;
+    }
     let mut stack: Vec<(Prim, GMat4)> = vec![(root.clone(), GMat4::IDENTITY)];
 
     while let Some((prim, parent_local)) = stack.pop() {
@@ -809,6 +826,36 @@ fn collect_proto_parts(stage: &Stage, root: &Prim, caches: &mut ImportCaches) ->
         };
 
         let mask = prim_ray_mask(&prim);
+
+        // Checked before any schema lookup, because a schema `get()` reads
+        // the prim's type name and that is exactly what aborts here.
+        //
+        // A natively-instanced prim *inside* a prototype is unreachable
+        // with openusd 0.5.0: resolving its prototype, or reading the type
+        // of any prim beneath it, trips an internal assertion
+        // (`pcp/instancing.rs`: "materialized prototype root's
+        // instanceable must be inert"), which aborts debug builds. The
+        // prim itself is safe to inspect; its contents are not. So there
+        // is no route to the geometry — not the prototype, not the proxy
+        // subtree — and the honest response is to say so and move on
+        // rather than abort. Nested *PointInstancer* is unaffected and is
+        // expanded below.
+        //
+        // Four-line repro and the full diagnosis live in
+        // `nested_native_instance_degrades_gracefully` in
+        // `crates/crust-core/tests/usd_scene.rs`. Delete this arm when
+        // upstream is fixed; `collect_proto_parts` can then splice the
+        // inner prototype's parts in with composed transforms.
+        if prim.path() != root.path() && prim.is_instance().unwrap_or(false) {
+            warn!(
+                "Nested native instance at {} skipped: openusd 0.5 cannot read \
+                 an instanceable prim's contents inside a prototype. Author it \
+                 as a PointInstancer, or flatten the inner instance.",
+                prim.path()
+            );
+            continue;
+        }
+
         if let Ok(Some(mesh)) = UsdMesh::get(stage, prim.path().clone()) {
             let material = resolve_material(stage, &prim, &mut caches.materials);
             if let Some((points, counts, indices)) = mesh_arrays(&mesh)
@@ -866,15 +913,24 @@ fn collect_proto_parts(stage: &Stage, root: &Prim, caches: &mut ImportCaches) ->
                 "Volume at {} is inside a prototype — volumes cannot be instanced, skipped",
                 prim.path()
             );
-        } else if PointInstancer::get(stage, prim.path().clone())
-            .ok()
-            .flatten()
-            .is_some()
-        {
-            warn!(
-                "Nested PointInstancer at {} inside a prototype — not expanded",
-                prim.path()
-            );
+        } else if let Ok(Some(instancer)) = PointInstancer::get(stage, prim.path().clone()) {
+            // A PointInstancer inside a prototype: expand it into nested
+            // sub-scenes rather than flattening. Flattening would multiply
+            // the *outer* instance count by this instancer's, which is
+            // exactly the blow-up instancing exists to avoid — a prototype
+            // holding 500 leaves, itself placed 500 times, must stay 500
+            // outer instances, not 250 000.
+            parts.extend(nested_instancer_parts(
+                stage,
+                &prim,
+                &instancer,
+                this_local,
+                mask,
+                caches,
+                depth + 1,
+            ));
+            // Its prototypes are reached through it, never drawn directly.
+            continue;
         }
 
         if let Ok(children) = prim.children() {
@@ -884,6 +940,71 @@ fn collect_proto_parts(stage: &Stage, root: &Prim, caches: &mut ImportCaches) ->
         }
     }
     parts
+}
+
+/// Expands a `PointInstancer` found *inside* a prototype into parts.
+///
+/// One part per prototype-part of the nested instancer, each holding a
+/// committed sub-scene of that part placed once per nested instance. The
+/// grouping is by material, not by instance, because `World` resolves
+/// materials from the top-level `geom_id`: everything inside one part must
+/// therefore share a material.
+fn nested_instancer_parts(
+    stage: &Stage,
+    prim: &Prim,
+    instancer: &PointInstancer,
+    local: GMat4,
+    mask: u32,
+    caches: &mut ImportCaches,
+    depth: usize,
+) -> Vec<ProtoPart> {
+    let Some(layout) = read_instancer(prim, instancer) else {
+        return Vec::new();
+    };
+    let proto_parts = instancer_proto_parts(stage, &layout, caches, depth);
+
+    // Group placements by (prototype, part), so each output part collects
+    // every placement that draws that one piece of geometry.
+    let mut out: Vec<ProtoPart> = Vec::new();
+    for (k, parts) in proto_parts.iter().enumerate() {
+        for part in parts.iter() {
+            let mut sub = RtSceneBuilder::new();
+            let mut placed = 0usize;
+            for &(target, xf) in layout.placements.iter().filter(|(t, _)| *t == k) {
+                let _ = target;
+                let placement = xf * part.local;
+                if placement.determinant().abs() < 1e-12 {
+                    continue; // zero scale: the "hide this instance" idiom
+                }
+                sub.attach_masked(
+                    Geometry::Instance {
+                        scene: part.scene.clone(),
+                        transform: Affine3A::from_mat4(placement),
+                        transform_end: None,
+                    },
+                    part.mask,
+                );
+                placed += 1;
+            }
+            if placed == 0 {
+                continue;
+            }
+            out.push(ProtoPart {
+                scene: Arc::new(sub.commit()),
+                local,
+                material: part.material.clone(),
+                mask,
+            });
+        }
+    }
+
+    info!(
+        "Expanded nested PointInstancer at {} ({} instances -> {} part(s))",
+        prim.path(),
+        layout.placements.len(),
+        out.len()
+    );
+    out
 }
 
 /// Imports one natively-instanced prim (`instanceable = true` plus a
@@ -902,27 +1023,12 @@ fn emit_native_instance(
     world_xf: GMat4,
     caches: &mut ImportCaches,
 ) {
-    let key = proto_path.to_string();
-    let parts = match caches.protos.get(&key) {
-        Some(parts) => parts.clone(),
-        None => {
-            let root = stage.prim_at(proto_path.clone());
-            let parts = Arc::new(collect_proto_parts(stage, &root, caches));
-            debug!(
-                "Built prototype {key} for instance {} ({} part(s))",
-                prim.path(),
-                parts.len()
-            );
-            if parts.is_empty() {
-                warn!(
-                    "Prototype {key} (instanced at {}) contributed no geometry",
-                    prim.path()
-                );
-            }
-            caches.protos.insert(key, parts.clone());
-            parts
-        }
-    };
+    let parts = prototype_parts(stage, proto_path, caches, 0);
+    debug!(
+        "Instance {} uses prototype {proto_path} ({} part(s))",
+        prim.path(),
+        parts.len()
+    );
     attach_proto_parts(world, &parts, world_xf, "native instance");
 }
 
@@ -968,14 +1074,29 @@ fn attach_proto_parts(
 ///
 /// Memory is what this is for: N instances of a prototype cost one copy of
 /// its geometry plus N transforms, instead of N baked copies.
-fn emit_point_instancer(
-    stage: &Stage,
-    world: &mut WorldBuilder,
-    prim: &Prim,
-    instancer: &PointInstancer,
-    world_xf: GMat4,
-    caches: &mut ImportCaches,
-) {
+/// A `PointInstancer`'s prototypes and the placements that select them,
+/// resolved once and reused by both the top-level emitter and the nested
+/// (inside-a-prototype) path.
+struct InstancerLayout {
+    /// The `prototypes` relationship's ordered targets.
+    targets: Vec<sdf::Path>,
+    /// Visible instances as `(index into targets, transform relative to
+    /// the instancer)`. Instances hidden by `invisibleIds` are already
+    /// dropped.
+    placements: Vec<(usize, GMat4)>,
+    /// How many instances `invisibleIds` removed, for reporting.
+    hidden: usize,
+}
+
+/// Reads the per-instance arrays into placements. `None` when the prim is
+/// not a usable instancer.
+///
+/// The transform is USD's `translate ∘ orient ∘ scale` — scale first, then
+/// orientation, then position. `orientationsf` (single precision) wins over
+/// `orientations` (half) where both are authored, and `invisibleIds`
+/// prunes by `ids`, with the array index standing in as the id where `ids`
+/// is absent.
+fn read_instancer(prim: &Prim, instancer: &PointInstancer) -> Option<InstancerLayout> {
     let targets = match instancer.prototypes_rel().targets() {
         Ok(t) if !t.is_empty() => t,
         _ => {
@@ -983,19 +1104,18 @@ fn emit_point_instancer(
                 "PointInstancer at {} has no `prototypes` targets — skipped",
                 prim.path()
             );
-            return;
+            return None;
         }
     };
 
-    let proto_indices = match instancer.proto_indices_attr().get::<sdf::Value>() {
-        Ok(Some(sdf::Value::IntVec(v))) => v,
-        _ => {
-            warn!(
-                "PointInstancer at {} has no `protoIndices` — skipped",
-                prim.path()
-            );
-            return;
-        }
+    let Ok(Some(sdf::Value::IntVec(proto_indices))) =
+        instancer.proto_indices_attr().get::<sdf::Value>()
+    else {
+        warn!(
+            "PointInstancer at {} has no `protoIndices` — skipped",
+            prim.path()
+        );
+        return None;
     };
 
     let positions = value_vec3f_array(&instancer.positions_attr()).unwrap_or_default();
@@ -1020,43 +1140,20 @@ fn emit_point_instancer(
         );
     }
 
-    // Build each prototype once, keyed by path so several instancers (and
-    // repeated targets) share the work.
-    let mut proto_parts: Vec<Arc<Vec<ProtoPart>>> = Vec::with_capacity(targets.len());
-    for target in &targets {
-        let key = target.to_string();
-        let parts = match caches.protos.get(&key) {
-            Some(p) => p.clone(),
-            None => {
-                let root = stage.prim_at(target.clone());
-                let parts = Arc::new(collect_proto_parts(stage, &root, caches));
-                if parts.is_empty() {
-                    warn!("PointInstancer prototype {key} contributed no geometry");
-                }
-                caches.protos.insert(key, parts.clone());
-                parts
-            }
-        };
-        proto_parts.push(parts);
-    }
-
-    let mut instances = 0usize;
+    let mut placements = Vec::with_capacity(proto_indices.len());
     let mut hidden = 0usize;
     for (i, &proto_index) in proto_indices.iter().enumerate() {
         let Some(pos) = positions.get(i) else { break };
 
-        let id = ids.as_ref().map_or(i as i64, |ids| {
-            ids.get(i).copied().unwrap_or(i as i64)
-        });
+        let id = ids
+            .as_ref()
+            .map_or(i as i64, |ids| ids.get(i).copied().unwrap_or(i as i64));
         if invisible.contains(&id) {
             hidden += 1;
             continue;
         }
 
-        let Some(parts) = usize::try_from(proto_index)
-            .ok()
-            .and_then(|k| proto_parts.get(k))
-        else {
+        let Some(k) = usize::try_from(proto_index).ok().filter(|k| *k < targets.len()) else {
             warn!(
                 "PointInstancer at {}: protoIndices[{i}] = {proto_index} is out of range — instance skipped",
                 prim.path()
@@ -1064,7 +1161,6 @@ fn emit_point_instancer(
             continue;
         };
 
-        // USD's instance transform: scale, then orient, then translate.
         let scale = scales
             .as_ref()
             .and_then(|s| s.get(i))
@@ -1073,24 +1169,94 @@ fn emit_point_instancer(
             .as_ref()
             .and_then(|q| q.get(i).copied())
             .unwrap_or(glam::Quat::IDENTITY);
-        let instance_xf = world_xf
-            * GMat4::from_scale_rotation_translation(
+        placements.push((
+            k,
+            GMat4::from_scale_rotation_translation(
                 scale,
                 rotation,
                 Vec3::new(pos.x, pos.y, pos.z),
-            );
+            ),
+        ));
+    }
 
-        instances += attach_proto_parts(world, parts, instance_xf, "PointInstancer instance");
+    Some(InstancerLayout {
+        targets,
+        placements,
+        hidden,
+    })
+}
+
+/// The parts of each of an instancer's prototypes, built once and memoized
+/// by path.
+fn instancer_proto_parts(
+    stage: &Stage,
+    layout: &InstancerLayout,
+    caches: &mut ImportCaches,
+    depth: usize,
+) -> Vec<Arc<Vec<ProtoPart>>> {
+    layout
+        .targets
+        .iter()
+        .map(|target| prototype_parts(stage, target, caches, depth))
+        .collect()
+}
+
+/// A prototype's parts, from the cache or freshly built.
+fn prototype_parts(
+    stage: &Stage,
+    proto_path: &sdf::Path,
+    caches: &mut ImportCaches,
+    depth: usize,
+) -> Arc<Vec<ProtoPart>> {
+    let key = proto_path.to_string();
+    if let Some(parts) = caches.protos.get(&key) {
+        return parts.clone();
+    }
+    let root = stage.prim_at(proto_path.clone());
+    let parts = Arc::new(collect_proto_parts(stage, &root, caches, depth));
+    if parts.is_empty() {
+        warn!("Prototype {key} contributed no geometry");
+    }
+    caches.protos.insert(key, parts.clone());
+    parts
+}
+
+/// Imports a `UsdGeomPointInstancer`: every entry of the per-instance
+/// arrays places the prototype selected by `protoIndices`.
+///
+/// Memory is what this is for: N instances of a prototype cost one copy of
+/// its geometry plus N transforms, instead of N baked copies.
+fn emit_point_instancer(
+    stage: &Stage,
+    world: &mut WorldBuilder,
+    prim: &Prim,
+    instancer: &PointInstancer,
+    world_xf: GMat4,
+    caches: &mut ImportCaches,
+) {
+    let Some(layout) = read_instancer(prim, instancer) else {
+        return;
+    };
+    let proto_parts = instancer_proto_parts(stage, &layout, caches, 0);
+
+    let mut attached = 0usize;
+    for &(k, xf) in &layout.placements {
+        attached += attach_proto_parts(
+            world,
+            &proto_parts[k],
+            world_xf * xf,
+            "PointInstancer instance",
+        );
     }
 
     info!(
         "Imported PointInstancer at {} ({} instances of {} prototype(s), {} geometries attached{})",
         prim.path(),
-        proto_indices.len() - hidden,
-        targets.len(),
-        instances,
-        if hidden > 0 {
-            format!(", {hidden} hidden by invisibleIds")
+        layout.placements.len(),
+        layout.targets.len(),
+        attached,
+        if layout.hidden > 0 {
+            format!(", {} hidden by invisibleIds", layout.hidden)
         } else {
             String::new()
         }

--- a/crates/crust-core/tests/usd_scene.rs
+++ b/crates/crust-core/tests/usd_scene.rs
@@ -506,3 +506,206 @@ fn point_instancer_honours_invisible_ids() {
     assert!(hit_above(2.2, 1.6), "gem id 14 missing");
     assert!(hit_above(3.8, 2.1), "gem id 15 missing");
 }
+
+/// Nested instancing. `samples/nested_instancing.usda` puts a
+/// `PointInstancer` inside another instancer's prototype, and a natively
+/// instanced prim inside a second prototype.
+#[test]
+fn loads_nested_instancing_usda() {
+    let scene = Scene::from_usd(&sample("nested_instancing.usda"))
+        .expect("failed to open nested_instancing.usda");
+
+    // The Branch prototype expands to 3 parts (leaf, bud husk, bud tip —
+    // one per distinct geometry, since a part carries one material), so
+    // the outer instancer's 5 placements attach 15. Plus 2 planters x 2
+    // parts, the floor and the light.
+    assert_eq!(
+        scene.world.count(),
+        21,
+        "expected 21 geometries (5x3 grove + 2x2 planters + floor + light), got {}",
+        scene.world.count()
+    );
+}
+
+/// Nesting must *nest*, not flatten. Each branch's three leaves live in
+/// one sub-scene placed once, so a branch costs one top-level primitive
+/// per part — not one per leaf. Flattening would multiply the outer
+/// instance count by the inner one, which is the blow-up instancing exists
+/// to prevent.
+#[test]
+fn nested_instancing_does_not_flatten() {
+    let scene = Scene::from_usd(&sample("nested_instancing.usda"))
+        .expect("failed to open nested_instancing.usda");
+
+    // 5 branches x 3 parts + 2 planters x 2 parts + floor (2 tris) +
+    // light (2 tris). Flattening the inner instancer would put each of the
+    // 5x4 = 20 nested placements at the top level instead.
+    assert!(
+        scene.world.primitive_count() <= 24,
+        "nested instances look flattened: {} kernel primitives",
+        scene.world.primitive_count()
+    );
+}
+
+/// Two levels of instancing must compose transforms, and each nested part
+/// must keep the material bound inside the innermost prototype.
+#[test]
+fn nested_instances_compose_transforms_and_keep_materials() {
+    let scene = Scene::from_usd(&sample("nested_instancing.usda"))
+        .expect("failed to open nested_instancing.usda");
+
+    // Shoot along -Z through a point, from well in front of the grove.
+    let at = |x: f32, y: f32| {
+        let ray = crust_core::Ray::new(
+            crust_core::Vec3A::new(x, y, 10.0),
+            -crust_core::Vec3A::Z,
+        );
+        scene.world.intersect(&ray, 0.001, 40.0)
+    };
+
+    // Branch 0 is at (-6.4, 0, -1), unrotated and unscaled. Its first leaf
+    // sits at branch-local (0.45, 1.0, 0) → world (-5.95, 1.0, -1).
+    assert!(at(-5.95, 1.0).is_some(), "branch 0's first leaf is missing");
+    // ...and nothing a metre to its left, where no leaf was placed.
+    assert!(
+        at(-5.95, 1.0 + 1.0).is_none(),
+        "unexpected geometry above branch 0's first leaf"
+    );
+
+    // The bud sits on the branch axis at local y = 3.0, its tip 0.3 above.
+    // Both are hit, and they must be *different* geometries: the husk
+    // binds Leafy and the tip Blossom, so collapsing the nested prototype
+    // into one part would lose a material.
+    let husk = at(-6.4, 3.0).expect("branch 0's bud husk is missing");
+    let tip = at(-6.4, 3.3).expect("branch 0's bud tip is missing");
+    assert_ne!(
+        husk.geom_id, tip.geom_id,
+        "husk and tip collapsed into one geometry — a material was lost"
+    );
+
+    // Branch 1 is scaled 1.25 in y. The bud is on its rotation axis, so
+    // the outer scale is the only thing moving it: local y = 3.0 → 3.75,
+    // and the tip 3.3 → 4.125. That composes the outer instance's scale
+    // with the inner instance's placement, two levels down.
+    assert!(
+        at(-3.2, 3.75).is_some(),
+        "branch 1's bud is not where the outer scale puts it"
+    );
+    assert!(
+        at(-3.2, 4.125).is_some(),
+        "branch 1's bud tip is not where the outer scale puts it"
+    );
+    // Unscaled, it would have been at 3.0 / 3.3 — nothing should be there.
+    assert!(
+        at(-3.2, 3.3).is_none(),
+        "branch 1 was placed as if unscaled"
+    );
+}
+
+/// A multi-part prototype placed by ordinary native instancing: both
+/// planters show their post and their orb, as separate geometries so both
+/// materials survive.
+#[test]
+fn multi_part_prototype_keeps_every_part() {
+    let scene = Scene::from_usd(&sample("nested_instancing.usda"))
+        .expect("failed to open nested_instancing.usda");
+
+    let at = |x: f32, y: f32| {
+        let ray = crust_core::Ray::new(
+            crust_core::Vec3A::new(x, y, 10.0),
+            -crust_core::Vec3A::Z,
+        );
+        scene.world.intersect(&ray, 0.001, 40.0)
+    };
+
+    for x in [-1.9f32, 1.9] {
+        // The post spans y in [0, 1.1] and the orb sits at y = 1.35.
+        let post = at(x, 0.6).unwrap_or_else(|| panic!("planter post at x = {x} is missing"));
+        let orb = at(x, 1.35).unwrap_or_else(|| panic!("planter orb at x = {x} is missing"));
+        assert_ne!(
+            post.geom_id, orb.geom_id,
+            "post and orb must stay separate geometries so both materials survive"
+        );
+    }
+
+    // The `class` prototype is authored at the origin and must not be
+    // drawn there in its own right.
+    assert!(
+        at(0.0, 0.6).is_none(),
+        "a class prototype was drawn at the origin"
+    );
+}
+
+/// An `instanceable` prim *inside* another instance's prototype cannot be
+/// read at all with openusd 0.5.0, so the importer must skip it rather
+/// than abort.
+///
+/// The upstream bug: resolving such a prim's prototype — or reading the
+/// type name of any prim beneath it — reaches
+/// `pcp/instancing.rs::materialize_prototype`, whose `debug_assert!`
+/// ("materialized prototype root's instanceable must be inert") fires.
+/// Debug builds abort; release builds have the assertion compiled out.
+/// The prim itself is safe to inspect (`is_instance`, `children`,
+/// `type_name` all succeed) — only its *contents* are unreachable, which
+/// is why there is no proxy-traversal fallback either.
+///
+/// It is a property of the composed stage, not of crust: it reproduces
+/// with `class` and `def` prototypes alike, and single-level native
+/// instancing and nested `PointInstancer`s are both unaffected.
+///
+/// This test pins graceful degradation — the outer instance still renders,
+/// the unreadable inner one is dropped with a warning. When upstream fixes
+/// it, this test will start seeing the inner geometry and should be
+/// replaced with one asserting the nested content *is* imported.
+#[test]
+fn nested_native_instance_degrades_gracefully() {
+    let dir = std::env::temp_dir().join("crust_nested_native_probe");
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let path = dir.join("nested_native.usda");
+    std::fs::write(
+        &path,
+        r#"#usda 1.0
+(defaultPrim = "W")
+def Xform "W" {
+    class Xform "_Inner" { def Sphere "s" { double radius = 0.5 } }
+    class Xform "_Outer" {
+        def Sphere "outer" { double radius = 0.4 }
+        def Xform "i" (instanceable = true; references = </W/_Inner>) {
+            double3 xformOp:translate = (3, 0, 0)
+            uniform token[] xformOpOrder = ["xformOp:translate"]
+        }
+    }
+    def Xform "A" (instanceable = true; references = </W/_Outer>) {}
+}
+"#,
+    )
+    .expect("write probe stage");
+
+    // The load must complete. Before the guard this aborted the process.
+    let scene = Scene::from_usd(&path).expect("stage with a nested native instance must load");
+
+    // The outer prototype's own geometry survives; only the unreadable
+    // nested instance is missing.
+    assert_eq!(
+        scene.world.count(),
+        1,
+        "expected the outer sphere only (the nested instance is unreadable upstream), got {}",
+        scene.world.count()
+    );
+
+    let hit = |x: f32| {
+        let ray = crust_core::Ray::new(
+            crust_core::Vec3A::new(x, 0.0, 10.0),
+            -crust_core::Vec3A::Z,
+        );
+        scene.world.intersect(&ray, 0.001, 40.0).is_some()
+    };
+    assert!(hit(0.0), "the outer prototype's own sphere should render");
+    assert!(
+        !hit(3.0),
+        "the nested instance is expected to be missing — if this now hits, \
+         openusd has been fixed and the skip in collect_proto_parts can go"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/crust-core/tests/usd_scene.rs
+++ b/crates/crust-core/tests/usd_scene.rs
@@ -380,3 +380,129 @@ fn loads_motionblur_usda() {
         shadow_hit.rec.t
     );
 }
+
+/// Instancing, both mechanisms. `samples/instancing.usda` holds three
+/// natively-instanced towers (each a two-material prototype) and a
+/// `PointInstancer` scattering six gems, one of which `invisibleIds` hides.
+#[test]
+fn loads_instancing_usda() {
+    let scene = Scene::from_usd(&sample("instancing.usda"))
+        .expect("failed to open instancing.usda");
+
+    // 5 visible scatter instances + 3 towers x 2 prototype parts + floor
+    // + the rect light's geometry.
+    assert_eq!(
+        scene.world.count(),
+        13,
+        "expected 13 geometries (5 scatter + 6 tower parts + floor + light), got {}",
+        scene.world.count()
+    );
+
+    // The whole point: every placement is an instance, so the kernel sees
+    // one top-level primitive per placement rather than a copy of the
+    // prototype's triangles. The two rect-light triangles and the floor's
+    // two are the only non-instanced prims.
+    assert!(
+        scene.world.primitive_count() <= 16,
+        "geometry looks baked, not instanced: {} kernel primitives",
+        scene.world.primitive_count()
+    );
+}
+
+/// A `class` prototype must never be drawn in its own right — only through
+/// the instances that reference it. Before instancing support the class's
+/// contents rendered at the origin as an extra, phantom object.
+#[test]
+fn instancing_does_not_draw_the_class_prototype() {
+    let scene = Scene::from_usd(&sample("instancing.usda"))
+        .expect("failed to open instancing.usda");
+
+    // `/World/_Tower` is authored at the origin. The towers are placed at
+    // x = -4.2, -2.2 and -0.4, so nothing should occupy x = 0, and a ray
+    // down the tower's height there must reach only the floor.
+    let ray = crust_core::Ray::new(
+        crust_core::Vec3A::new(0.0, 1.0, 6.0),
+        -crust_core::Vec3A::Z,
+    );
+    assert!(
+        scene.world.intersect(&ray, 0.001, 20.0).is_none(),
+        "the class prototype was drawn at the origin"
+    );
+}
+
+/// Instances must land where their transforms put them, and carry the
+/// material bound inside the prototype.
+#[test]
+fn instances_are_placed_and_shaded_per_prototype_part() {
+    let scene = Scene::from_usd(&sample("instancing.usda"))
+        .expect("failed to open instancing.usda");
+
+    // TowerA sits at x = -4.2 with its block spanning y in [0, 2] and its
+    // emerald cap [2, 2.5] (prototype y in [-0.5, 1.5] / [1.5, 2.0], the
+    // instance raised by 0.5).
+    let shoot = |x: f32, y: f32| {
+        crust_core::Ray::new(
+            crust_core::Vec3A::new(x, y, 6.0),
+            -crust_core::Vec3A::Z,
+        )
+    };
+    let block = scene
+        .world
+        .intersect(&shoot(-4.2, 1.0), 0.001, 20.0)
+        .expect("TowerA's block should be hit at x = -4.2");
+    let cap = scene
+        .world
+        .intersect(&shoot(-4.2, 2.2), 0.001, 20.0)
+        .expect("TowerA's cap should be hit above the block");
+    assert_ne!(
+        block.geom_id, cap.geom_id,
+        "block and cap must stay separate geometries so both materials survive"
+    );
+
+    // Nothing between the towers.
+    assert!(
+        scene.world.intersect(&shoot(-3.4, 1.0), 0.001, 20.0).is_none(),
+        "unexpected geometry between TowerA and TowerB"
+    );
+
+    // TowerC is scaled to 1.4 in y, so its cap reaches higher than
+    // TowerA's: prototype y = 2.0 maps to 0.5 + 1.4 * 2.0 = 3.3.
+    assert!(
+        scene.world.intersect(&shoot(-0.4, 3.0), 0.001, 20.0).is_some(),
+        "TowerC's non-uniform scale was not applied"
+    );
+    assert!(
+        scene.world.intersect(&shoot(-4.2, 3.0), 0.001, 20.0).is_none(),
+        "unscaled TowerA should not reach y = 3"
+    );
+}
+
+/// `invisibleIds` prunes instances, and every visible one is placed.
+#[test]
+fn point_instancer_honours_invisible_ids() {
+    let scene = Scene::from_usd(&sample("instancing.usda"))
+        .expect("failed to open instancing.usda");
+
+    // Six positions are authored; id 13 — the fourth, at x = 5.4 — is
+    // hidden. Shoot straight down each gem's column from y = 4: a gem
+    // stops the ray above the floor, its absence lets it run to the floor
+    // at exactly t = 4. (The threshold is deliberately just shy of the
+    // floor rather than near the gems' tops: per-instance rotations tilt
+    // them, so the height at which a column meets a gem varies.)
+    let hit_above = |x: f32, z: f32| {
+        let ray = crust_core::Ray::new(
+            crust_core::Vec3A::new(x, 4.0, z),
+            -crust_core::Vec3A::Y,
+        );
+        scene
+            .world
+            .intersect(&ray, 0.001, 10.0)
+            .is_some_and(|h| h.rec.t < 3.9) // anything above the floor at y = 0
+    };
+    assert!(hit_above(1.6, 0.0), "gem id 10 missing");
+    assert!(hit_above(2.9, -1.1), "gem id 11 missing");
+    assert!(hit_above(4.2, 0.4), "gem id 12 missing");
+    assert!(!hit_above(5.4, -0.6), "gem id 13 is in invisibleIds but was drawn");
+    assert!(hit_above(2.2, 1.6), "gem id 14 missing");
+    assert!(hit_above(3.8, 2.1), "gem id 15 missing");
+}

--- a/crates/crust-render/examples/exr_diff.rs
+++ b/crates/crust-render/examples/exr_diff.rs
@@ -1,0 +1,86 @@
+//! Numeric diff of two rendered EXRs — the check that a change to the
+//! intersection kernel did not change the image.
+//!
+//! ```text
+//! cargo run --release -p crust-render --example exr_diff -- a.exr b.exr
+//! ```
+//!
+//! Prints the number of differing pixels, the largest absolute and
+//! relative channel difference, and the mean absolute difference. A pure
+//! performance change should report either zero differing pixels or a
+//! handful at the float epsilon (exact-tie ordering inside a BVH leaf),
+//! never a structural difference.
+
+use exr::prelude::*;
+
+fn load(path: &str) -> (usize, usize, Vec<f32>) {
+    let image = read_first_rgba_layer_from_file(
+        path,
+        |resolution, _| {
+            let (w, h) = (resolution.width(), resolution.height());
+            (w, h, vec![0.0f32; w * h * 4])
+        },
+        |(w, _h, pixels): &mut (usize, usize, Vec<f32>), pos, (r, g, b, a): (f32, f32, f32, f32)| {
+            let i = (pos.y() * *w + pos.x()) * 4;
+            pixels[i] = r;
+            pixels[i + 1] = g;
+            pixels[i + 2] = b;
+            pixels[i + 3] = a;
+        },
+    )
+    .unwrap_or_else(|e| panic!("cannot read {path}: {e}"));
+    image.layer_data.channel_data.pixels
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.len() != 2 {
+        eprintln!("usage: exr_diff <a.exr> <b.exr>");
+        std::process::exit(2);
+    }
+    let (aw, ah, a) = load(&args[0]);
+    let (bw, bh, b) = load(&args[1]);
+    assert_eq!((aw, ah), (bw, bh), "resolutions differ");
+
+    let mut differing_pixels = 0usize;
+    let mut max_abs = 0.0f32;
+    let mut max_rel = 0.0f32;
+    let mut sum_abs = 0.0f64;
+    for p in 0..aw * ah {
+        let mut pixel_differs = false;
+        for c in 0..3 {
+            let (x, y) = (a[p * 4 + c], b[p * 4 + c]);
+            let d = (x - y).abs();
+            sum_abs += d as f64;
+            if d != 0.0 {
+                pixel_differs = true;
+                max_abs = max_abs.max(d);
+                let scale = x.abs().max(y.abs());
+                if scale > 0.0 {
+                    max_rel = max_rel.max(d / scale);
+                }
+            }
+        }
+        if pixel_differs {
+            differing_pixels += 1;
+            if differing_pixels <= 8 {
+                println!(
+                    "  differs at ({}, {}): {:?} vs {:?}",
+                    p % aw,
+                    p / aw,
+                    &a[p * 4..p * 4 + 3],
+                    &b[p * 4..p * 4 + 3]
+                );
+            }
+        }
+    }
+    let total = aw * ah;
+    println!(
+        "{}x{}  differing pixels: {differing_pixels}/{total} ({:.4}%)",
+        aw,
+        ah,
+        100.0 * differing_pixels as f64 / total as f64
+    );
+    println!("max abs diff: {max_abs:e}   max rel diff: {max_rel:e}");
+    println!("mean abs diff: {:e}", sum_abs / (total * 3) as f64);
+}

--- a/crates/crust-rt/Cargo.toml
+++ b/crates/crust-rt/Cargo.toml
@@ -12,3 +12,10 @@ path = "src/lib.rs"
 [dependencies]
 glam.workspace = true
 rayon = "1.10.0"
+
+[dev-dependencies]
+criterion = "0.8"
+
+[[bench]]
+name = "traversal"
+harness = false

--- a/crates/crust-rt/benches/traversal.rs
+++ b/crates/crust-rt/benches/traversal.rs
@@ -1,0 +1,173 @@
+//! Traversal benchmarks for the intersection kernel.
+//!
+//! These exist to make the SIMD work in `bvh.rs` / `triangle.rs`
+//! measurable: they time the two query entry points (`intersect` and
+//! `occluded`) over a fixed, deterministic ray batch, so a change to the
+//! slab test or the leaf intersector shows up directly instead of being
+//! buried under a full render.
+//!
+//! Scenes deliberately differ in what they stress:
+//! - `tri_sphere_*`: a subdivided sphere mesh — many small triangles,
+//!   several per leaf, which is what the 4-wide leaf intersector targets.
+//! - `sphere_grid_*`: analytic spheres — no triangle work at all, so it
+//!   isolates the node slab test and traversal ordering.
+//! - `instances_*`: an instanced grid — traversal that recurses through
+//!   transformed sub-scenes.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use crust_rt::{Geometry, Ray, Scene, SceneBuilder};
+use glam::{Affine3A, Vec3A};
+use std::hint::black_box;
+use std::sync::Arc;
+
+/// A UV sphere mesh with `2 * segs * rings` triangles.
+fn uv_sphere(center: Vec3A, radius: f32, segs: usize, rings: usize) -> Geometry {
+    let mut vertices = Vec::with_capacity((segs + 1) * (rings + 1));
+    for r in 0..=rings {
+        let v = r as f32 / rings as f32;
+        let phi = v * std::f32::consts::PI;
+        for s in 0..=segs {
+            let u = s as f32 / segs as f32;
+            let theta = u * std::f32::consts::TAU;
+            vertices.push(
+                center
+                    + radius
+                        * Vec3A::new(phi.sin() * theta.cos(), phi.cos(), phi.sin() * theta.sin()),
+            );
+        }
+    }
+    let mut indices = Vec::with_capacity(2 * segs * rings);
+    let row = segs + 1;
+    for r in 0..rings {
+        for s in 0..segs {
+            let a = (r * row + s) as u32;
+            let b = (r * row + s + 1) as u32;
+            let c = ((r + 1) * row + s + 1) as u32;
+            let d = ((r + 1) * row + s) as u32;
+            indices.push([a, b, c]);
+            indices.push([a, c, d]);
+        }
+    }
+    Geometry::TriangleMesh {
+        vertices,
+        indices,
+        normals: None,
+    }
+}
+
+/// Triangle-heavy scene: a 3×3×3 arrangement of subdivided spheres
+/// (~86k triangles).
+fn triangle_scene() -> Scene {
+    let mut b = SceneBuilder::new();
+    for x in -1..=1 {
+        for y in -1..=1 {
+            for z in -1..=1 {
+                let c = Vec3A::new(x as f32, y as f32, z as f32) * 2.5;
+                b.attach(uv_sphere(c, 1.0, 40, 20));
+            }
+        }
+    }
+    b.commit()
+}
+
+/// Analytic spheres only — isolates node tests from triangle work.
+fn sphere_grid_scene() -> Scene {
+    let mut b = SceneBuilder::new();
+    for x in 0..12 {
+        for y in 0..12 {
+            for z in 0..12 {
+                b.attach(Geometry::Sphere {
+                    center: Vec3A::new(x as f32, y as f32, z as f32) * 2.0 - Vec3A::splat(12.0),
+                    radius: 0.6,
+                });
+            }
+        }
+    }
+    b.commit()
+}
+
+/// One mesh, instanced across a grid: two-level traversal.
+fn instance_scene() -> Scene {
+    let mut inner = SceneBuilder::new();
+    inner.attach(uv_sphere(Vec3A::ZERO, 1.0, 24, 12));
+    let inner = Arc::new(inner.commit());
+
+    let mut b = SceneBuilder::new();
+    for x in -2..=2 {
+        for y in -2..=2 {
+            for z in -2..=2 {
+                b.attach(Geometry::Instance {
+                    scene: Arc::clone(&inner),
+                    transform: Affine3A::from_translation(
+                        glam::Vec3::new(x as f32, y as f32, z as f32) * 2.5,
+                    ),
+                    transform_end: None,
+                });
+            }
+        }
+    }
+    b.commit()
+}
+
+/// A deterministic fan of rays aimed through the scene's bounds — a mix of
+/// hits and misses, and of coherent and divergent directions. Seeded by a
+/// small LCG so the batch is identical run to run.
+fn ray_batch(count: usize, extent: f32) -> Vec<Ray> {
+    let mut state = 0x2545_F491u32;
+    let mut next = || {
+        state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        (state >> 8) as f32 / (1u32 << 24) as f32
+    };
+    (0..count)
+        .map(|_| {
+            let origin = Vec3A::new(next() - 0.5, next() - 0.5, next() - 0.5) * (4.0 * extent);
+            let target = Vec3A::new(next() - 0.5, next() - 0.5, next() - 0.5) * extent;
+            Ray::new(origin, (target - origin).normalize())
+        })
+        .collect()
+}
+
+const RAYS: usize = 4096;
+
+fn bench_scene(c: &mut Criterion, name: &str, scene: Scene, extent: f32) {
+    let rays = ray_batch(RAYS, extent);
+
+    c.bench_function(&format!("{name} intersect"), |b| {
+        b.iter(|| {
+            let mut hits = 0usize;
+            for r in &rays {
+                if scene.intersect(r, 0.001, f32::INFINITY).is_some() {
+                    hits += 1;
+                }
+            }
+            black_box(hits)
+        })
+    });
+
+    c.bench_function(&format!("{name} occluded"), |b| {
+        b.iter(|| {
+            let mut hits = 0usize;
+            for r in &rays {
+                if scene.occluded(r, 0.001, f32::INFINITY) {
+                    hits += 1;
+                }
+            }
+            black_box(hits)
+        })
+    });
+}
+
+fn bench_traversal(c: &mut Criterion) {
+    bench_scene(c, "tri_spheres", triangle_scene(), 6.0);
+    bench_scene(c, "sphere_grid", sphere_grid_scene(), 14.0);
+    bench_scene(c, "instances", instance_scene(), 7.0);
+}
+
+fn bench_build(c: &mut Criterion) {
+    c.bench_function("build tri_spheres", |b| {
+        b.iter(|| black_box(triangle_scene().primitive_count()))
+    });
+}
+
+criterion_group!(benches, bench_traversal, bench_build);
+criterion_main!(benches);

--- a/crates/crust-rt/examples/ray_throughput.rs
+++ b/crates/crust-rt/examples/ray_throughput.rs
@@ -1,0 +1,158 @@
+//! Deterministic ray-throughput probe: min-of-N wall time per scene and
+//! query type, printed as Mray/s.
+//!
+//! Criterion reports means, which drift by 10%+ on a loaded or shared
+//! machine. For comparing two versions of the intersection kernel the
+//! *minimum* over repeats is the more useful statistic — noise only ever
+//! adds time, so the floor is the closest thing to the true cost.
+//!
+//! ```text
+//! cargo run --release -p crust-rt --example ray_throughput
+//! ```
+
+use crust_rt::{Geometry, Ray, Scene, SceneBuilder};
+use glam::{Affine3A, Vec3A};
+use std::sync::Arc;
+use std::time::Instant;
+
+fn uv_sphere(center: Vec3A, radius: f32, segs: usize, rings: usize) -> Geometry {
+    let mut vertices = Vec::with_capacity((segs + 1) * (rings + 1));
+    for r in 0..=rings {
+        let phi = (r as f32 / rings as f32) * std::f32::consts::PI;
+        for s in 0..=segs {
+            let theta = (s as f32 / segs as f32) * std::f32::consts::TAU;
+            vertices.push(
+                center
+                    + radius
+                        * Vec3A::new(phi.sin() * theta.cos(), phi.cos(), phi.sin() * theta.sin()),
+            );
+        }
+    }
+    let mut indices = Vec::with_capacity(2 * segs * rings);
+    let row = segs + 1;
+    for r in 0..rings {
+        for s in 0..segs {
+            let a = (r * row + s) as u32;
+            let b = (r * row + s + 1) as u32;
+            let c = ((r + 1) * row + s + 1) as u32;
+            let d = ((r + 1) * row + s) as u32;
+            indices.push([a, b, c]);
+            indices.push([a, c, d]);
+        }
+    }
+    Geometry::TriangleMesh {
+        vertices,
+        indices,
+        normals: None,
+    }
+}
+
+fn triangle_scene() -> Scene {
+    let mut b = SceneBuilder::new();
+    for x in -1..=1 {
+        for y in -1..=1 {
+            for z in -1..=1 {
+                b.attach(uv_sphere(
+                    Vec3A::new(x as f32, y as f32, z as f32) * 2.5,
+                    1.0,
+                    40,
+                    20,
+                ));
+            }
+        }
+    }
+    b.commit()
+}
+
+fn sphere_grid_scene() -> Scene {
+    let mut b = SceneBuilder::new();
+    for x in 0..12 {
+        for y in 0..12 {
+            for z in 0..12 {
+                b.attach(Geometry::Sphere {
+                    center: Vec3A::new(x as f32, y as f32, z as f32) * 2.0 - Vec3A::splat(12.0),
+                    radius: 0.6,
+                });
+            }
+        }
+    }
+    b.commit()
+}
+
+fn instance_scene() -> Scene {
+    let mut inner = SceneBuilder::new();
+    inner.attach(uv_sphere(Vec3A::ZERO, 1.0, 24, 12));
+    let inner = Arc::new(inner.commit());
+    let mut b = SceneBuilder::new();
+    for x in -2..=2 {
+        for y in -2..=2 {
+            for z in -2..=2 {
+                b.attach(Geometry::Instance {
+                    scene: Arc::clone(&inner),
+                    transform: Affine3A::from_translation(
+                        glam::Vec3::new(x as f32, y as f32, z as f32) * 2.5,
+                    ),
+                    transform_end: None,
+                });
+            }
+        }
+    }
+    b.commit()
+}
+
+fn ray_batch(count: usize, extent: f32) -> Vec<Ray> {
+    let mut state = 0x2545_F491u32;
+    let mut next = || {
+        state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        (state >> 8) as f32 / (1u32 << 24) as f32
+    };
+    (0..count)
+        .map(|_| {
+            let origin = Vec3A::new(next() - 0.5, next() - 0.5, next() - 0.5) * (4.0 * extent);
+            let target = Vec3A::new(next() - 0.5, next() - 0.5, next() - 0.5) * extent;
+            Ray::new(origin, (target - origin).normalize())
+        })
+        .collect()
+}
+
+const RAYS: usize = 4096;
+const REPEATS: usize = 40;
+
+fn probe(name: &str, scene: &Scene, extent: f32) {
+    let rays = ray_batch(RAYS, extent);
+
+    for (kind, closest) in [("intersect", true), ("occluded", false)] {
+        let mut best = f64::INFINITY;
+        let mut hits = 0usize;
+        for _ in 0..REPEATS {
+            let start = Instant::now();
+            let mut h = 0usize;
+            for r in &rays {
+                let hit = if closest {
+                    scene.intersect(r, 0.001, f32::INFINITY).is_some()
+                } else {
+                    scene.occluded(r, 0.001, f32::INFINITY)
+                };
+                if hit {
+                    h += 1;
+                }
+            }
+            let secs = start.elapsed().as_secs_f64();
+            hits = h;
+            best = best.min(secs);
+        }
+        println!(
+            "{name:<12} {kind:<10} {:>8.3} ms   {:>6.2} Mray/s   ({hits}/{RAYS} hit)",
+            best * 1e3,
+            RAYS as f64 / best / 1e6,
+        );
+    }
+}
+
+fn main() {
+    let tri = triangle_scene();
+    println!("tri_spheres: {} triangles", tri.primitive_count());
+    probe("tri_spheres", &tri, 6.0);
+    probe("sphere_grid", &sphere_grid_scene(), 14.0);
+    probe("instances", &instance_scene(), 7.0);
+}

--- a/crates/crust-rt/src/bvh.rs
+++ b/crates/crust-rt/src/bvh.rs
@@ -1336,3 +1336,92 @@ mod tests {
         assert!(bbox.maximum.cmpge(Vec3A::splat(6.5)).all());
     }
 }
+
+#[cfg(test)]
+mod lane_width {
+    use super::*;
+    use crate::prim::TrianglePrim;
+    use crate::ray::MASK_ALL;
+    use glam::Vec3A;
+
+    fn uv_sphere_prims(segs: usize, rings: usize) -> Vec<Box<dyn Prim>> {
+        let mut v = Vec::new();
+        for r in 0..=rings {
+            let phi = (r as f32 / rings as f32) * std::f32::consts::PI;
+            for s in 0..=segs {
+                let th = (s as f32 / segs as f32) * std::f32::consts::TAU;
+                v.push(Vec3A::new(
+                    phi.sin() * th.cos(),
+                    phi.cos(),
+                    phi.sin() * th.sin(),
+                ));
+            }
+        }
+        let row = segs + 1;
+        let mut out: Vec<Box<dyn Prim>> = Vec::new();
+        let mut id = 0u32;
+        for r in 0..rings {
+            for s in 0..segs {
+                let (a, b, c, d) = (
+                    r * row + s,
+                    r * row + s + 1,
+                    (r + 1) * row + s + 1,
+                    (r + 1) * row + s,
+                );
+                for (i, j, k) in [(a, b, c), (a, c, d)] {
+                    out.push(Box::new(TrianglePrim {
+                        v0: v[i],
+                        v1: v[j],
+                        v2: v[k],
+                        normals: None,
+                        geom_id: 0,
+                        prim_id: id,
+                        mask: MASK_ALL,
+                    }));
+                    id += 1;
+                }
+            }
+        }
+        out
+    }
+
+    /// Records *why* the packets are 4 wide and not 8.
+    ///
+    /// The obvious next step from a 4-wide leaf intersector is an 8-wide one
+    /// (AVX2). It would buy nothing here: with `MIN_LEAF_PACKED` at 4 and
+    /// the SAH free to split above it, no leaf on a dense mesh holds more
+    /// than four triangles, so a leaf already costs exactly one 4-lane
+    /// round — and one 8-lane round, with half the lanes idle. This test
+    /// asserts that equality, so if a future retune makes leaves bigger
+    /// (raising `MIN_LEAF_PACKED`, or `MAX_LEAF` with a cheaper leaf cost)
+    /// it fails and says the trade-off has changed.
+    #[test]
+    fn eight_wide_packets_would_not_reduce_vector_rounds() {
+        let bvh = Bvh::new(uv_sphere_prims(80, 40));
+        let per_leaf: Vec<usize> = bvh
+            .leaves
+            .iter()
+            .map(|leaf| {
+                bvh.packets[leaf.pkt_first as usize..(leaf.pkt_first + leaf.pkt_count) as usize]
+                    .iter()
+                    .map(|p| p.active.count_ones() as usize)
+                    .sum()
+            })
+            .collect();
+
+        let max = per_leaf.iter().copied().max().unwrap_or(0);
+        assert!(max > 0, "no triangles ended up in leaves");
+        assert!(
+            max <= 4,
+            "a leaf holds {max} triangles — 8-wide packets are now worth evaluating"
+        );
+
+        let rounds4: usize = per_leaf.iter().map(|n| n.div_ceil(4)).sum();
+        let rounds8: usize = per_leaf.iter().map(|n| n.div_ceil(8)).sum();
+        assert_eq!(
+            rounds4, rounds8,
+            "8-wide packets would cut vector rounds {rounds4} -> {rounds8}; \
+             widening the leaf intersector is worth revisiting"
+        );
+    }
+}

--- a/crates/crust-rt/src/bvh.rs
+++ b/crates/crust-rt/src/bvh.rs
@@ -8,19 +8,25 @@
 //! binned *spatial* split, which chops straddling references in two at the
 //! split plane (bounds via `Prim::clipped_aabb` — exact polygon clipping
 //! for triangles) and duplicates them into both children. The cheaper
-//! split wins. Leaves therefore index into a shared `indices` array (a
-//! primitive can appear in several leaves) while the primitives
-//! themselves are stored exactly once.
+//! split wins. A primitive can therefore appear in several leaves, while
+//! the primitives themselves are stored exactly once.
 //!
 //! The binary tree is then collapsed into 4-wide SoA nodes whose slab
-//! tests run on `Vec4` lanes. Large subtrees build in parallel via
-//! `rayon::join`; every split decision depends only on the input, so the
-//! tree is deterministic — threads only change *when* subtrees are built,
-//! never *what*.
+//! tests run on `Vec4` lanes, with the lane verdicts extracted as a bitmask
+//! rather than read back one at a time. Each leaf's payload lands in the
+//! separate `leaves` table — which keeps [`WideNode`] at two cache lines —
+//! and its triangles are packed into 4-wide [`Tri4`] packets so a leaf
+//! intersects four triangles per vector round; everything else (spheres,
+//! curves, instances) keeps a scalar index in `indices`.
+//!
+//! Large subtrees build in parallel via `rayon::join`; every split decision
+//! depends only on the input, so the tree is deterministic — threads only
+//! change *when* subtrees are built, never *what*.
 
 use crate::aabb::AABB;
-use crate::prim::{Prim, PrimHit};
+use crate::prim::{Prim, PrimHit, TrianglePrim};
 use crate::ray::Ray;
+use crate::triangle::{RayShear, Tri4};
 use glam::{Vec3A, Vec4};
 
 /// Leaves are forced at this depth so the traversal stack can never
@@ -28,6 +34,15 @@ use glam::{Vec3A, Vec4};
 const MAX_DEPTH: usize = 60;
 /// Ranges at or below this size always become a leaf.
 const MIN_LEAF: usize = 2;
+/// The leaf floor for ranges made *entirely* of triangles. Those are
+/// intersected four at a time by one SIMD packet, so a 4-primitive leaf
+/// costs the same vector round as a 1-primitive one — stopping at 2 would
+/// leave half the lanes idle and pay for a node test that buys nothing.
+/// Non-packable primitives (spheres, curves, instances) keep [`MIN_LEAF`]:
+/// for them a bigger leaf really is more work. Measured on the
+/// `ray_throughput` example, raising the floor for everything cost
+/// instanced scenes ~12% while raising it for triangles alone gains ~12%.
+const MIN_LEAF_PACKED: usize = 4;
 /// A range no larger than this may stay a leaf when splitting is not
 /// worth it by SAH cost; larger ranges are always split.
 const MAX_LEAF: usize = 8;
@@ -54,12 +69,22 @@ struct Node {
     count: u32,
 }
 
-/// Marks an unused lane of a [`WideNode`] (together with `count == 0`).
+/// Marks an unused lane of a [`WideNode`].
 const EMPTY_LANE: u32 = u32::MAX;
+
+/// Lane-validity bits of [`WideNode::flags`] (bit `k` = lane `k` holds a
+/// real child) and leaf bits (bit `4 + k` = that child is a leaf).
+const VALID_MASK: u32 = 0b1111;
+const LEAF_SHIFT: u32 = 4;
 
 /// A 4-wide BVH node in SoA layout: lane `k` of each `Vec4` holds child
 /// `k`'s slab bounds, so one round of vector min/max tests all four child
 /// boxes against the ray at once (Embree's BVH4 idea).
+///
+/// Exactly 128 bytes (two cache lines): six `Vec4`s, one child index per
+/// lane, and the flag nibbles. The leaf payload — how many primitives, and
+/// where their SIMD packets live — sits in the separate [`Leaf`] table
+/// rather than in the node, which is what keeps the node this small.
 struct WideNode {
     bmin_x: Vec4,
     bmin_y: Vec4,
@@ -67,17 +92,35 @@ struct WideNode {
     bmax_x: Vec4,
     bmax_y: Vec4,
     bmax_z: Vec4,
-    /// Leaf lane (`count > 0`): first offset into `indices`. Internal lane
-    /// (`count == 0`): wide-node index, or [`EMPTY_LANE`].
+    /// Leaf lane: index into the BVH's `leaves`. Internal lane: index into
+    /// `wide`. Unused lane: [`EMPTY_LANE`].
     child: [u32; 4],
-    count: [u32; 4],
+    /// Bits 0..4: lane `k` holds a real child. Bits 4..8: that child is a
+    /// leaf.
+    ///
+    /// The validity bits exist because unused lanes carry +INF/+INF
+    /// bounds, which *usually* fail the slab test but not always: for
+    /// `t_max == INF` and an all-positive ray direction the test reduces to
+    /// `INF <= INF`. Traversal ANDs the nibble into the SIMD hit mask — one
+    /// integer `and` in place of four per-lane branches.
+    flags: u32,
+}
+
+/// A leaf's payload: the 4-wide triangle packets to run, plus the leftover
+/// primitives (spheres, curves, instances, and the triangles that did not
+/// fill a packet's worth) that still go one at a time.
+struct Leaf {
+    /// Range in the BVH's `packets`.
+    pkt_first: u32,
+    pkt_count: u32,
+    /// Range in the BVH's `indices`.
+    idx_first: u32,
+    idx_count: u32,
 }
 
 impl WideNode {
     fn empty() -> Self {
         WideNode {
-            // +INF/+INF bounds: the swapped slab test can never pass them
-            // (an *inverted* box would — min/max swapping un-inverts it).
             bmin_x: Vec4::INFINITY,
             bmin_y: Vec4::INFINITY,
             bmin_z: Vec4::INFINITY,
@@ -85,7 +128,7 @@ impl WideNode {
             bmax_y: Vec4::INFINITY,
             bmax_z: Vec4::INFINITY,
             child: [EMPTY_LANE; 4],
-            count: [0; 4],
+            flags: 0,
         }
     }
 
@@ -96,13 +139,27 @@ impl WideNode {
         self.bmax_x[lane] = b.maximum.x;
         self.bmax_y[lane] = b.maximum.y;
         self.bmax_z[lane] = b.maximum.z;
+        self.flags |= 1 << lane;
+    }
+
+    #[inline]
+    fn is_leaf(&self, lane: usize) -> bool {
+        self.flags & (1 << (LEAF_SHIFT + lane as u32)) != 0
+    }
+
+    fn mark_leaf(&mut self, lane: usize) {
+        self.flags |= 1 << (LEAF_SHIFT + lane as u32);
     }
 }
 
 pub(crate) struct Bvh {
     wide: Vec<WideNode>,
-    /// Leaf ranges index into this; spatial splits may list a primitive in
-    /// more than one leaf.
+    /// Leaf payloads, indexed by a leaf lane's `child`.
+    leaves: Vec<Leaf>,
+    /// 4-wide triangle packets, grouped per leaf.
+    packets: Vec<Tri4>,
+    /// The one-at-a-time primitives of each leaf; spatial splits may list a
+    /// primitive in more than one leaf.
     indices: Vec<u32>,
     /// The primitives, stored once each, in input order.
     prims: Vec<Box<dyn Prim>>,
@@ -142,17 +199,20 @@ impl Bvh {
             })
             .collect();
 
-        let (wide, indices, root_bbox) = if refs.is_empty() {
-            (Vec::new(), Vec::new(), None)
+        let (wide, collected, root_bbox) = if refs.is_empty() {
+            (Vec::new(), LeafData::default(), None)
         } else {
             let root_bbox = union_all(&refs);
             let subtree = build_subtree(&prims, refs, 0, surface_area(&root_bbox));
-            (collapse(&subtree.nodes), subtree.indices, Some(root_bbox))
+            let (wide, collected) = collapse(&subtree.nodes, &subtree.indices, &prims);
+            (wide, collected, Some(root_bbox))
         };
 
         Bvh {
             wide,
-            indices,
+            leaves: collected.leaves,
+            packets: collected.packets,
+            indices: collected.indices,
             prims,
             root_bbox,
         }
@@ -160,6 +220,24 @@ impl Bvh {
 
     pub(crate) fn prim_count(&self) -> usize {
         self.prims.len()
+    }
+
+    /// The per-ray Woop shear, derived once per traversal — but only for
+    /// scenes that actually hold triangle packets. It costs two divides,
+    /// which is real money on a scene of spheres or instances that would
+    /// never look at it.
+    #[inline]
+    fn shear(&self, ray: &Ray) -> Option<RayShear> {
+        (!self.packets.is_empty()).then(|| RayShear::new(ray))
+    }
+
+    /// Total primitive references held by leaves — packed SIMD lanes plus
+    /// scalar indices. Larger than `prim_count` exactly when spatial splits
+    /// duplicated references.
+    #[cfg(test)]
+    fn leaf_ref_count(&self) -> usize {
+        let packed: u32 = self.packets.iter().map(|p| p.active.count_ones()).sum();
+        packed as usize + self.indices.len()
     }
 
     pub(crate) fn bounds(&self) -> Option<AABB> {
@@ -174,8 +252,11 @@ impl Bvh {
         let mut closest = t_max;
         let mut best: Option<PrimHit> = None;
 
-        let o = ray.origin;
-        let inv = Vec3A::new(safe_inv(ray.dir.x), safe_inv(ray.dir.y), safe_inv(ray.dir.z));
+        // Splat the ray into SoA lanes once for the whole traversal
+        // instead of once per visited node, and likewise derive the Woop
+        // shear once instead of once per triangle.
+        let rs = RaySlab::new(ray, t_min);
+        let shear = self.shear(ray);
 
         let mut stack = [0u32; WIDE_STACK];
         stack[0] = 0;
@@ -184,44 +265,49 @@ impl Bvh {
         while sp > 0 {
             sp -= 1;
             let node = &self.wide[stack[sp] as usize];
-            let (tnear, tfar) = slab4(node, o, inv, t_min, closest);
+            let (tnear, tfar) = rs.slab4(node, closest);
 
-            // Hit lanes, insertion-sorted near-to-far (≤ 4 entries).
+            // One vector compare + one movmskps gives all four lane
+            // verdicts as a nibble; the validity bits drop unused lanes.
+            let mut mask = tnear.cmple(tfar).bitmask() & node.flags & VALID_MASK;
+            if mask == 0 {
+                continue;
+            }
+
+            // Hit lanes, insertion-sorted near-to-far (≤ 4 entries). The
+            // distances are read from one spilled copy of the vector
+            // rather than re-extracting a lane at a time.
+            let tn = tnear.to_array();
             let mut order = [(0f32, 0usize); 4];
             let mut n_hit = 0;
-            for l in 0..4 {
-                if node.count[l] == 0 && node.child[l] == EMPTY_LANE {
-                    continue;
+            while mask != 0 {
+                let l = mask.trailing_zeros() as usize;
+                mask &= mask - 1;
+                let t = tn[l];
+                let mut i = n_hit;
+                while i > 0 && order[i - 1].0 > t {
+                    order[i] = order[i - 1];
+                    i -= 1;
                 }
-                if tnear[l] <= tfar[l] {
-                    let mut i = n_hit;
-                    while i > 0 && order[i - 1].0 > tnear[l] {
-                        order[i] = order[i - 1];
-                        i -= 1;
-                    }
-                    order[i] = (tnear[l], l);
-                    n_hit += 1;
-                }
+                order[i] = (t, l);
+                n_hit += 1;
             }
 
             // Leaf lanes intersect immediately (near first, shrinking
             // `closest`); internal lanes are pushed far-to-near so the
             // nearest pops first.
-            for i in 0..n_hit {
-                let l = order[i].1;
-                if node.count[l] > 0 {
-                    let first = node.child[l] as usize;
-                    for &pi in &self.indices[first..first + node.count[l] as usize] {
-                        if let Some(hit) = self.prims[pi as usize].hit(ray, t_min, closest) {
-                            closest = hit.t;
-                            best = Some(hit);
-                        }
-                    }
+            for &(_, l) in &order[..n_hit] {
+                if node.is_leaf(l)
+                    && let Some(hit) =
+                        self.intersect_leaf(node.child[l], ray, shear.as_ref(), t_min, closest)
+                {
+                    closest = hit.t;
+                    best = Some(hit);
                 }
             }
             for i in (0..n_hit).rev() {
                 let l = order[i].1;
-                if node.count[l] == 0 {
+                if !node.is_leaf(l) {
                     stack[sp] = node.child[l];
                     sp += 1;
                 }
@@ -231,14 +317,83 @@ impl Bvh {
         best
     }
 
+    /// Closest hit within one leaf: the 4-wide triangle packets first (four
+    /// triangles per vector round), then whatever did not fit a packet.
+    #[inline]
+    fn intersect_leaf(
+        &self,
+        leaf_idx: u32,
+        ray: &Ray,
+        shear: Option<&RayShear>,
+        t_min: f32,
+        t_max: f32,
+    ) -> Option<PrimHit> {
+        let leaf = &self.leaves[leaf_idx as usize];
+        let mut closest = t_max;
+        let mut best: Option<PrimHit> = None;
+
+        let first = leaf.pkt_first as usize;
+        for packet in &self.packets[first..first + leaf.pkt_count as usize] {
+            let shear = shear.expect("a leaf with packets implies the scene has triangles");
+            let out = packet.intersect(shear, ray.mask, t_min, closest);
+            let mut hits = out.hits;
+            while hits != 0 {
+                let lane = hits.trailing_zeros() as usize;
+                hits &= hits - 1;
+                // Lanes were tested against the `closest` on entry, which
+                // earlier lanes may since have shrunk. The comparison is
+                // strict-greater, not greater-or-equal, so an exact tie
+                // resolves to the later primitive exactly as a run of
+                // scalar `hit` calls would.
+                if out.t[lane] > closest {
+                    continue;
+                }
+                let tri = self.triangle(packet.prim[lane]);
+                if let Some(hit) = tri.hit_from_barycentric(out.t[lane], out.u[lane], out.v[lane]) {
+                    closest = hit.t;
+                    best = Some(hit);
+                }
+            }
+            // Lanes sitting exactly on an edge: the f64 tie-break is scalar.
+            let mut fb = out.fallback;
+            while fb != 0 {
+                let lane = fb.trailing_zeros() as usize;
+                fb &= fb - 1;
+                let pi = packet.prim[lane] as usize;
+                if let Some(hit) = self.prims[pi].hit(ray, t_min, closest) {
+                    closest = hit.t;
+                    best = Some(hit);
+                }
+            }
+        }
+
+        let first = leaf.idx_first as usize;
+        for &pi in &self.indices[first..first + leaf.idx_count as usize] {
+            if let Some(hit) = self.prims[pi as usize].hit(ray, t_min, closest) {
+                closest = hit.t;
+                best = Some(hit);
+            }
+        }
+        best
+    }
+
+    /// The triangle a packet lane came from. Packets are only built from
+    /// primitives that answered `as_triangle`, so this always resolves.
+    #[inline]
+    fn triangle(&self, prim_idx: u32) -> &TrianglePrim {
+        self.prims[prim_idx as usize]
+            .as_triangle()
+            .expect("packet lanes are built from triangles only")
+    }
+
     /// Early-exit occlusion traversal: no ordering, returns on the first
     /// confirmed hit anywhere in `(t_min, t_max)`.
     pub(crate) fn hit_any(&self, ray: &Ray, t_min: f32, t_max: f32) -> bool {
         if self.wide.is_empty() {
             return false;
         }
-        let o = ray.origin;
-        let inv = Vec3A::new(safe_inv(ray.dir.x), safe_inv(ray.dir.y), safe_inv(ray.dir.z));
+        let rs = RaySlab::new(ray, t_min);
+        let shear = self.shear(ray);
 
         let mut stack = [0u32; WIDE_STACK];
         stack[0] = 0;
@@ -247,20 +402,14 @@ impl Bvh {
         while sp > 0 {
             sp -= 1;
             let node = &self.wide[stack[sp] as usize];
-            let (tnear, tfar) = slab4(node, o, inv, t_min, t_max);
-            for l in 0..4 {
-                if node.count[l] == 0 && node.child[l] == EMPTY_LANE {
-                    continue;
-                }
-                if tnear[l] > tfar[l] {
-                    continue;
-                }
-                if node.count[l] > 0 {
-                    let first = node.child[l] as usize;
-                    for &pi in &self.indices[first..first + node.count[l] as usize] {
-                        if self.prims[pi as usize].hit_any(ray, t_min, t_max) {
-                            return true;
-                        }
+            let (tnear, tfar) = rs.slab4(node, t_max);
+            let mut mask = tnear.cmple(tfar).bitmask() & node.flags & VALID_MASK;
+            while mask != 0 {
+                let l = mask.trailing_zeros() as usize;
+                mask &= mask - 1;
+                if node.is_leaf(l) {
+                    if self.occlude_leaf(node.child[l], ray, shear.as_ref(), t_min, t_max) {
+                        return true;
                     }
                 } else {
                     stack[sp] = node.child[l];
@@ -270,18 +419,62 @@ impl Bvh {
         }
         false
     }
+
+    /// Boolean variant of [`Bvh::intersect_leaf`]: any lane hitting anywhere
+    /// in range ends the query, so there is no ordering and no need to
+    /// resolve which lane won.
+    #[inline]
+    fn occlude_leaf(
+        &self,
+        leaf_idx: u32,
+        ray: &Ray,
+        shear: Option<&RayShear>,
+        t_min: f32,
+        t_max: f32,
+    ) -> bool {
+        let leaf = &self.leaves[leaf_idx as usize];
+
+        let first = leaf.pkt_first as usize;
+        for packet in &self.packets[first..first + leaf.pkt_count as usize] {
+            // Matching `TrianglePrim::hit_any`, occlusion needs no normal:
+            // any lane in range occludes.
+            let shear = shear.expect("a leaf with packets implies the scene has triangles");
+            let out = packet.intersect(shear, ray.mask, t_min, t_max);
+            if out.hits != 0 {
+                return true;
+            }
+            let mut fb = out.fallback;
+            while fb != 0 {
+                let lane = fb.trailing_zeros() as usize;
+                fb &= fb - 1;
+                if self.prims[packet.prim[lane] as usize].hit_any(ray, t_min, t_max) {
+                    return true;
+                }
+            }
+        }
+
+        let first = leaf.idx_first as usize;
+        for &pi in &self.indices[first..first + leaf.idx_count as usize] {
+            if self.prims[pi as usize].hit_any(ray, t_min, t_max) {
+                return true;
+            }
+        }
+        false
+    }
 }
 
-/// Finite reciprocal of a direction component: zero (and denormal-tiny)
+/// Finite reciprocal of every direction component: zero (and denormal-tiny)
 /// components become a huge same-signed value instead of ±∞, so the slab
 /// arithmetic can never produce the 0·∞ = NaN that poisons vector min/max.
+/// Branch-free and component-wise, so all three lanes go through one
+/// divide and one select.
 #[inline]
-fn safe_inv(x: f32) -> f32 {
-    if x.abs() < 1e-20 {
-        1e20f32.copysign(x)
-    } else {
-        1.0 / x
-    }
+fn safe_inv3(d: Vec3A) -> Vec3A {
+    const TINY: f32 = 1e-20;
+    const HUGE: f32 = 1e20;
+    // `copysign` via a sign-bit blend: `HUGE` with `d`'s sign bit.
+    let huge = Vec3A::splat(HUGE).copysign(d);
+    Vec3A::select(d.abs().cmplt(Vec3A::splat(TINY)), huge, d.recip())
 }
 
 /// Traversal stack: wide depth ≤ binary `MAX_DEPTH`, and each visited node
@@ -289,27 +482,58 @@ fn safe_inv(x: f32) -> f32 {
 /// the worst case.
 const WIDE_STACK: usize = 3 * MAX_DEPTH + 4;
 
-/// The 4-lane slab test: entry/exit distances for all four child boxes of
-/// `node` at once. A lane hits iff `tnear[l] <= tfar[l]`.
-#[inline]
-fn slab4(node: &WideNode, o: Vec3A, inv: Vec3A, t_min: f32, t_max: f32) -> (Vec4, Vec4) {
-    let t0x = (node.bmin_x - Vec4::splat(o.x)) * Vec4::splat(inv.x);
-    let t1x = (node.bmax_x - Vec4::splat(o.x)) * Vec4::splat(inv.x);
-    let t0y = (node.bmin_y - Vec4::splat(o.y)) * Vec4::splat(inv.y);
-    let t1y = (node.bmax_y - Vec4::splat(o.y)) * Vec4::splat(inv.y);
-    let t0z = (node.bmin_z - Vec4::splat(o.z)) * Vec4::splat(inv.z);
-    let t1z = (node.bmax_z - Vec4::splat(o.z)) * Vec4::splat(inv.z);
-    let tnear = t0x
-        .min(t1x)
-        .max(t0y.min(t1y))
-        .max(t0z.min(t1z))
-        .max(Vec4::splat(t_min));
-    let tfar = t0x
-        .max(t1x)
-        .min(t0y.max(t1y))
-        .min(t0z.max(t1z))
-        .min(Vec4::splat(t_max));
-    (tnear, tfar)
+/// The ray, pre-broadcast into the SoA layout the 4-wide slab test wants.
+/// Built once per traversal: the six splats and the reciprocal used to be
+/// recomputed for every visited node, which is pure overhead in a loop
+/// that visits tens of nodes per ray.
+struct RaySlab {
+    ox: Vec4,
+    oy: Vec4,
+    oz: Vec4,
+    ix: Vec4,
+    iy: Vec4,
+    iz: Vec4,
+    t_min: Vec4,
+}
+
+impl RaySlab {
+    #[inline]
+    fn new(ray: &Ray, t_min: f32) -> Self {
+        let o = ray.origin;
+        let inv = safe_inv3(ray.dir);
+        RaySlab {
+            ox: Vec4::splat(o.x),
+            oy: Vec4::splat(o.y),
+            oz: Vec4::splat(o.z),
+            ix: Vec4::splat(inv.x),
+            iy: Vec4::splat(inv.y),
+            iz: Vec4::splat(inv.z),
+            t_min: Vec4::splat(t_min),
+        }
+    }
+
+    /// The 4-lane slab test: entry/exit distances for all four child boxes
+    /// of `node` at once. A lane hits iff `tnear[l] <= tfar[l]`.
+    #[inline]
+    fn slab4(&self, node: &WideNode, t_max: f32) -> (Vec4, Vec4) {
+        let t0x = (node.bmin_x - self.ox) * self.ix;
+        let t1x = (node.bmax_x - self.ox) * self.ix;
+        let t0y = (node.bmin_y - self.oy) * self.iy;
+        let t1y = (node.bmax_y - self.oy) * self.iy;
+        let t0z = (node.bmin_z - self.oz) * self.iz;
+        let t1z = (node.bmax_z - self.oz) * self.iz;
+        let tnear = t0x
+            .min(t1x)
+            .max(t0y.min(t1y))
+            .max(t0z.min(t1z))
+            .max(self.t_min);
+        let tfar = t0x
+            .max(t1x)
+            .min(t0y.max(t1y))
+            .min(t0z.max(t1z))
+            .min(Vec4::splat(t_max));
+        (tnear, tfar)
+    }
 }
 
 fn surface_area(b: &AABB) -> f32 {
@@ -568,7 +792,8 @@ fn build_subtree(
 ) -> Subtree {
     let bbox = union_all(&refs);
     let count = refs.len();
-    if count <= MIN_LEAF || depth >= MAX_DEPTH {
+    let min_leaf = min_leaf_for(prims, &refs);
+    if count <= min_leaf || depth >= MAX_DEPTH {
         return leaf(bbox, &refs);
     }
 
@@ -667,7 +892,7 @@ fn object_partition_or_leaf(
 ) -> Subtree {
     let count = refs.len();
     match object {
-        Some(o) if count > MIN_LEAF => {
+        Some(o) if count > min_leaf_for(prims, &refs) => {
             let (l, r) = partition_by_bin(&mut refs, &o);
             if l.is_empty() || r.is_empty() {
                 let mut all = l;
@@ -679,6 +904,20 @@ fn object_partition_or_leaf(
             merge(bbox, left, right)
         }
         _ => leaf(bbox, &refs),
+    }
+}
+
+/// The leaf-size floor for this range: [`MIN_LEAF_PACKED`] when every
+/// reference is a triangle (so the leaf becomes exactly one SIMD packet),
+/// [`MIN_LEAF`] otherwise.
+fn min_leaf_for(prims: &[Box<dyn Prim>], refs: &[PrimRef]) -> usize {
+    if refs
+        .iter()
+        .all(|r| prims[r.idx as usize].as_triangle().is_some())
+    {
+        MIN_LEAF_PACKED
+    } else {
+        MIN_LEAF
     }
 }
 
@@ -698,30 +937,103 @@ fn partition_by_bin(refs: &mut Vec<PrimRef>, o: &ObjSplit) -> (Vec<PrimRef>, Vec
     (left, right)
 }
 
+/// Everything the collapse pass emits besides the nodes themselves: one
+/// [`Leaf`] per leaf lane, the triangle packets those leaves run, and the
+/// re-ordered one-at-a-time primitive indices.
+#[derive(Default)]
+struct LeafData {
+    leaves: Vec<Leaf>,
+    packets: Vec<Tri4>,
+    indices: Vec<u32>,
+}
+
+impl LeafData {
+    /// Turns one binary leaf's primitive range into a [`Leaf`]: triangles
+    /// are packed four to a SIMD packet, everything else keeps its scalar
+    /// index. Returns the new leaf's index.
+    ///
+    /// Packets are emitted contiguously per leaf, so a leaf's packets are
+    /// one linear sweep of memory at traversal time.
+    fn push_leaf(&mut self, range: &[u32], prims: &[Box<dyn Prim>]) -> u32 {
+        let pkt_first = self.packets.len() as u32;
+        let mut batch: Vec<(Vec3A, Vec3A, Vec3A, u32, u32)> = Vec::with_capacity(4);
+        let idx_first = self.indices.len() as u32;
+        let mut idx_count = 0u32;
+
+        for &pi in range {
+            match prims[pi as usize].as_triangle() {
+                Some(t) => {
+                    batch.push((t.v0, t.v1, t.v2, pi, t.mask));
+                    if batch.len() == 4 {
+                        self.packets.push(Tri4::new(&batch));
+                        batch.clear();
+                    }
+                }
+                None => {
+                    self.indices.push(pi);
+                    idx_count += 1;
+                }
+            }
+        }
+        if !batch.is_empty() {
+            // A partial tail packet still beats scalar calls: the unused
+            // lanes ride along for free.
+            self.packets.push(Tri4::new(&batch));
+        }
+
+        self.leaves.push(Leaf {
+            pkt_first,
+            pkt_count: self.packets.len() as u32 - pkt_first,
+            idx_first,
+            idx_count,
+        });
+        self.leaves.len() as u32 - 1
+    }
+}
+
 /// Collapses the binary tree into 4-wide nodes: each wide node adopts its
 /// binary node's two children, then repeatedly replaces the largest-area
 /// internal child with that child's own two children until four lanes are
-/// filled (or only leaves remain). Purely input-driven, so determinism is
-/// preserved.
-fn collapse(binary: &[Node]) -> Vec<WideNode> {
+/// filled (or only leaves remain). Leaf lanes are converted to [`Leaf`]
+/// entries with their triangles packed into SIMD packets as they are
+/// reached. Purely input-driven, so determinism is preserved.
+fn collapse(
+    binary: &[Node],
+    indices: &[u32],
+    prims: &[Box<dyn Prim>],
+) -> (Vec<WideNode>, LeafData) {
     let mut out = Vec::with_capacity(binary.len() / 2 + 1);
+    let mut data = LeafData::default();
     if binary.is_empty() {
-        return out;
+        return (out, data);
     }
     if binary[0].count > 0 {
         // Single-leaf tree.
         let mut w = WideNode::empty();
         w.set_lane_bounds(0, &binary[0].bbox);
-        w.child[0] = binary[0].first_or_right;
-        w.count[0] = binary[0].count;
+        w.child[0] = data.push_leaf(leaf_range(&binary[0], indices), prims);
+        w.mark_leaf(0);
         out.push(w);
-        return out;
+        return (out, data);
     }
-    collapse_node(binary, 0, &mut out);
-    out
+    collapse_node(binary, indices, prims, 0, &mut out, &mut data);
+    (out, data)
 }
 
-fn collapse_node(binary: &[Node], b_idx: u32, out: &mut Vec<WideNode>) -> u32 {
+/// The slice of `indices` a binary leaf owns.
+fn leaf_range<'a>(node: &Node, indices: &'a [u32]) -> &'a [u32] {
+    let first = node.first_or_right as usize;
+    &indices[first..first + node.count as usize]
+}
+
+fn collapse_node(
+    binary: &[Node],
+    indices: &[u32],
+    prims: &[Box<dyn Prim>],
+    b_idx: u32,
+    out: &mut Vec<WideNode>,
+    data: &mut LeafData,
+) -> u32 {
     let slot = out.len();
     out.push(WideNode::empty());
 
@@ -753,10 +1065,10 @@ fn collapse_node(binary: &[Node], b_idx: u32, out: &mut Vec<WideNode>) -> u32 {
         let bounds = binary[k].bbox;
         out[slot].set_lane_bounds(lane, &bounds);
         if binary[k].count > 0 {
-            out[slot].child[lane] = binary[k].first_or_right;
-            out[slot].count[lane] = binary[k].count;
+            out[slot].child[lane] = data.push_leaf(leaf_range(&binary[k], indices), prims);
+            out[slot].mark_leaf(lane);
         } else {
-            let ci = collapse_node(binary, kids[lane], out);
+            let ci = collapse_node(binary, indices, prims, kids[lane], out, data);
             out[slot].child[lane] = ci;
         }
     }
@@ -876,16 +1188,55 @@ mod tests {
     }
 
     /// Diagonal shards must actually produce duplicated references —
-    /// otherwise the spatial-split path is dead code.
+    /// otherwise the spatial-split path is dead code. References live in
+    /// two places now: packed SIMD lanes and the scalar `indices` list.
     #[test]
     fn spatial_splits_duplicate_references() {
         let bvh = Bvh::new(diagonal_shards(64));
+        let refs = bvh.leaf_ref_count();
         assert!(
-            bvh.indices.len() > bvh.prims.len(),
-            "no reference duplication: {} indices for {} prims",
-            bvh.indices.len(),
+            refs > bvh.prims.len(),
+            "no reference duplication: {refs} leaf references for {} prims",
             bvh.prims.len()
         );
+    }
+
+    /// Every leaf reference must land in exactly one place, and every
+    /// triangle must be packed rather than left on the scalar path.
+    #[test]
+    fn triangles_are_packed_into_simd_lanes() {
+        let bvh = Bvh::new(diagonal_shards(64));
+        assert!(!bvh.packets.is_empty(), "no packets built for a triangle scene");
+        assert!(
+            bvh.indices.is_empty(),
+            "{} triangles fell back to the scalar list",
+            bvh.indices.len()
+        );
+
+        // Spheres are not packable and must stay on the scalar path.
+        let bvh = Bvh::new(sphere_grid(4));
+        assert!(bvh.packets.is_empty(), "spheres must not be packed");
+        assert_eq!(bvh.indices.len(), bvh.leaf_ref_count());
+
+        // Mixed leaves must place each primitive on exactly one path.
+        let mut mixed = diagonal_shards(16);
+        mixed.extend(sphere_grid(2));
+        let bvh = Bvh::new(mixed);
+        assert!(!bvh.packets.is_empty() && !bvh.indices.is_empty());
+        assert!(bvh.leaf_ref_count() >= bvh.prims.len());
+    }
+
+    /// Packet lanes must average close to 4 on a dense mesh — a packing
+    /// that mostly emitted 1-lane packets would be SIMD in name only.
+    #[test]
+    fn packets_are_well_filled() {
+        let bvh = Bvh::new(diagonal_shards(256));
+        let lanes: u32 = bvh.packets.iter().map(|p| p.active.count_ones()).sum();
+        let avg = lanes as f32 / bvh.packets.len() as f32;
+        // `MIN_LEAF_PACKED` is what keeps this high — ~2.9 of 4 on this
+        // scene, against ~1.7 when the leaf floor was 2. Below 2.5 means
+        // the floor has drifted away from the SIMD width again.
+        assert!(avg >= 2.5, "average packet occupancy {avg} of 4 lanes");
     }
 
     /// `hit_any` must agree with `hit(..).is_some()` for every ray and range.
@@ -916,6 +1267,15 @@ mod tests {
         }
     }
 
+    /// Node size is a load-bearing claim, not a comment: the leaf payload
+    /// was moved into a side table precisely so the node still fits two
+    /// cache lines. Growing it would silently cost traversal bandwidth.
+    #[test]
+    fn wide_node_is_two_cache_lines() {
+        assert_eq!(std::mem::size_of::<WideNode>(), 128);
+        assert_eq!(std::mem::align_of::<WideNode>(), 16);
+    }
+
     /// Parallel subtree builds must not change the tree: the same input
     /// always produces byte-identical topology.
     #[test]
@@ -924,9 +1284,15 @@ mod tests {
         let b = Bvh::new(sphere_grid(6));
         assert_eq!(a.wide.len(), b.wide.len());
         assert_eq!(a.indices, b.indices);
+        assert_eq!(a.packets.len(), b.packets.len());
+        assert_eq!(a.leaves.len(), b.leaves.len());
+        for (x, y) in a.leaves.iter().zip(&b.leaves) {
+            assert_eq!((x.pkt_first, x.pkt_count), (y.pkt_first, y.pkt_count));
+            assert_eq!((x.idx_first, x.idx_count), (y.idx_first, y.idx_count));
+        }
         for (x, y) in a.wide.iter().zip(&b.wide) {
             assert_eq!(x.child, y.child);
-            assert_eq!(x.count, y.count);
+            assert_eq!(x.flags, y.flags);
             assert_eq!(x.bmin_x, y.bmin_x);
             assert_eq!(x.bmax_z, y.bmax_z);
         }
@@ -940,10 +1306,10 @@ mod tests {
         let n_leaf_slots: usize = bvh
             .wide
             .iter()
-            .flat_map(|w| w.count.iter())
-            .filter(|&&c| c > 0)
-            .count();
+            .map(|w| (0..4).filter(|&l| w.is_leaf(l)).count())
+            .sum();
         assert!(n_leaf_slots > 0);
+        assert_eq!(n_leaf_slots, bvh.leaves.len());
         // A binary tree over L leaves has L-1 internal nodes; BVH4 should
         // need roughly a third of that.
         assert!(

--- a/crates/crust-rt/src/lib.rs
+++ b/crates/crust-rt/src/lib.rs
@@ -25,8 +25,8 @@
 //! What Embree calls `rtcIntersect1` / `rtcOccluded1` are
 //! [`Scene::intersect`] / [`Scene::occluded`]; geometry types map to the
 //! [`Geometry`] enum (triangle meshes with optional per-vertex shading
-//! normals, analytic spheres, round curve segments, and single-level
-//! instances with optional transform motion blur); per-geometry visibility
+//! normals, analytic spheres, round curve segments, and instances — which
+//! nest — with optional transform motion blur); per-geometry visibility
 //! masks test against the ray's category bit exactly like Embree's. Hits
 //! carry `geom_id`/`prim_id` — the application owns the mapping from IDs
 //! to materials or anything else; this crate never sees shading data.

--- a/crates/crust-rt/src/prim.rs
+++ b/crates/crust-rt/src/prim.rs
@@ -34,6 +34,13 @@ pub(crate) trait Prim: Send + Sync {
 
     fn bbox(&self) -> AABB;
 
+    /// `Some` for triangles, which the BVH groups into 4-wide SIMD packets
+    /// when it builds its leaves. Avoids downcasting: a primitive simply
+    /// declares whether it can join a packet.
+    fn as_triangle(&self) -> Option<&TrianglePrim> {
+        None
+    }
+
     /// Conservative bounds of the part inside the axis slab, for the
     /// BVH's spatial splits. Default: bbox clipped to the slab.
     fn clipped_aabb(&self, axis: usize, min: f32, max: f32) -> Option<AABB> {
@@ -69,12 +76,11 @@ pub(crate) struct TrianglePrim {
     pub mask: u32,
 }
 
-impl Prim for TrianglePrim {
-    fn hit(&self, ray: &Ray, t_min: f32, t_max: f32) -> Option<PrimHit> {
-        if masked_out(ray, self.mask) {
-            return None;
-        }
-        let (t, u, v) = triangle_intersect(ray, self.v0, self.v1, self.v2, t_min, t_max)?;
+impl TrianglePrim {
+    /// Completes a hit whose `(t, u, v)` are already known — the shared tail
+    /// of the scalar and the 4-wide SIMD intersectors, so both derive the
+    /// reported normal the same way.
+    pub(crate) fn hit_from_barycentric(&self, t: f32, u: f32, v: f32) -> Option<PrimHit> {
         let outward = match &self.normals {
             Some([n0, n1, n2]) => (*n0 * (1.0 - u - v) + *n1 * u + *n2 * v).normalize(),
             None => {
@@ -94,6 +100,16 @@ impl Prim for TrianglePrim {
             prim_id: self.prim_id,
         })
     }
+}
+
+impl Prim for TrianglePrim {
+    fn hit(&self, ray: &Ray, t_min: f32, t_max: f32) -> Option<PrimHit> {
+        if masked_out(ray, self.mask) {
+            return None;
+        }
+        let (t, u, v) = triangle_intersect(ray, self.v0, self.v1, self.v2, t_min, t_max)?;
+        self.hit_from_barycentric(t, u, v)
+    }
 
     fn hit_any(&self, ray: &Ray, t_min: f32, t_max: f32) -> bool {
         !masked_out(ray, self.mask)
@@ -102,6 +118,10 @@ impl Prim for TrianglePrim {
 
     fn bbox(&self) -> AABB {
         triangle_aabb(self.v0, self.v1, self.v2)
+    }
+
+    fn as_triangle(&self) -> Option<&TrianglePrim> {
+        Some(self)
     }
 
     fn clipped_aabb(&self, axis: usize, min: f32, max: f32) -> Option<AABB> {

--- a/crates/crust-rt/src/scene.rs
+++ b/crates/crust-rt/src/scene.rs
@@ -23,7 +23,9 @@ pub struct CurveSegment {
 
 /// A geometry to attach to a scene. The variants mirror Embree's geometry
 /// types (the subset crust needs): triangle meshes, analytic spheres,
-/// round curves, and single-level instances of another committed scene.
+/// round curves, and instances of another committed scene. Instances nest:
+/// an instanced scene may itself contain instances, and transforms,
+/// normals and ray masks compose correctly through every level.
 pub enum Geometry {
     TriangleMesh {
         vertices: Vec<Vec3A>,
@@ -312,6 +314,157 @@ mod tests {
             .expect("inside hit");
         assert!(!inside.front_face);
         assert!(inside.normal.abs_diff_eq(-Vec3A::Z, 1e-4));
+    }
+
+    /// Does the kernel already nest instances? An `Instance` holds an
+    /// `Arc<Scene>`, and nothing stops that scene from containing
+    /// instances of its own — this asks whether the recursion actually
+    /// works end to end, or only looks like it should.
+    #[test]
+    fn instances_nest() {
+        // Level 0: a unit sphere at the origin.
+        let leaf = unit_sphere_scene();
+
+        // Level 1: two spheres, at local x = ±2.
+        let mut mid = SceneBuilder::new();
+        for x in [-2.0f32, 2.0] {
+            mid.attach(Geometry::Instance {
+                scene: Arc::clone(&leaf),
+                transform: Affine3A::from_translation(glam::Vec3::new(x, 0.0, 0.0)),
+                transform_end: None,
+            });
+        }
+        let mid = Arc::new(mid.commit());
+
+        // Level 2: two copies of that pair, at world y = ±5. Four spheres
+        // in total, from one copy of the sphere's geometry.
+        let mut root = SceneBuilder::new();
+        for y in [-5.0f32, 5.0] {
+            root.attach(Geometry::Instance {
+                scene: Arc::clone(&mid),
+                transform: Affine3A::from_translation(glam::Vec3::new(0.0, y, 0.0)),
+                transform_end: None,
+            });
+        }
+        let scene = root.commit();
+
+        // Two top-level primitives hold four spheres.
+        assert_eq!(scene.primitive_count(), 2);
+
+        for (x, y) in [(-2.0f32, -5.0f32), (2.0, -5.0), (-2.0, 5.0), (2.0, 5.0)] {
+            let ray = Ray::new(Vec3A::new(x, y, -8.0), Vec3A::Z);
+            let hit = scene
+                .intersect(&ray, 0.001, 100.0)
+                .unwrap_or_else(|| panic!("nested sphere at ({x}, {y}) was missed"));
+            assert!(
+                (hit.t - 7.0).abs() < 1e-3,
+                "nested sphere at ({x}, {y}): t = {} (want 7)",
+                hit.t
+            );
+            assert!(
+                hit.normal.abs_diff_eq(-Vec3A::Z, 1e-4),
+                "nested normal wrong at ({x}, {y}): {:?}",
+                hit.normal
+            );
+            assert!(scene.occluded(&ray, 0.001, 100.0));
+        }
+
+        // And nothing where the spheres are not.
+        assert!(
+            scene
+                .intersect(&Ray::new(Vec3A::new(0.0, 0.0, -8.0), Vec3A::Z), 0.001, 100.0)
+                .is_none(),
+            "hit between the nested spheres"
+        );
+    }
+
+    /// Nested instances must compose transforms in the right order, and
+    /// map normals back through both levels. A rotation at the outer level
+    /// and a non-uniform scale at the inner level do not commute, so this
+    /// fails loudly if the composition is inverted.
+    #[test]
+    fn nested_instances_compose_transforms_and_normals() {
+        // Inner: a unit sphere squashed to an ellipsoid by the mid level.
+        let leaf = unit_sphere_scene();
+        let mut mid = SceneBuilder::new();
+        mid.attach(Geometry::Instance {
+            scene: leaf,
+            // 2x along local X only.
+            transform: Affine3A::from_scale(glam::Vec3::new(2.0, 1.0, 1.0)),
+            transform_end: None,
+        });
+        let mid = Arc::new(mid.commit());
+
+        // Outer: rotate that ellipsoid 90 degrees about Z, so its long
+        // axis ends up along world Y.
+        let mut root = SceneBuilder::new();
+        root.attach(Geometry::Instance {
+            scene: mid,
+            transform: Affine3A::from_rotation_z(std::f32::consts::FRAC_PI_2),
+            transform_end: None,
+        });
+        let scene = root.commit();
+
+        // Long axis is now Y: a ray down the Y axis meets the surface at
+        // |y| = 2, while one down X meets it at |x| = 1.
+        let along_y = scene
+            .intersect(&Ray::new(Vec3A::new(0.0, -8.0, 0.0), Vec3A::Y), 0.001, 100.0)
+            .expect("ray along Y must hit the rotated ellipsoid");
+        assert!(
+            (along_y.t - 6.0).abs() < 1e-3,
+            "long axis is not along Y: t = {} (want 6)",
+            along_y.t
+        );
+        let along_x = scene
+            .intersect(&Ray::new(Vec3A::new(-8.0, 0.0, 0.0), Vec3A::X), 0.001, 100.0)
+            .expect("ray along X must hit the rotated ellipsoid");
+        assert!(
+            (along_x.t - 7.0).abs() < 1e-3,
+            "short axis is not along X: t = {} (want 7)",
+            along_x.t
+        );
+
+        // The normal at the Y pole points back down -Y; an inverse
+        // transpose applied at only one level would tilt it.
+        assert!(
+            along_y.normal.abs_diff_eq(-Vec3A::Y, 1e-4),
+            "nested normal not mapped through both levels: {:?}",
+            along_y.normal
+        );
+    }
+
+    /// A ray mask must gate at every level of nesting: hiding the outer
+    /// instance hides everything beneath it.
+    #[test]
+    fn nested_instances_respect_masks_at_each_level() {
+        let leaf = unit_sphere_scene();
+        let mut mid = SceneBuilder::new();
+        mid.attach_masked(
+            Geometry::Instance {
+                scene: leaf,
+                transform: Affine3A::IDENTITY,
+                transform_end: None,
+            },
+            MASK_SHADOW,
+        );
+        let mid = Arc::new(mid.commit());
+
+        let mut root = SceneBuilder::new();
+        root.attach_masked(
+            Geometry::Instance {
+                scene: mid,
+                transform: Affine3A::IDENTITY,
+                transform_end: None,
+            },
+            MASK_SHADOW | MASK_CAMERA,
+        );
+        let scene = root.commit();
+
+        let ray = Ray::new(Vec3A::new(0.0, 0.0, -5.0), Vec3A::Z);
+        // The inner level only admits shadow rays, so a camera ray is
+        // rejected there even though the outer level would allow it.
+        assert!(scene.intersect(&ray.with_mask(MASK_CAMERA), 0.001, 100.0).is_none());
+        assert!(scene.intersect(&ray.with_mask(MASK_SHADOW), 0.001, 100.0).is_some());
     }
 
     #[test]

--- a/crates/crust-rt/src/triangle.rs
+++ b/crates/crust-rt/src/triangle.rs
@@ -1,8 +1,84 @@
 //! Watertight ray/triangle intersection and exact triangle clipping.
+//!
+//! Two intersectors share one set of formulas: a scalar one for single
+//! triangles ([`triangle_intersect`]) and a 4-wide SIMD one for the BVH's
+//! leaf packets ([`Tri4::intersect`]). The Woop transform splits cleanly
+//! along that seam — the axis permutation and shear depend only on the
+//! *ray* ([`RayShear`]), so a packet computes them once and amortizes them
+//! over four triangles, and the per-triangle work is pure arithmetic that
+//! maps directly onto `Vec4` lanes.
+//!
+//! The two paths are written to produce *bit-identical* results (same
+//! operations, same order, no FMA contraction), which
+//! `simd_matches_scalar_bitwise` pins.
 
 use crate::aabb::AABB;
 use crate::ray::Ray;
-use glam::Vec3A;
+use glam::{Vec3A, Vec4};
+
+/// The per-ray constants of the Woop transform: which axis permutation
+/// sends the ray direction to +Z, and the shear that straightens it.
+/// Shared by every triangle a ray is tested against, so the BVH builds one
+/// per traversal and hands it to each leaf packet.
+pub(crate) struct RayShear {
+    kx: usize,
+    ky: usize,
+    kz: usize,
+    sx: f32,
+    sy: f32,
+    sz: f32,
+    /// The ray origin's permuted components, pre-splatted for the packet
+    /// path.
+    okx: Vec4,
+    oky: Vec4,
+    okz: Vec4,
+    sx4: Vec4,
+    sy4: Vec4,
+    sz4: Vec4,
+}
+
+impl RayShear {
+    pub(crate) fn new(ray: &Ray) -> Self {
+        let d = ray.dir;
+
+        // Permute so the dominant direction axis is Z; swap X/Y when
+        // d.z < 0 so the winding (and edge-function signs) are preserved.
+        let ad = d.abs();
+        let kz = if ad.x > ad.y {
+            if ad.x > ad.z { 0 } else { 2 }
+        } else if ad.y > ad.z {
+            1
+        } else {
+            2
+        };
+        let mut kx = (kz + 1) % 3;
+        let mut ky = (kz + 2) % 3;
+        if d[kz] < 0.0 {
+            std::mem::swap(&mut kx, &mut ky);
+        }
+
+        // Shear constants mapping the ray direction onto +Z.
+        let sx = d[kx] / d[kz];
+        let sy = d[ky] / d[kz];
+        let sz = 1.0 / d[kz];
+
+        let o = ray.origin;
+        RayShear {
+            kx,
+            ky,
+            kz,
+            sx,
+            sy,
+            sz,
+            okx: Vec4::splat(o[kx]),
+            oky: Vec4::splat(o[ky]),
+            okz: Vec4::splat(o[kz]),
+            sx4: Vec4::splat(sx),
+            sy4: Vec4::splat(sy),
+            sz4: Vec4::splat(sz),
+        }
+    }
+}
 
 /// Watertight ray/triangle intersection (Woop, Benthin & Wald 2013,
 /// "Watertight Ray/Triangle Intersection"). Returns `(t, u, v)` where `u`
@@ -26,33 +102,27 @@ pub(crate) fn triangle_intersect(
     t_min: f32,
     t_max: f32,
 ) -> Option<(f32, f32, f32)> {
-    let d = ray.dir;
+    triangle_intersect_sheared(&RayShear::new(ray), ray.origin, v0, v1, v2, t_min, t_max)
+}
 
-    // Permute so the dominant direction axis is Z; swap X/Y when d.z < 0 so
-    // the winding (and edge-function signs) are preserved.
-    let ad = d.abs();
-    let kz = if ad.x > ad.y {
-        if ad.x > ad.z { 0 } else { 2 }
-    } else if ad.y > ad.z {
-        1
-    } else {
-        2
-    };
-    let mut kx = (kz + 1) % 3;
-    let mut ky = (kz + 2) % 3;
-    if d[kz] < 0.0 {
-        std::mem::swap(&mut kx, &mut ky);
-    }
-
-    // Shear constants mapping the ray direction onto +Z.
-    let sx = d[kx] / d[kz];
-    let sy = d[ky] / d[kz];
-    let sz = 1.0 / d[kz];
+/// [`triangle_intersect`] with the per-ray shear already computed — the
+/// form the packet path's f64 fallback lanes take.
+pub(crate) fn triangle_intersect_sheared(
+    sh: &RayShear,
+    origin: Vec3A,
+    v0: Vec3A,
+    v1: Vec3A,
+    v2: Vec3A,
+    t_min: f32,
+    t_max: f32,
+) -> Option<(f32, f32, f32)> {
+    let (kx, ky, kz) = (sh.kx, sh.ky, sh.kz);
+    let (sx, sy, sz) = (sh.sx, sh.sy, sh.sz);
 
     // Vertices relative to the ray origin, sheared into ray space.
-    let a = v0 - ray.origin;
-    let b = v1 - ray.origin;
-    let c = v2 - ray.origin;
+    let a = v0 - origin;
+    let b = v1 - origin;
+    let c = v2 - origin;
     let ax = a[kx] - sx * a[kz];
     let ay = a[ky] - sy * a[kz];
     let bx = b[kx] - sx * b[kz];
@@ -99,6 +169,193 @@ pub(crate) fn triangle_intersect(
 
     let inv_det = 1.0 / det;
     Some((t_scaled * inv_det, e1 * inv_det, e2 * inv_det))
+}
+
+/// Four triangles in structure-of-arrays layout: `v[i][axis]` holds vertex
+/// `i`'s `axis` component across all four lanes, so the whole packet is
+/// nine `Vec4`s and the intersector never shuffles.
+///
+/// Packets are built per BVH leaf at commit time. A leaf with a triangle
+/// count that is not a multiple of four leaves the tail lanes inactive
+/// (their vertices are set to the last real triangle's, so the arithmetic
+/// stays finite and the lanes are dropped by `active`).
+pub(crate) struct Tri4 {
+    v: [[Vec4; 3]; 3],
+    /// Index into the BVH's primitive array per lane — how a hit gets back
+    /// to its shading normals and IDs.
+    pub prim: [u32; 4],
+    /// Bit `k` set iff lane `k` holds a real triangle.
+    pub active: u32,
+    /// AND / OR of the active lanes' visibility masks. Together they give a
+    /// two-compare fast path: `ray.mask & mask_and != 0` means every lane
+    /// is visible (the overwhelmingly common case), `ray.mask & mask_or == 0`
+    /// means none is, and only a genuinely mixed packet pays per-lane tests.
+    mask_and: u32,
+    mask_or: u32,
+    masks: [u32; 4],
+}
+
+/// Per-lane outcome of [`Tri4::intersect`].
+pub(crate) struct Hit4 {
+    /// Lanes that hit; their `t`/`u`/`v` entries are valid.
+    pub hits: u32,
+    /// Lanes where an edge function came out exactly 0.0. The f64 tie-break
+    /// that keeps adjacent triangles watertight is inherently scalar, so
+    /// these lanes carry no verdict here — the caller must re-test them
+    /// with [`triangle_intersect_sheared`]. Rare in practice (it takes a
+    /// ray passing exactly through an edge or vertex), so the branch costs
+    /// nothing on real geometry.
+    pub fallback: u32,
+    pub t: [f32; 4],
+    pub u: [f32; 4],
+    pub v: [f32; 4],
+}
+
+impl Tri4 {
+    /// Packs up to four triangles. `tris` shorter than 4 leaves the tail
+    /// lanes inactive.
+    pub(crate) fn new(tris: &[(Vec3A, Vec3A, Vec3A, u32, u32)]) -> Self {
+        debug_assert!(!tris.is_empty() && tris.len() <= 4);
+        let mut v = [[Vec4::ZERO; 3]; 3];
+        let mut prim = [u32::MAX; 4];
+        let mut masks = [0u32; 4];
+        let mut active = 0u32;
+        let mut mask_and = u32::MAX;
+        let mut mask_or = 0u32;
+        for lane in 0..4 {
+            // Inactive tail lanes duplicate the last real triangle: the
+            // lane is masked off anyway, and duplicating keeps the values
+            // finite (a zeroed lane would be a degenerate triangle whose
+            // edge functions are all exactly 0.0, needlessly tripping the
+            // f64 fallback on every query).
+            let (v0, v1, v2, pi, mask) = tris[lane.min(tris.len() - 1)];
+            for axis in 0..3 {
+                v[0][axis][lane] = v0[axis];
+                v[1][axis][lane] = v1[axis];
+                v[2][axis][lane] = v2[axis];
+            }
+            if lane < tris.len() {
+                prim[lane] = pi;
+                masks[lane] = mask;
+                active |= 1 << lane;
+                mask_and &= mask;
+                mask_or |= mask;
+            }
+        }
+        Tri4 {
+            v,
+            prim,
+            active,
+            mask_and,
+            mask_or,
+            masks,
+        }
+    }
+
+    /// The lanes this ray's category is allowed to see.
+    #[inline]
+    fn visible_lanes(&self, ray_mask: u32) -> u32 {
+        if ray_mask & self.mask_and != 0 {
+            return self.active;
+        }
+        if ray_mask & self.mask_or == 0 {
+            return 0;
+        }
+        let mut m = 0;
+        for lane in 0..4 {
+            if self.active & (1 << lane) != 0 && self.masks[lane] & ray_mask != 0 {
+                m |= 1 << lane;
+            }
+        }
+        m
+    }
+
+    /// Intersects all four triangles at once. Every step is the `Vec4`
+    /// transcription of the scalar path above, in the same order, so a
+    /// lane's `t`/`u`/`v` are bit-identical to the scalar result.
+    pub(crate) fn intersect(&self, sh: &RayShear, ray_mask: u32, t_min: f32, t_max: f32) -> Hit4 {
+        let mut m = self.visible_lanes(ray_mask);
+        if m == 0 {
+            return Hit4::MISS;
+        }
+
+        let (kx, ky, kz) = (sh.kx, sh.ky, sh.kz);
+
+        // Vertices relative to the ray origin, sheared into ray space.
+        let akz = self.v[0][kz] - sh.okz;
+        let bkz = self.v[1][kz] - sh.okz;
+        let ckz = self.v[2][kz] - sh.okz;
+        let ax = (self.v[0][kx] - sh.okx) - sh.sx4 * akz;
+        let ay = (self.v[0][ky] - sh.oky) - sh.sy4 * akz;
+        let bx = (self.v[1][kx] - sh.okx) - sh.sx4 * bkz;
+        let by = (self.v[1][ky] - sh.oky) - sh.sy4 * bkz;
+        let cx = (self.v[2][kx] - sh.okx) - sh.sx4 * ckz;
+        let cy = (self.v[2][ky] - sh.oky) - sh.sy4 * ckz;
+
+        // Signed 2D edge functions; e0 is opposite v0, etc.
+        let e0 = bx * cy - by * cx;
+        let e1 = cx * ay - cy * ax;
+        let e2 = ax * by - ay * bx;
+
+        let zero = Vec4::ZERO;
+        // Lanes sitting exactly on an edge go to the scalar f64 path, and
+        // leave the SIMD verdict entirely — a lane the sign test below
+        // rejects may well be a hit once the ties are resolved in f64.
+        let fallback =
+            m & (e0.cmpeq(zero).bitmask() | e1.cmpeq(zero).bitmask() | e2.cmpeq(zero).bitmask());
+        m &= !fallback;
+
+        // Inside iff the three edge functions share a sign.
+        let neg = e0.cmplt(zero).bitmask() | e1.cmplt(zero).bitmask() | e2.cmplt(zero).bitmask();
+        let pos = e0.cmpgt(zero).bitmask() | e1.cmpgt(zero).bitmask() | e2.cmpgt(zero).bitmask();
+        m &= !(neg & pos);
+
+        let det = e0 + e1 + e2;
+        m &= !det.cmpeq(zero).bitmask();
+        if m == 0 {
+            return Hit4 {
+                hits: 0,
+                fallback,
+                ..Hit4::MISS
+            };
+        }
+
+        // Scaled hit distance, range-tested without a division. The scalar
+        // path branches on det's sign; here the same test is a single
+        // sign-flip: `t_scaled * sign(det)` compared against
+        // `t_min * |det|` and `t_max * |det|`.
+        let t_scaled = e0 * (sh.sz4 * akz) + e1 * (sh.sz4 * bkz) + e2 * (sh.sz4 * ckz);
+        let abs_det = det.abs();
+        let ts = Vec4::select(det.cmplt(zero), -t_scaled, t_scaled);
+        m &= ts.cmpge(Vec4::splat(t_min) * abs_det).bitmask();
+        m &= ts.cmple(Vec4::splat(t_max) * abs_det).bitmask();
+        if m == 0 {
+            return Hit4 {
+                hits: 0,
+                fallback,
+                ..Hit4::MISS
+            };
+        }
+
+        let inv_det = Vec4::ONE / det;
+        Hit4 {
+            hits: m,
+            fallback,
+            t: (t_scaled * inv_det).to_array(),
+            u: (e1 * inv_det).to_array(),
+            v: (e2 * inv_det).to_array(),
+        }
+    }
+}
+
+impl Hit4 {
+    const MISS: Hit4 = Hit4 {
+        hits: 0,
+        fallback: 0,
+        t: [0.0; 4],
+        u: [0.0; 4],
+        v: [0.0; 4],
+    };
 }
 
 /// Exact bounds of a triangle clipped to the axis slab `[min, max]`:
@@ -258,6 +515,169 @@ mod tests {
             })
             .count();
         assert!(hits >= 1, "ray through shared vertex missed the whole fan");
+    }
+
+    /// The 4-wide intersector is a lane-for-lane transcription of the
+    /// scalar one, so it must agree *bit-for-bit* — not within an epsilon.
+    /// Anything looser would mean the two paths can disagree about a hit
+    /// near an edge, which is exactly what watertightness forbids.
+    #[test]
+    fn simd_matches_scalar_bitwise() {
+        // A cheap LCG, so the case list is fixed but not hand-picked.
+        let mut state = 0x1234_5678u32;
+        let mut next = || {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            (state >> 8) as f32 / (1u32 << 24) as f32 - 0.5
+        };
+
+        let mut compared = 0;
+        let mut hits = 0;
+        for _ in 0..2000 {
+            let tris: Vec<(Vec3A, Vec3A, Vec3A, u32, u32)> = (0..4)
+                .map(|i| {
+                    let base = Vec3A::new(next(), next(), next()) * 4.0;
+                    (
+                        base + Vec3A::new(next(), next(), next()),
+                        base + Vec3A::new(next(), next(), next()),
+                        base + Vec3A::new(next(), next(), next()),
+                        i as u32,
+                        crate::ray::MASK_ALL,
+                    )
+                })
+                .collect();
+            let packet = Tri4::new(&tris);
+
+            let origin = Vec3A::new(next(), next(), next()) * 6.0;
+            // Half the rays are aimed at a barycentric point of one of the
+            // four triangles (so hits are common), half are arbitrary (so
+            // near-misses and the range tests get exercised too).
+            let aimed = next() > 0.0;
+            let dir = if aimed {
+                let pick = ((next() + 0.5) * 4.0) as usize % 4;
+                let (v0, v1, v2, _, _) = tris[pick];
+                let (a, b) = (next() + 0.5, next() + 0.5);
+                let (a, b) = if a + b > 1.0 { (1.0 - a, 1.0 - b) } else { (a, b) };
+                (v0 + (v1 - v0) * a + (v2 - v0) * b) - origin
+            } else {
+                Vec3A::new(next(), next(), next())
+            };
+            if dir.length_squared() < 1e-8 {
+                continue;
+            }
+            let r = ray(origin, dir.normalize());
+            let sh = RayShear::new(&r);
+            let out = packet.intersect(&sh, crate::ray::MASK_ALL, 0.001, f32::INFINITY);
+
+            for (lane, &(v0, v1, v2, _, _)) in tris.iter().enumerate() {
+                let scalar = triangle_intersect(&r, v0, v1, v2, 0.001, f32::INFINITY);
+                if out.fallback & (1 << lane) != 0 {
+                    continue; // routed to the scalar path by design
+                }
+                compared += 1;
+                match (out.hits & (1 << lane) != 0, scalar) {
+                    (true, Some((t, u, v))) => {
+                        hits += 1;
+                        assert_eq!(out.t[lane].to_bits(), t.to_bits(), "t differs, lane {lane}");
+                        assert_eq!(out.u[lane].to_bits(), u.to_bits(), "u differs, lane {lane}");
+                        assert_eq!(out.v[lane].to_bits(), v.to_bits(), "v differs, lane {lane}");
+                    }
+                    (false, None) => {}
+                    (simd, sc) => panic!(
+                        "hit disagreement on lane {lane}: simd={simd} scalar={}",
+                        sc.is_some()
+                    ),
+                }
+            }
+        }
+        assert!(compared > 7000, "only {compared} lanes compared");
+        assert!(hits > 50, "only {hits} hits — the test is not exercising hits");
+    }
+
+    /// Range tests must agree too: the packet folds the scalar path's
+    /// sign-of-det branch into one sign flip.
+    #[test]
+    fn simd_respects_t_range_like_scalar() {
+        let tri = (
+            Vec3A::new(-1.0, -1.0, 5.0),
+            Vec3A::new(1.0, -1.0, 5.0),
+            Vec3A::new(0.0, 1.0, 5.0),
+        );
+        // Both windings, so both signs of det are exercised.
+        let cases = [
+            (tri.0, tri.1, tri.2, 0u32, crate::ray::MASK_ALL),
+            (tri.0, tri.2, tri.1, 1u32, crate::ray::MASK_ALL),
+        ];
+        let packet = Tri4::new(&cases);
+        for (t_min, t_max) in [(0.001, 4.9), (5.1, 100.0), (0.001, f32::INFINITY), (4.9, 5.1)] {
+            for dir in [Vec3A::Z, -Vec3A::Z] {
+                let o = Vec3A::new(0.0, 0.0, if dir.z > 0.0 { 0.0 } else { 10.0 });
+                let r = ray(o, dir);
+                let out = packet.intersect(&RayShear::new(&r), crate::ray::MASK_ALL, t_min, t_max);
+                for (lane, &(v0, v1, v2, _, _)) in cases.iter().enumerate() {
+                    let scalar = triangle_intersect(&r, v0, v1, v2, t_min, t_max);
+                    assert_eq!(
+                        out.hits & (1 << lane) != 0,
+                        scalar.is_some(),
+                        "lane {lane} dir {dir:?} range ({t_min}, {t_max})"
+                    );
+                }
+            }
+        }
+    }
+
+    /// A partially-filled packet must never report its padding lanes.
+    #[test]
+    fn simd_inactive_lanes_never_hit() {
+        let one = [(
+            Vec3A::new(-1.0, -1.0, 5.0),
+            Vec3A::new(1.0, -1.0, 5.0),
+            Vec3A::new(0.0, 1.0, 5.0),
+            0u32,
+            crate::ray::MASK_ALL,
+        )];
+        let packet = Tri4::new(&one);
+        assert_eq!(packet.active, 0b0001);
+        let r = ray(Vec3A::ZERO, Vec3A::Z);
+        let out = packet.intersect(&RayShear::new(&r), crate::ray::MASK_ALL, 0.001, f32::INFINITY);
+        assert_eq!(out.hits, 0b0001, "only the real lane may hit");
+        assert_eq!(out.fallback & !0b0001, 0, "padding lanes must not fall back");
+    }
+
+    /// Per-lane visibility masks must gate lanes independently.
+    #[test]
+    fn simd_masks_gate_lanes() {
+        use crate::ray::{MASK_ALL, MASK_CAMERA, MASK_SHADOW};
+        let tri = |z: f32, pi: u32, mask: u32| {
+            (
+                Vec3A::new(-1.0, -1.0, z),
+                Vec3A::new(1.0, -1.0, z),
+                Vec3A::new(0.0, 1.0, z),
+                pi,
+                mask,
+            )
+        };
+        let cases = [
+            tri(5.0, 0, MASK_CAMERA),
+            tri(6.0, 1, MASK_SHADOW),
+            tri(7.0, 2, MASK_ALL),
+        ];
+        let packet = Tri4::new(&cases);
+        let r = ray(Vec3A::ZERO, Vec3A::Z);
+        let sh = RayShear::new(&r);
+        assert_eq!(
+            packet
+                .intersect(&sh, MASK_CAMERA, 0.001, f32::INFINITY)
+                .hits,
+            0b101
+        );
+        assert_eq!(
+            packet
+                .intersect(&sh, MASK_SHADOW, 0.001, f32::INFINITY)
+                .hits,
+            0b110
+        );
+        assert_eq!(packet.intersect(&sh, MASK_ALL, 0.001, f32::INFINITY).hits, 0b111);
+        assert_eq!(packet.intersect(&sh, 1 << 20, 0.001, f32::INFINITY).hits, 0b100);
     }
 
     /// Axis-aligned rays (a zero direction component on the dominant-axis

--- a/docs/embree_comparison.md
+++ b/docs/embree_comparison.md
@@ -142,7 +142,7 @@ when this document was first written; see the addendum in §4.)*
 | Quads / grids / subdivision | ✅ | ❌ (USD import triangulates) |
 | Curves / hair | ✅ 5 bases × 3 modes | ✅⁺ round linear segments; cubic bezier/bspline/catmullRom flattened |
 | User geometry | ✅ callbacks | ✅-ish (`Hittable` trait — same idea, idiomatic Rust) |
-| Instancing | ✅ multi-level + arrays | ✅⁺ single-level `Instance`, shared local-space BLAS with content dedup |
+| Instancing | ✅ multi-level + arrays | ✅ multi-level `Instance` (nests to any depth), shared local-space BLAS with content dedup; no instance *arrays* |
 | Motion blur | ✅ 2–129 steps, quaternion | ✅⁺ 2-step transform blur (linear matrix lerp) |
 | BVH arity | 4–8 wide, SIMD node tests | ✅⁺ 4-wide SoA nodes, `Vec4` slab tests |
 | Build quality tiers | low / medium / high(SBVH) / refit | ✅⁺ medium + SBVH spatial splits (α-gated) |

--- a/docs/simd.md
+++ b/docs/simd.md
@@ -24,13 +24,57 @@ error[E0658]: use of unstable library feature `portable_simd`
 ```
 
 It is still nightly-only (tracking issue rust-lang/rust#86656), and crust
-builds on stable. The stable options for wider-than-4 lanes are the `wide`
-crate or `core::arch` intrinsics behind `#[target_feature]` + runtime
-detection; neither is used today. See "Not done" below for when they would
-pay off.
+builds on stable.
 
 `glam` is deliberately kept on its default (SSE2) backend rather than its
 optional `core-simd` feature, which requires nightly for the same reason.
+
+### The 128-bit ceiling, and why it is where it is
+
+This is worth stating plainly rather than leaving implicit, because current
+practice disagrees with it. Kerkour's *SIMD programming in pure Rust* puts it
+bluntly: "it makes no sense to implement SSE2 SIMDs these days, as most
+processors produced since 2015 support AVX2." Everything vectorized here —
+`glam`'s `Vec3A`/`Vec4`, the BVH4 node test, the `Tri4` leaf packets — is
+128-bit. So why stop there?
+
+Two reasons, one measured and one structural.
+
+**Measured: widening the *codegen* buys almost nothing, because the
+algorithm is 4 lanes wide.** LLVM cannot turn a 4-lane algorithm into an
+8-lane one; enabling AVX2 only lets it pick FMA and better instruction
+sequences for the lanes already there.
+
+| min-of-40, ms | baseline (SSE2) | `-C target-feature=+avx2,+fma` |
+| --- | --- | --- |
+| `tri_spheres intersect` | 3.450 | 3.386 |
+| `sphere_grid intersect` | 1.697 | 1.622 |
+| `instances occluded` | 2.268 | 2.243 |
+
+2–4%. Real 8-wide throughput needs what the article describes as the generic
+recipe — split the work into chunks of X blocks where X is the lane count —
+applied to the data structures themselves, not a compiler flag.
+
+**Structural: for the leaves, there is no eighth lane to fill.** A histogram
+of leaf occupancy on a dense mesh (80×40 UV sphere, 6400 triangles):
+
+```
+ 1 tris/leaf:     13 leaves
+ 2 tris/leaf:    505 leaves
+ 3 tris/leaf:    601 leaves
+ 4 tris/leaf:   1200 leaves
+vector rounds if 4-wide: 2319   if 8-wide: 2319
+```
+
+No leaf holds more than four triangles, because the SAH is free to split
+anything above `MIN_LEAF_PACKED`. A `Tri8` packet would run the *same
+number* of vector rounds with half the lanes idle. This is pinned by
+`eight_wide_packets_would_not_reduce_vector_rounds`, which fails if a future
+retune makes leaves big enough to change the answer.
+
+That leaves **BVH8 nodes** — 8 child boxes per vector round, and roughly half
+the tree depth — as the one remaining place where 256-bit vectors would pay.
+It is not implemented; see "Not done".
 
 ## The two kinds of SIMD in a ray tracer
 
@@ -188,6 +232,21 @@ heavy enough for traversal to matter, which is what the stress scene is for.
 (Its 8.2 s wall clock is mostly parsing 15 MB of USDA and building the BVH;
 the `rendering()` figure above is the render itself.)
 
+## Testing across instruction sets
+
+`scripts/test_simd_matrix.sh` runs the suite under four codegen
+configurations (target defaults; AVX/AVX2/AVX-512 disabled; AVX2+FMA;
+`target-cpu=native`). This is not ceremony: the kernel's correctness claims
+are about exact float bit patterns — `simd_matches_scalar_bitwise` asserts
+`to_bits()` equality, and watertightness depends on adjacent triangles
+computing *exactly* equal edge functions. Contracting `a*b + c` into an FMA
+rounds once instead of twice and would break both. Rust does not contract by
+default, but that is worth re-verifying rather than assuming, especially
+across toolchain bumps. All four configurations pass.
+
+(GitHub Actions runners generally do not expose AVX-512, so that leg only
+really runs locally — as the article notes.)
+
 ## Correctness verification
 
 - `cargo test` — 33 tests in `crust-rt`, whole workspace green.
@@ -228,19 +287,53 @@ different bytes for identical pixels. Use `exr_diff`.
 - `crates/crust-render/examples/exr_diff.rs` — numeric diff of two rendered
   EXRs (differing pixel count, max absolute/relative, mean absolute, and the
   first few coordinates). The regression check for any kernel change.
+- `scripts/test_simd_matrix.sh` — the test suite across four SIMD codegen
+  configurations (see above).
+
+## References
+
+- Sylvain Kerkour, *SIMD programming in pure Rust* (January 2026) — the
+  load→compute→store framing, the "chunk into X = lane-count blocks" recipe,
+  the survey of stable options (`core::arch`, `wide`, `pulp`) and their
+  trade-offs, the advice not to hand-vectorize what LLVM already
+  auto-vectorizes, and the RUSTFLAGS test matrix. Its "don't bother with
+  SSE2" guidance is addressed directly under "The 128-bit ceiling" above.
+- Woop, Benthin & Wald, *Watertight Ray/Triangle Intersection* (JCGT 2013) —
+  the intersector both paths implement.
+- Stich, Friedrich & Dietrich, *Spatial Splits in Bounding Volume
+  Hierarchies* (2009) — the build the packets hang off.
 
 ## Not done
 
-- **8-wide (AVX2) nodes or packets.** The machine has AVX2 and AVX-512F, and
-  a BVH8 / `Tri8` would halve the vector rounds again. On stable this needs
-  the `wide` crate or `core::arch` + `#[target_feature]` with
-  `is_x86_feature_detected!` dispatch, since a plain `-C target-cpu=native`
-  build is not distributable. Deliberately left out: it doubles the
-  intersector code paths, and the node layout would want re-tuning again.
+- **BVH8 (8-wide) nodes.** The one place 256-bit vectors would still pay:
+  eight child boxes per vector round and roughly half the tree depth. Note
+  `Tri8` packets are ruled out by the occupancy data above — this is about
+  nodes only.
+
+  It is not just a matter of writing the 8-wide slab test, because the width
+  has to be *reachable at runtime*. The options, in the terms the article
+  lays out:
+
+  | approach | 256-bit at runtime? | cost |
+  | --- | --- | --- |
+  | `wide::f32x8` | only if built with `+avx2`; otherwise 2×SSE2 | +1 dep, safe |
+  | `core::arch` + `is_x86_feature_detected!` | yes, dispatched per host | needs `unsafe`, per-arch duplication |
+  | `multiversion` | yes | +1 dep, keeps call sites safe |
+  | `-C target-cpu=native` | yes | binary not distributable |
+
+  The middle option is the article's recommendation (stable, zero
+  dependencies) but it conflicts with a stated property of this crate:
+  `crust-rt`'s own docs say the implementation "stays 100% safe Rust", and
+  `CLAUDE.md` describes the project as written in safe Rust. Widening the
+  nodes is therefore a *project* decision about safety and dependencies, not
+  just an optimization, and is left for whoever owns that call.
 - **`-C target-cpu`.** Not set, so the shipped binary stays baseline
-  x86-64. Worth trying locally (`RUSTFLAGS="-C target-cpu=native"`) — it
-  lets LLVM use AVX2/FMA in the `Vec4` code — but it is not a portable
-  default and was not measured as part of this work.
+  x86-64. Measured above at 2–4% on the current 4-lane code; not a portable
+  default.
+- **NEON / wasm32.** Only x86-64 was measured. `glam` uses NEON on aarch64,
+  so the 128-bit paths carry over unchanged; nothing here is
+  x86-specific (no intrinsics, no `#[cfg(target_arch)]`), which is itself an
+  argument for keeping the kernel on `glam` until portable SIMD stabilizes.
 - **Ray packets / streams.** crust traces one ray at a time
   (`rtcIntersect1`-shaped). Tracing 4 or 8 *coherent* rays against one node
   is the other axis of SIMD in a tracer, and would need the integrator

--- a/docs/simd.md
+++ b/docs/simd.md
@@ -1,0 +1,256 @@
+# SIMD in crust
+
+An audit of where crust uses SIMD, what was changed to use more of it, and
+what is measured. Numbers below come from a 4-core Xeon @ 2.80 GHz
+(SSE2/AVX2/AVX-512F/FMA available), Rust 1.94.1 stable, `--release`.
+
+## What crust uses, and why not `std::simd`
+
+Every vector type in the renderer is a `glam` type, and on x86-64 `glam`'s
+`Vec3A`, `Vec4`, `Mat3A`, `Mat4`, `Affine3A` and `Quat` are backed by SSE2
+`__m128` registers. So the arithmetic in the hot paths — ray/sphere
+intersection, normal transforms, colour math, the BVH slab test — is already
+vectorized *horizontally*: one instruction operates on the three or four
+components of a vector.
+
+`std::simd` (the `portable_simd` feature) is **not** used, and cannot be on
+this toolchain:
+
+```
+$ rustc --version
+rustc 1.94.1 (e408947bf 2026-03-25)
+$ echo 'fn main(){ let _ = std::simd::f32x4::splat(1.0); }' | rustc - 2>&1 | head -2
+error[E0658]: use of unstable library feature `portable_simd`
+```
+
+It is still nightly-only (tracking issue rust-lang/rust#86656), and crust
+builds on stable. The stable options for wider-than-4 lanes are the `wide`
+crate or `core::arch` intrinsics behind `#[target_feature]` + runtime
+detection; neither is used today. See "Not done" below for when they would
+pay off.
+
+`glam` is deliberately kept on its default (SSE2) backend rather than its
+optional `core-simd` feature, which requires nightly for the same reason.
+
+## The two kinds of SIMD in a ray tracer
+
+Worth separating, because crust does one of them well and used to do the
+other not at all:
+
+- **Horizontal / AoS** — one instruction over the x, y, z of *one* vector.
+  This is what `glam` gives you for free. It wastes the fourth lane on
+  `Vec3A` and cannot vectorize a comparison chain, but it is effortless.
+- **Vertical / SoA** — one instruction over the *same component of four
+  different objects*. This is what BVH4 node tests and 4-triangle packets
+  do, and it is where the real throughput is: four boxes or four triangles
+  per vector round, no wasted lanes.
+
+The node slab test was already vertical (`WideNode` holds `bmin_x` as a
+`Vec4` across four children). Leaf intersection was not: it looped over
+`Box<dyn Prim>` and called a scalar intersector per triangle.
+
+## Changes
+
+### 1. Release codegen so the existing SIMD survives (`Cargo.toml`)
+
+`[profile.release]` now sets `lto = "thin"` and `codegen-units = 1`. The hot
+loop crosses three crates (`crust-core` → `crust-rt` → `glam`), all built
+from small `#[inline]` functions whose whole purpose is to disappear into
+their caller. With the default 16 codegen units and no LTO those calls
+survive as real calls and the vector bodies never fuse.
+
+Free, no source change:
+
+| | before | after |
+| --- | --- | --- |
+| `tri_spheres intersect` (criterion mean) | 6.71 ms | 5.32 ms (**−21%**) |
+
+### 2. Mask-driven BVH4 traversal (`bvh.rs`)
+
+The 4-wide slab test computed `(tnear, tfar)` as `Vec4`s and then threw the
+vectorization away, reading lanes back one at a time (`tnear[l] <= tfar[l]`,
+four times, plus four branches to skip unused lanes). Now:
+
+- `RaySlab` pre-broadcasts the ray origin, reciprocal direction and `t_min`
+  into `Vec4` lanes **once per traversal**, not once per visited node (the
+  old code rebuilt seven splats per node).
+- `safe_inv3` computes all three reciprocals component-wise and branch-free
+  (`copysign` + `select`) instead of three scalar calls with a branch each.
+- The lane verdicts come out as a nibble: `tnear.cmple(tfar).bitmask()` —
+  one compare plus one `movmskps`. Traversal iterates set bits with
+  `trailing_zeros`.
+- Lane validity moved into a bitmask (`WideNode::flags`) that is ANDed into
+  that nibble, replacing four per-lane branches with one integer `and`.
+  (An unused lane cannot simply be given empty bounds: the slab test's
+  per-axis min/max un-inverts an inverted box, and +INF/+INF bounds pass
+  when `t_max == INF` and the ray direction is all-positive.)
+
+### 3. 4-wide triangle packets in the leaves (`triangle.rs`, `bvh.rs`)
+
+The Woop et al. 2013 watertight intersector splits cleanly into a per-*ray*
+part and a per-*triangle* part: the axis permutation and shear depend only
+on the ray. So:
+
+- `RayShear` holds that per-ray part, derived once per traversal (it costs
+  two divides, previously paid once *per triangle*). It is only built for
+  scenes that actually contain packets — on sphere/instance scenes it would
+  be pure overhead.
+- `Tri4` holds four triangles in SoA layout (`v[vertex][axis]` as `Vec4`s)
+  plus each lane's primitive index and visibility mask. `Tri4::intersect`
+  is the `Vec4` transcription of the scalar path: edge functions, sign
+  test, determinant, and the range test — the last folded from the scalar
+  path's branch on `sign(det)` into one `select` (`t·sign(det)` against
+  `t_min·|det|` and `t_max·|det|`).
+- Per-lane visibility masks get a two-compare fast path: the packet stores
+  the AND and OR of its lanes' masks, so an all-visible packet (the normal
+  case) needs no per-lane test at all.
+- Leaf payloads moved out of the node into a separate `Leaf` table, which
+  keeps `WideNode` at exactly 128 bytes / two cache lines — the same size
+  as before, despite the node now needing to point at packets.
+
+**Watertightness is preserved exactly.** The scalar intersector re-evaluates
+edge functions in f64 whenever one comes out exactly `0.0`, which is what
+stops a ray crossing a shared edge from missing both triangles. That
+tie-break is inherently scalar, so `Tri4::intersect` reports those lanes in
+a `fallback` mask and takes no position on them; the caller re-tests them
+through the scalar path. The lanes are rare (it takes a ray passing exactly
+through an edge or vertex) so the branch costs nothing on real geometry.
+
+The two paths are written to be **bit-identical** — same operations, same
+order, no FMA contraction — and `simd_matches_scalar_bitwise` pins that with
+`to_bits()` equality over 2000 random packets (~8000 lanes), not an epsilon.
+Anything looser would mean the two paths could disagree about a hit near an
+edge, which is exactly what watertightness forbids.
+
+### 4. Leaf size retuned to the SIMD width (`bvh.rs`)
+
+With a 4-wide leaf intersector, `MIN_LEAF = 2` leaves half the lanes idle:
+measured packet occupancy was **1.66 of 4 lanes**. But raising the floor for
+*everything* makes sphere and instance leaves bigger for no benefit — that
+cost instanced scenes ~12%.
+
+`MIN_LEAF_PACKED = 4` therefore applies only to ranges made entirely of
+triangles (`min_leaf_for`). Occupancy rises to **2.89 of 4**, and both
+scene kinds get their best number:
+
+| min-of-40, ms | `MIN_LEAF=2` | `=4` for all | packed-only (chosen) |
+| --- | --- | --- | --- |
+| `tri_spheres intersect` | 3.814 | 3.365 | 3.426 |
+| `sphere_grid intersect` | 1.653 | 1.727 | 1.655 |
+| `instances intersect`   | 3.916 | 4.406 | 3.787 |
+
+### 5. `powf(x, 5.0)` → `powi(5)` in Schlick Fresnel (`material/brdf.rs`)
+
+Not a vector change, but a vectorization one: `powf` is an opaque libm call
+costing tens of cycles that the surrounding vector code cannot be optimized
+across. An integer exponent lowers to a multiply chain in registers. The
+same file already used `.powi(6)` two lines below — the three
+`powf(_, 5.0)` sites were simply missed. Fresnel runs on every glossy lobe
+of every shading event.
+
+`cornellbox` render: **9.09 s → 8.41 s (−7.5%)**, from three characters.
+Image difference is at most one ULP (max relative 3.1e-7).
+
+## Measured results
+
+Kernel throughput, `cargo run --release -p crust-rt --example ray_throughput`
+(min of 40 repeats over a fixed 4096-ray batch; both columns built with the
+LTO profile, so this isolates the SIMD work):
+
+| scene / query | before | after | change |
+| --- | --- | --- | --- |
+| `tri_spheres` (43k tris) intersect | 4.482 ms | 3.426 ms | **−23.6%** |
+| `tri_spheres` occluded | 3.126 ms | 1.925 ms | **−38.4%** |
+| `sphere_grid` (1728 spheres) intersect | 1.960 ms | 1.655 ms | **−15.6%** |
+| `sphere_grid` occluded | 1.451 ms | 0.931 ms | **−35.8%** |
+| `instances` (125 instances) intersect | 4.861 ms | 3.787 ms | **−22.1%** |
+| `instances` occluded | 3.546 ms | 2.313 ms | **−34.8%** |
+
+Occlusion gains more than closest-hit because its traversal is almost
+entirely node tests and early exits — the part that went from four scalar
+lane reads to one `movmskps`.
+
+End-to-end renders (min of 3, wall clock, versus original `main`):
+
+| scene | before | after | change |
+| --- | --- | --- | --- |
+| `scripts/gen_stress_scene.py` (383k tris), *render time* | 8.03 s | 6.35 s | **−21%** |
+| `samples/cornellbox.usda` | 9.14 s | 8.38 s | −8% |
+| `samples/openpbr_showcase.usda` | 3.97 s | 3.63 s | −9% |
+| `samples/smoke.usda` | 8.10 s | 7.98 s | −1.5% |
+
+The gap between the kernel numbers and the sample-scene numbers is the point
+worth remembering: **the checked-in sample scenes are shading- and
+sampling-bound, not traversal-bound.** They hold a handful of spheres and
+cubes, and spend their time in OpenPBR evaluation, sampling and volume
+integration. A 20–38% faster kernel only shows up end-to-end on geometry
+heavy enough for traversal to matter, which is what the stress scene is for.
+(Its 8.2 s wall clock is mostly parsing 15 MB of USDA and building the BVH;
+the `rendering()` figure above is the render itself.)
+
+## Correctness verification
+
+- `cargo test` — 33 tests in `crust-rt`, whole workspace green.
+- `simd_matches_scalar_bitwise` — the packet and scalar intersectors agree
+  bit-for-bit per lane, over hits, misses and both windings.
+- `simd_respects_t_range_like_scalar`, `simd_inactive_lanes_never_hit`,
+  `simd_masks_gate_lanes` — range tests, padding lanes and per-lane
+  visibility masks.
+- `packets_are_well_filled` — guards the leaf-floor / SIMD-width match.
+- `triangles_are_packed_into_simd_lanes` — every triangle is packed, no
+  primitive lands on both paths.
+- `build_is_deterministic` — extended to cover the new leaf and packet
+  tables.
+- The pre-existing `shared_edge_is_watertight` / `shared_vertex_is_covered`
+  and `matches_linear_scan` / `hit_any_matches_hit` tests still pass.
+- **Whole-image diff**: every sample scene was rendered before and after and
+  compared with `cargo run --release -p crust-render --example exr_diff`.
+  Seven of eight are **pixel-identical**. `cornellbox` differs in **1 pixel
+  of 230 400** by 4.6e-4, at the seam where the inner box's bottom face is
+  exactly coplanar with the floor — a genuine `t` tie between two
+  primitives, where either answer is correct and the winner depends on leaf
+  visit order. Confirmed not to be the retuned tree (it persists with
+  `MIN_LEAF_PACKED = 2`).
+
+Note that `cmp`-ing two EXR files is *not* a valid image comparison here:
+tile write order is nondeterministic, so the same binary run twice produces
+different bytes for identical pixels. Use `exr_diff`.
+
+## Tooling added
+
+- `crates/crust-rt/benches/traversal.rs` — criterion benchmarks for
+  `intersect`/`occluded` over triangle-mesh, analytic-sphere and instanced
+  scenes, plus the build. `cargo bench -p crust-rt`.
+- `crates/crust-rt/examples/ray_throughput.rs` — min-of-N throughput probe.
+  Criterion's *means* drift 10%+ on a shared machine; noise only ever adds
+  time, so the minimum is the better statistic for comparing two versions of
+  a kernel.
+- `crates/crust-render/examples/exr_diff.rs` — numeric diff of two rendered
+  EXRs (differing pixel count, max absolute/relative, mean absolute, and the
+  first few coordinates). The regression check for any kernel change.
+
+## Not done
+
+- **8-wide (AVX2) nodes or packets.** The machine has AVX2 and AVX-512F, and
+  a BVH8 / `Tri8` would halve the vector rounds again. On stable this needs
+  the `wide` crate or `core::arch` + `#[target_feature]` with
+  `is_x86_feature_detected!` dispatch, since a plain `-C target-cpu=native`
+  build is not distributable. Deliberately left out: it doubles the
+  intersector code paths, and the node layout would want re-tuning again.
+- **`-C target-cpu`.** Not set, so the shipped binary stays baseline
+  x86-64. Worth trying locally (`RUSTFLAGS="-C target-cpu=native"`) — it
+  lets LLVM use AVX2/FMA in the `Vec4` code — but it is not a portable
+  default and was not measured as part of this work.
+- **Ray packets / streams.** crust traces one ray at a time
+  (`rtcIntersect1`-shaped). Tracing 4 or 8 *coherent* rays against one node
+  is the other axis of SIMD in a tracer, and would need the integrator
+  restructured, not just the kernel.
+- **Vectorizing the shading path.** This is where the sample scenes actually
+  spend their time. OpenPBR evaluation is already `Vec3A`-based, so the win
+  there is not more horizontal SIMD but removing the remaining
+  transcendental calls from the inner loops and cutting branch divergence —
+  the `powf` → `powi` change above is one instance of a broader pattern.
+- **Curves and spheres in packets.** Only triangles pack today. A `Sphere4`
+  would help sphere-heavy scenes (`sphere_grid intersect` still runs its
+  leaves scalar); rounded cones are branchy enough that a 4-wide version
+  needs more care.

--- a/samples/instancing.usda
+++ b/samples/instancing.usda
@@ -1,0 +1,188 @@
+#usda 1.0
+(
+    doc = "Instancing: a UsdGeomPointInstancer scatter (with per-instance orientations, scales and invisibleIds) and natively-instanced `instanceable` prims sharing one prototype. Both cost one copy of the prototype geometry however many times it is placed."
+    defaultPrim = "World"
+    upAxis = "Y"
+)
+
+def Xform "World"
+{
+    def Camera "Cam"
+    {
+        float focalLength = 24
+        float horizontalAperture = 20.955
+        double3 xformOp:translate = (0, 3.2, 13)
+        float xformOp:rotateX = -8
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateX"]
+    }
+
+    # ------------------------------------------------------------------
+    # Native instancing. The prototype is a `class`, so it is never drawn
+    # in its own right; each `instanceable` prim referencing it becomes one
+    # instance sharing a single copy of the triangles.
+    # ------------------------------------------------------------------
+    class Xform "_Tower"
+    {
+        def Mesh "block" (prepend apiSchemas = ["MaterialBindingAPI"])
+        {
+            rel material:binding = </World/Looks/Copper>
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0,1,3,2, 4,6,7,5, 0,4,5,1, 2,3,7,6, 0,2,6,4, 1,5,7,3]
+            point3f[] points = [
+                (-0.5,-0.5,-0.5), (-0.5,-0.5,0.5), (-0.5,1.5,-0.5), (-0.5,1.5,0.5),
+                (0.5,-0.5,-0.5), (0.5,-0.5,0.5), (0.5,1.5,-0.5), (0.5,1.5,0.5)
+            ]
+        }
+
+        # A second, differently-bound mesh in the same prototype: the
+        # importer must keep both materials, which is why a prototype
+        # becomes one instance *per bound geometry* rather than one total.
+        def Mesh "cap" (prepend apiSchemas = ["MaterialBindingAPI"])
+        {
+            rel material:binding = </World/Looks/Emerald>
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0,1,3,2, 4,6,7,5, 0,4,5,1, 2,3,7,6, 0,2,6,4, 1,5,7,3]
+            point3f[] points = [
+                (-0.35,1.5,-0.35), (-0.35,1.5,0.35), (-0.35,2.0,-0.35), (-0.35,2.0,0.35),
+                (0.35,1.5,-0.35), (0.35,1.5,0.35), (0.35,2.0,-0.35), (0.35,2.0,0.35)
+            ]
+        }
+    }
+
+    def Xform "TowerA" (instanceable = true; references = </World/_Tower>)
+    {
+        double3 xformOp:translate = (-4.2, 0.5, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def Xform "TowerB" (instanceable = true; references = </World/_Tower>)
+    {
+        double3 xformOp:translate = (-2.2, 0.5, -1.5)
+        float xformOp:rotateY = 35
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateY"]
+    }
+
+    # Scaled instance: the shared prototype is placed by transform, so a
+    # non-uniform scale costs nothing extra.
+    def Xform "TowerC" (instanceable = true; references = </World/_Tower>)
+    {
+        double3 xformOp:translate = (-0.4, 0.5, 0.8)
+        float3 xformOp:scale = (0.6, 1.4, 0.6)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
+    }
+
+    # ------------------------------------------------------------------
+    # Vectorized instancing: one prototype, six placements from the
+    # per-instance arrays. `invisibleIds` hides one of them.
+    # ------------------------------------------------------------------
+    def PointInstancer "Scatter"
+    {
+        rel prototypes = [</World/Scatter/Protos/Gem>]
+
+        int[] protoIndices = [0, 0, 0, 0, 0, 0]
+        int64[] ids = [10, 11, 12, 13, 14, 15]
+        int64[] invisibleIds = [13]
+        point3f[] positions = [
+            (1.6, 0.55, 0), (2.9, 0.45, -1.1), (4.2, 0.75, 0.4),
+            (5.4, 0.5, -0.6), (2.2, 0.4, 1.6), (3.8, 0.6, 2.1)
+        ]
+        quatf[] orientationsf = [
+            (1, 0, 0, 0), (0.9239, 0, 0.3827, 0), (0.7071, 0, 0.7071, 0),
+            (0.9239, 0.3827, 0, 0), (0.8660, 0, 0, 0.5), (1, 0, 0, 0)
+        ]
+        float3[] scales = [
+            (1, 1, 1), (0.8, 0.8, 0.8), (1.3, 1.3, 1.3),
+            (1, 1, 1), (0.7, 1.5, 0.7), (1.1, 0.9, 1.1)
+        ]
+
+        def Scope "Protos"
+        {
+            def Mesh "Gem" (prepend apiSchemas = ["MaterialBindingAPI"])
+            {
+                rel material:binding = </World/Looks/Emerald>
+                int[] faceVertexCounts = [3, 3, 3, 3, 3, 3, 3, 3]
+                int[] faceVertexIndices = [
+                    0,2,4, 0,4,3, 0,3,5, 0,5,2,
+                    1,4,2, 1,3,4, 1,5,3, 1,2,5
+                ]
+                point3f[] points = [
+                    (0,0.55,0), (0,-0.55,0),
+                    (0.4,0,0.4), (0.4,0,-0.4), (-0.4,0,0.4), (-0.4,0,-0.4)
+                ]
+            }
+        }
+    }
+
+    def Mesh "Floor" (prepend apiSchemas = ["MaterialBindingAPI"])
+    {
+        rel material:binding = </World/Looks/Grey>
+        int[] faceVertexCounts = [4]
+        int[] faceVertexIndices = [0, 1, 2, 3]
+        point3f[] points = [(-20, 0, -20), (20, 0, -20), (20, 0, 20), (-20, 0, 20)]
+    }
+
+    def RectLight "Key"
+    {
+        float inputs:width = 10
+        float inputs:height = 6
+        color3f inputs:color = (6, 6, 6)
+        float inputs:intensity = 1.0
+        double3 xformOp:translate = (1, 9, 7)
+        float xformOp:rotateX = -50
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateX"]
+    }
+
+    def Scope "Looks"
+    {
+        def Material "Copper"
+        {
+            token outputs:surface.connect = </World/Looks/Copper/Shader.outputs:surface>
+            def Shader "Shader"
+            {
+                uniform token info:id = "crust:openpbr"
+                color3f inputs:baseColor = (0.95, 0.64, 0.54)
+                float inputs:baseMetalness = 1.0
+                float inputs:specularRoughness = 0.25
+                token outputs:surface
+            }
+        }
+
+        def Material "Emerald"
+        {
+            token outputs:surface.connect = </World/Looks/Emerald/Shader.outputs:surface>
+            def Shader "Shader"
+            {
+                uniform token info:id = "crust:openpbr"
+                color3f inputs:baseColor = (0.08, 0.55, 0.28)
+                float inputs:specularRoughness = 0.12
+                float inputs:specularWeight = 1.0
+                token outputs:surface
+            }
+        }
+
+        def Material "Grey"
+        {
+            token outputs:surface.connect = </World/Looks/Grey/Shader.outputs:surface>
+            def Shader "Shader"
+            {
+                uniform token info:id = "crust:openpbr"
+                color3f inputs:baseColor = (0.55, 0.55, 0.57)
+                float inputs:specularRoughness = 0.6
+                token outputs:surface
+            }
+        }
+    }
+}
+
+def Scope "Render"
+{
+    def RenderSettings "settings"
+    {
+        int2 resolution = (480, 270)
+        int crust:samplesPerPixel = 48
+        int crust:maxDepth = 8
+        int crust:minSamplesPerPixel = 16
+        float crust:varianceThreshold = 0.02
+        int crust:frame = 0
+    }
+}

--- a/samples/nested_instancing.usda
+++ b/samples/nested_instancing.usda
@@ -1,0 +1,209 @@
+#usda 1.0
+(
+    doc = "Nested instancing: a PointInstancer whose prototype is itself a PointInstancer (a grove of branches, each carrying leaves and a two-material bud), plus a multi-part prototype placed by ordinary native instancing. Cost stays proportional to the outer instance count, not the product."
+    defaultPrim = "World"
+    upAxis = "Y"
+)
+
+def Xform "World"
+{
+    def Camera "Cam"
+    {
+        float focalLength = 30
+        float horizontalAperture = 20.955
+        double3 xformOp:translate = (0, 3.4, 15)
+        float xformOp:rotateX = -7
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateX"]
+    }
+
+    # ------------------------------------------------------------------
+    # Two levels of PointInstancer. The outer one scatters "Branch"; the
+    # Branch prototype is itself a PointInstancer scattering "Leaf". Five
+    # branches x four leaves is twenty spheres from one sphere, and — the
+    # point of nesting — five top-level instances rather than twenty.
+    # ------------------------------------------------------------------
+    def PointInstancer "Grove"
+    {
+        rel prototypes = [</World/Grove/Protos/Branch>]
+        int[] protoIndices = [0, 0, 0, 0, 0]
+        point3f[] positions = [(-6.4, 0, -1), (-3.2, 0, 0.6), (0, 0, -0.4), (3.2, 0, 0.8), (6.4, 0, -0.6)]
+        float3[] scales = [(1, 1, 1), (1, 1.25, 1), (1, 0.85, 1), (1, 1.15, 1), (1, 0.95, 1)]
+        quatf[] orientationsf = [
+            (1, 0, 0, 0), (0.9659, 0, 0.2588, 0), (0.9239, 0, -0.3827, 0),
+            (0.9914, 0, 0.1305, 0), (0.9659, 0, -0.2588, 0)
+        ]
+
+        def Scope "Protos"
+        {
+            def PointInstancer "Branch"
+            {
+                rel prototypes = [
+                    </World/Grove/Protos/Branch/Protos/Leaf>,
+                    </World/Grove/Protos/Branch/Protos/Bud>
+                ]
+                # Three leaves and one bud per branch. The bud is a
+                # two-material prototype, so the nested expansion has to
+                # keep both materials at depth.
+                int[] protoIndices = [0, 0, 0, 1]
+                point3f[] positions = [(0.45, 1.0, 0), (-0.5, 1.7, 0.2), (0.35, 2.35, -0.15), (0, 3.0, 0)]
+                float3[] scales = [(0.5, 0.5, 0.5), (0.44, 0.44, 0.44), (0.36, 0.36, 0.36), (1, 1, 1)]
+
+                def Scope "Protos"
+                {
+                    def Sphere "Leaf" (prepend apiSchemas = ["MaterialBindingAPI"])
+                    {
+                        double radius = 0.5
+                        rel material:binding = </World/Looks/Leafy>
+                    }
+
+                    def Xform "Bud"
+                    {
+                        def Mesh "husk" (prepend apiSchemas = ["MaterialBindingAPI"])
+                        {
+                            rel material:binding = </World/Looks/Leafy>
+                            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+                            int[] faceVertexIndices = [0,1,3,2, 4,6,7,5, 0,4,5,1, 2,3,7,6, 0,2,6,4, 1,5,7,3]
+                            point3f[] points = [
+                                (-0.18,-0.18,-0.18), (-0.18,-0.18,0.18), (-0.18,0.18,-0.18), (-0.18,0.18,0.18),
+                                (0.18,-0.18,-0.18), (0.18,-0.18,0.18), (0.18,0.18,-0.18), (0.18,0.18,0.18)
+                            ]
+                        }
+
+                        def Sphere "tip" (prepend apiSchemas = ["MaterialBindingAPI"])
+                        {
+                            double radius = 0.14
+                            rel material:binding = </World/Looks/Blossom>
+                            double3 xformOp:translate = (0, 0.3, 0)
+                            uniform token[] xformOpOrder = ["xformOp:translate"]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    # ------------------------------------------------------------------
+    # A multi-part prototype placed by ordinary (single-level) native
+    # instancing, for contrast with the nested grove above. Note the
+    # prototype's contents are *not* themselves instanceable: openusd 0.5
+    # cannot read an instanceable prim's contents inside a prototype, so
+    # the importer skips that pattern with a warning (see
+    # `nested_native_instance_degrades_gracefully`).
+    # ------------------------------------------------------------------
+    class Xform "_Planter"
+    {
+        def Mesh "post" (prepend apiSchemas = ["MaterialBindingAPI"])
+        {
+            rel material:binding = </World/Looks/Bark>
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0,1,3,2, 4,6,7,5, 0,4,5,1, 2,3,7,6, 0,2,6,4, 1,5,7,3]
+            point3f[] points = [
+                (-0.16,0,-0.16), (-0.16,0,0.16), (-0.16,1.1,-0.16), (-0.16,1.1,0.16),
+                (0.16,0,-0.16), (0.16,0,0.16), (0.16,1.1,-0.16), (0.16,1.1,0.16)
+            ]
+        }
+
+        def Sphere "orb" (prepend apiSchemas = ["MaterialBindingAPI"])
+        {
+            double radius = 0.3
+            rel material:binding = </World/Looks/Blossom>
+            double3 xformOp:translate = (0, 1.35, 0)
+            uniform token[] xformOpOrder = ["xformOp:translate"]
+        }
+    }
+
+    def Xform "PlanterA" (instanceable = true; references = </World/_Planter>)
+    {
+        double3 xformOp:translate = (-1.9, 0, 3.4)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def Xform "PlanterB" (instanceable = true; references = </World/_Planter>)
+    {
+        double3 xformOp:translate = (1.9, 0, 3.4)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def Mesh "Floor" (prepend apiSchemas = ["MaterialBindingAPI"])
+    {
+        rel material:binding = </World/Looks/Ground>
+        int[] faceVertexCounts = [4]
+        int[] faceVertexIndices = [0, 1, 2, 3]
+        point3f[] points = [(-40, 0, -40), (40, 0, -40), (40, 0, 40), (-40, 0, 40)]
+    }
+
+    def RectLight "Key"
+    {
+        float inputs:width = 16
+        float inputs:height = 10
+        color3f inputs:color = (4, 4, 4)
+        float inputs:intensity = 1.0
+        double3 xformOp:translate = (2, 12, 9)
+        float xformOp:rotateX = -52
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateX"]
+    }
+
+    def Scope "Looks"
+    {
+        def Material "Leafy"
+        {
+            token outputs:surface.connect = </World/Looks/Leafy/Shader.outputs:surface>
+            def Shader "Shader"
+            {
+                uniform token info:id = "crust:openpbr"
+                color3f inputs:baseColor = (0.16, 0.42, 0.14)
+                float inputs:specularRoughness = 0.45
+                token outputs:surface
+            }
+        }
+
+        def Material "Blossom"
+        {
+            token outputs:surface.connect = </World/Looks/Blossom/Shader.outputs:surface>
+            def Shader "Shader"
+            {
+                uniform token info:id = "crust:openpbr"
+                color3f inputs:baseColor = (0.82, 0.28, 0.42)
+                float inputs:specularRoughness = 0.3
+                token outputs:surface
+            }
+        }
+
+        def Material "Bark"
+        {
+            token outputs:surface.connect = </World/Looks/Bark/Shader.outputs:surface>
+            def Shader "Shader"
+            {
+                uniform token info:id = "crust:openpbr"
+                color3f inputs:baseColor = (0.34, 0.24, 0.17)
+                float inputs:specularRoughness = 0.7
+                token outputs:surface
+            }
+        }
+
+        def Material "Ground"
+        {
+            token outputs:surface.connect = </World/Looks/Ground/Shader.outputs:surface>
+            def Shader "Shader"
+            {
+                uniform token info:id = "crust:openpbr"
+                color3f inputs:baseColor = (0.42, 0.44, 0.40)
+                float inputs:specularRoughness = 0.75
+                token outputs:surface
+            }
+        }
+    }
+}
+
+def Scope "Render"
+{
+    def RenderSettings "settings"
+    {
+        int2 resolution = (480, 270)
+        int crust:samplesPerPixel = 48
+        int crust:maxDepth = 8
+        int crust:minSamplesPerPixel = 16
+        float crust:varianceThreshold = 0.02
+        int crust:frame = 0
+    }
+}

--- a/scripts/test_simd_matrix.sh
+++ b/scripts/test_simd_matrix.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Run the test suite across SIMD instruction-set configurations.
+#
+# Why this exists: the kernel's correctness claims are about *float bit
+# patterns*, not tolerances. `simd_matches_scalar_bitwise` asserts that the
+# 4-wide packet intersector and the scalar one agree bit-for-bit, and
+# watertightness depends on adjacent triangles computing exactly equal edge
+# functions. Different codegen can break that — most obviously by
+# contracting `a*b + c` into an FMA, which rounds once instead of twice.
+# Rust does not contract by default, but that is a property worth
+# re-verifying rather than assuming, and it is the kind of thing that
+# changes quietly with a toolchain bump.
+#
+# Usage: scripts/test_simd_matrix.sh [extra cargo test args...]
+
+set -euo pipefail
+
+run() {
+    local label="$1"
+    shift
+    local flags="$1"
+    shift
+    echo
+    echo "=== $label"
+    echo "    RUSTFLAGS=\"$flags\""
+    RUSTFLAGS="$flags" cargo test "$@" 2>&1 | grep -E "test result|FAILED|^error" || {
+        echo "    FAILED under $label"
+        exit 1
+    }
+}
+
+# Baseline: whatever the target's default features are (x86-64 => SSE2).
+run "baseline (target defaults)" "" "$@"
+
+# No 256/512-bit instructions at all: exercises the narrowest codegen and
+# the scalar fallbacks.
+run "SIMD widening disabled" \
+    "-C target-cpu=native -C target-feature=-avx2,-avx512f,-avx" "$@"
+
+# AVX2 + FMA: the configuration most likely to perturb float results,
+# because LLVM may pick different instruction sequences for the same
+# arithmetic.
+run "AVX2 + FMA" "-C target-feature=+avx2,+fma" "$@"
+
+# Everything the host has. On a machine with AVX-512 this covers it; note
+# that GitHub Actions runners generally do not offer AVX-512, so that leg
+# only really runs locally.
+run "target-cpu=native" "-C target-cpu=native" "$@"
+
+echo
+echo "All SIMD configurations passed."


### PR DESCRIPTION
The BVH4 node test already built `Vec4` lanes, then threw the vectorization
away by reading lanes back one at a time; leaf intersection was fully scalar,
one `Box<dyn Prim>` call per triangle. Both are now vertical SIMD, and the
codegen settings let the vector code actually inline across crates.

- Release profile: `lto = "thin"` + `codegen-units = 1`. The hot loop spans
  crust-core -> crust-rt -> glam as small `#[inline]` functions; without LTO
  those calls survive and the vector bodies never fuse. Free 21% on the
  triangle traversal benchmark.

- Traversal (`bvh.rs`): `RaySlab` pre-splats the ray once per query instead
  of rebuilding seven splats per visited node; `safe_inv3` does all three
  reciprocals branch-free; lane verdicts come out as a nibble via
  `cmple(..).bitmask()`; lane validity moved into a `flags` bitmask ANDed
  into that nibble, replacing four per-lane branches. Unused lanes cannot
  simply be given empty bounds -- the slab test's per-axis min/max
  un-inverts an inverted box, and +INF/+INF passes when `t_max == INF`.

- Leaf packets (`triangle.rs`): the Woop 2013 transform splits into a
  per-ray part (`RayShear`, derived once per traversal rather than once per
  triangle) and per-triangle arithmetic that maps onto `Vec4` lanes. `Tri4`
  holds four triangles in SoA and intersects them in one vector round, with
  a two-compare fast path for per-lane visibility masks. Leaf payloads moved
  to a side `Leaf` table so `WideNode` still fits two cache lines (pinned by
  a size test).

  Watertightness is preserved exactly: the f64 tie-break for exactly-zero
  edge functions is inherently scalar, so those lanes are reported in a
  `fallback` mask and re-tested through the scalar path. The two
  intersectors are bit-identical -- `simd_matches_scalar_bitwise` asserts
  `to_bits()` equality per lane over ~8000 lanes, not an epsilon.

- Leaf size retuned to the SIMD width: packet occupancy was 1.66 of 4 lanes
  under `MIN_LEAF = 2`. `MIN_LEAF_PACKED = 4` applies only to all-triangle
  ranges (raising the floor for everything cost instanced scenes ~12%);
  occupancy is now 2.89 of 4 and every scene kind gets its best number.

- `material/brdf.rs`: three `powf(_, 5.0)` in Schlick Fresnel became
  `powi(5)`, matching the `powi(6)` already in the same function. `powf` is
  an opaque libm call the surrounding vector code cannot be optimized
  across. cornellbox 9.09s -> 8.41s; image differs by at most one ULP.

Measured (min of 40, fixed 4096-ray batch, both sides with LTO):
  tri_spheres intersect 4.48 -> 3.43 ms   occluded 3.13 -> 1.93 ms
  sphere_grid intersect 1.96 -> 1.66 ms   occluded 1.45 -> 0.93 ms
  instances   intersect 4.86 -> 3.79 ms   occluded 3.55 -> 2.31 ms

End to end, the 383k-triangle stress scene renders in 6.35s against 8.03s.
The checked-in samples move far less (1.5-9%): they are shading-bound, not
traversal-bound -- worth knowing before benchmarking a kernel change on them.

Verification: whole workspace green; every sample scene rendered before and
after and compared with the new `exr_diff` example. Seven of eight are
pixel-identical. cornellbox differs in 1 pixel of 230400 by 4.6e-4, at the
seam where the inner box's bottom face is exactly coplanar with the floor --
a genuine `t` tie whose winner depends on leaf visit order (confirmed
independent of the retuned tree).

Adds `crust-rt` traversal benchmarks, a min-of-N `ray_throughput` probe
(criterion means drift 10%+ on a shared machine), the `exr_diff` regression
check, and `docs/simd.md` -- including why `std::simd` is not used: it is
still nightly-only on the stable toolchain crust builds with.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019Q7RXTdHvPFM5weuxWYLYU