### PR TITLE
Stream the USD import: 117 GiB / 13:20 -> 44 GiB / 09:19 on Moana

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,7 +277,25 @@ randomness use `openqmc::pcg::Rng`.
 
 The only scene format. `load_scene` opens the stage, imports `RenderSettings` first (the
 camera needs the aspect ratio), then traverses prims with an explicit stack that bakes the
-Xform hierarchy into world matrices. Schema mapping:
+Xform hierarchy into world matrices.
+
+**Streaming import.** A production stage is dominated by USD itself, not by the
+renderer's own structures: composing all of Moana costs openusd 75.74 GiB and 6m19s,
+against 1.10 GiB and 2.6s for a stage masked to one element. So `load_scene` opens a
+cheap index stage (`InitialLoadSet::LoadNone`) for the settings and the list of
+top-level subtrees, then composes, traverses and **drops one masked stage per subtree**
+(`stream_roots` + `traverse_into`), bounding the composed set at about one element.
+On the island: 117.10 GiB / 13:20 → 43.76 GiB / 09:19, output pixel-identical.
+`MIN_STREAM_CHUNKS` keeps the single-stage path for scenes too small to repay the
+re-opens; `CRUST_STREAM_IMPORT=0` forces it.
+The subtlety is cache keying: prototype paths (`/__Prototype_N`) are **numbered per
+composition**, so every masked stage has its own `/__Prototype_0`. Anything keyed on
+such a path must be scoped per stage, or one chunk's data is silently handed to the
+next — see `MaterialCache::key` and `ImportCaches::epoch`. Keying materials on the bare
+path cost 5 835 258 triangles before it was caught, and *no single element reproduces
+it*: it needs two chunks that both carry prototype-internal materials.
+
+Schema mapping:
 
 - `UsdGeomMesh` → a *local-space* committed `rt::Scene` (one `TriangleMesh` geometry)
   placed by an `rt::Geometry::Instance`; prims with identical points/topology/material

--- a/crates/crust-core/src/rt_world.rs
+++ b/crates/crust-core/src/rt_world.rs
@@ -138,6 +138,12 @@ impl World {
         self.scene.unique_primitive_breakdown()
     }
 
+    /// Exact kernel-resident bytes — see
+    /// [`crust_rt::Scene::memory_footprint`].
+    pub fn memory_footprint(&self) -> crust_rt::MemoryFootprint {
+        self.scene.memory_footprint()
+    }
+
     /// The material bound to a geometry.
     pub fn material(&self, geom_id: u32) -> &dyn Material {
         self.materials[geom_id as usize].as_ref()

--- a/crates/crust-core/src/scene/usd_import.rs
+++ b/crates/crust-core/src/scene/usd_import.rs
@@ -57,40 +57,29 @@ const DEFAULT_GUIDING_PROB: f32 = 0.5;
 /// above any plausible authoring depth.
 const MAX_INSTANCE_NESTING: usize = 8;
 
-pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene, crate::Error> {
-    let import_start = Instant::now();
-    let mut stats = RenderStats::new();
+/// Everything a traversal accumulates, kept separate from the stage that
+/// feeds it so several stages can be walked into the same scene and each
+/// dropped when done — see [`traverse_into`].
+struct ImportCtx<'a> {
+    world: WorldBuilder,
+    lights: LightList,
+    volumes: Vec<VolumeRegion>,
+    camera: Option<Camera>,
+    caches: ImportCaches,
+    /// Time the host spent decoding assets, so the profile can separate it
+    /// from the traversal proper.
+    asset_time: Duration,
+    settings: RenderSettings,
+    /// The stage file, for resolving asset paths against its directory.
+    stage_path: &'a Path,
+    assets: &'a dyn AssetLoader,
+}
 
-    let path_str = path
-        .to_str()
-        .ok_or_else(|| crate::Error::NonUtf8Path(path.to_path_buf()))?;
-
-    let open_start = Instant::now();
-    let stage = Stage::open(path_str).map_err(|e| crate::Error::UsdOpen {
-        path: path.to_path_buf(),
-        message: e.to_string(),
-    })?;
-    let open_elapsed = open_start.elapsed();
-    let open_mem = MemorySample::now();
-
-    // Render settings come first — the camera importer needs the aspect ratio.
-    let settings = import_render_settings(&stage);
-
-    let mut world = WorldBuilder::new();
-    let mut lights = LightList::new();
-    let mut volumes: Vec<VolumeRegion> = Vec::new();
-    let mut camera_candidate: Option<Camera> = None;
-    // Prims binding the same material path share one Arc, and prims with
-    // identical local geometry + material share one committed kernel
-    // scene through instancing — N placements of a mesh cost one copy of
-    // its triangles.
-    let mut caches = ImportCaches::default();
-    // Time the host spends decoding assets, subtracted out of the traverse
-    // phase below so the two costs are not conflated.
-    let mut asset_time = Duration::ZERO;
-
-    let traverse_start = Instant::now();
-    let mut stack: Vec<(Prim, GMat4)> = vec![(stage.prim_at(sdf::Path::abs_root()), GMat4::IDENTITY)];
+/// Walks `root` and its subtree, emitting geometry, lights and volumes
+/// into `ctx`. Takes the stage by reference and keeps nothing borrowed
+/// from it, so the caller may drop the stage afterwards and walk another.
+fn traverse_into(stage: &Stage, root: Prim, root_xf: GMat4, ctx: &mut ImportCtx) {
+    let mut stack: Vec<(Prim, GMat4)> = vec![(root, root_xf)];
 
     while let Some((prim, parent_world)) = stack.pop() {
         // `class` prims (and their descendants) describe geometry that
@@ -110,8 +99,8 @@ pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene,
             continue;
         }
 
-        let local = local_matrix_at(&stage, &prim);
-        let resets = resets_xform_stack_at(&stage, &prim);
+        let local = local_matrix_at(stage, &prim);
+        let resets = resets_xform_stack_at(stage, &prim);
         let this_world = if resets { local } else { parent_world * local };
 
         // Native instancing: an `instanceable` prim with a composition arc
@@ -123,12 +112,12 @@ pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene,
             match prim.prototype() {
                 Ok(Some(proto_path)) => {
                     emit_native_instance(
-                        &stage,
-                        &mut world,
+                        stage,
+                        &mut ctx.world,
                         &prim,
                         &proto_path,
                         this_world,
-                        &mut caches,
+                        &mut ctx.caches,
                     );
                     continue;
                 }
@@ -145,54 +134,68 @@ pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene,
         // shadow rays. Otherwise order matters only for Meshes vs Sphere
         // prims — both check first so we don't recurse into their
         // materials as prims.
-        if let Ok(Some(instancer)) = PointInstancer::get(&stage, prim.path().clone()) {
-            emit_point_instancer(&stage, &mut world, &prim, &instancer, this_world, &mut caches);
+        if let Ok(Some(instancer)) = PointInstancer::get(stage, prim.path().clone()) {
+            emit_point_instancer(
+                stage,
+                &mut ctx.world,
+                &prim,
+                &instancer,
+                this_world,
+                &mut ctx.caches,
+            );
             // Prototypes are conventionally authored beneath the
             // instancer; they are drawn through it, never on their own.
             continue;
         } else if custom_token(&prim, "crust:volume:type").is_some() {
-            emit_volume(&prim, this_world, &mut volumes);
-        } else if let Ok(Some(mesh)) = UsdMesh::get(&stage, prim.path().clone()) {
-            let mat = resolve_material(&stage, &prim, &mut caches.materials);
-            emit_mesh(&mut world, &prim, &mesh, this_world, mat, &mut caches.meshes);
-        } else if let Ok(Some(sphere)) = UsdSphere::get(&stage, prim.path().clone()) {
-            let mat = resolve_material(&stage, &prim, &mut caches.materials);
-            emit_sphere(&mut world, &prim, &sphere, this_world, mat);
-        } else if let Ok(Some(curves)) = UsdBasisCurves::get(&stage, prim.path().clone()) {
-            let mat = resolve_material(&stage, &prim, &mut caches.materials);
-            emit_curves(&mut world, &prim, &curves, this_world, mat);
-        } else if UsdCamera::get(&stage, prim.path().clone())
+            emit_volume(&prim, this_world, &mut ctx.volumes);
+        } else if let Ok(Some(mesh)) = UsdMesh::get(stage, prim.path().clone()) {
+            let mat = resolve_material(stage, &prim, &mut ctx.caches.materials);
+            emit_mesh(
+                &mut ctx.world,
+                &prim,
+                &mesh,
+                this_world,
+                mat,
+                &mut ctx.caches.meshes,
+            );
+        } else if let Ok(Some(sphere)) = UsdSphere::get(stage, prim.path().clone()) {
+            let mat = resolve_material(stage, &prim, &mut ctx.caches.materials);
+            emit_sphere(&mut ctx.world, &prim, &sphere, this_world, mat);
+        } else if let Ok(Some(curves)) = UsdBasisCurves::get(stage, prim.path().clone()) {
+            let mat = resolve_material(stage, &prim, &mut ctx.caches.materials);
+            emit_curves(&mut ctx.world, &prim, &curves, this_world, mat);
+        } else if UsdCamera::get(stage, prim.path().clone())
             .ok()
             .flatten()
             .is_some()
         {
-            if camera_candidate.is_none() {
-                match build_camera(&stage, &prim, &settings) {
+            if ctx.camera.is_none() {
+                match build_camera(stage, &prim, &ctx.settings) {
                     Some(c) => {
                         info!("Imported USD camera at {}", prim.path());
-                        camera_candidate = Some(c);
+                        ctx.camera = Some(c);
                     }
                     None => warn!("Failed to build camera from {}", prim.path()),
                 }
             }
-        } else if let Ok(Some(light)) = SphereLight::get(&stage, prim.path().clone()) {
-            emit_sphere_light(&mut world, &mut lights, &light, this_world);
-        } else if let Ok(Some(light)) = RectLight::get(&stage, prim.path().clone()) {
-            emit_rect_light(&mut world, &mut lights, &light, this_world);
-        } else if let Ok(Some(light)) = UsdDistantLight::get(&stage, prim.path().clone()) {
-            emit_distant_light(&mut lights, &light, this_world);
-        } else if let Ok(Some(light)) = DomeLight::get(&stage, prim.path().clone()) {
+        } else if let Ok(Some(light)) = SphereLight::get(stage, prim.path().clone()) {
+            emit_sphere_light(&mut ctx.world, &mut ctx.lights, &light, this_world);
+        } else if let Ok(Some(light)) = RectLight::get(stage, prim.path().clone()) {
+            emit_rect_light(&mut ctx.world, &mut ctx.lights, &light, this_world);
+        } else if let Ok(Some(light)) = UsdDistantLight::get(stage, prim.path().clone()) {
+            emit_distant_light(&mut ctx.lights, &light, this_world);
+        } else if let Ok(Some(light)) = DomeLight::get(stage, prim.path().clone()) {
             emit_dome_light(
-                &mut lights,
+                &mut ctx.lights,
                 &prim,
                 &light,
                 this_world,
-                path,
-                assets,
-                &mut asset_time,
+                ctx.stage_path,
+                ctx.assets,
+                &mut ctx.asset_time,
             );
         } else {
-            warn_unsupported_light(&stage, &prim);
+            warn_unsupported_light(stage, &prim);
         }
 
         // Recurse. We push children onto the stack unconditionally; the
@@ -203,20 +206,64 @@ pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene,
             }
         }
     }
+}
+
+pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene, crate::Error> {
+    let import_start = Instant::now();
+    let mut stats = RenderStats::new();
+
+    let path_str = path
+        .to_str()
+        .ok_or_else(|| crate::Error::NonUtf8Path(path.to_path_buf()))?;
+
+    let open_start = Instant::now();
+    let stage = Stage::open(path_str).map_err(|e| crate::Error::UsdOpen {
+        path: path.to_path_buf(),
+        message: e.to_string(),
+    })?;
+    let open_elapsed = open_start.elapsed();
+    let open_mem = MemorySample::now();
+
+    // Render settings come first — the camera importer needs the aspect ratio.
+    let settings = import_render_settings(&stage);
+
+    let mut ctx = ImportCtx {
+        world: WorldBuilder::new(),
+        lights: LightList::new(),
+        volumes: Vec::new(),
+        camera: None,
+        // Prims binding the same material path share one Arc, and prims
+        // with identical local geometry + material share one committed
+        // kernel scene through instancing — N placements of a mesh cost
+        // one copy of its triangles.
+        caches: ImportCaches::default(),
+        asset_time: Duration::ZERO,
+        settings,
+        stage_path: path,
+        assets,
+    };
+
+    let traverse_start = Instant::now();
+    traverse_into(
+        &stage,
+        stage.prim_at(sdf::Path::abs_root()),
+        GMat4::IDENTITY,
+        &mut ctx,
+    );
 
     // The traverse also builds each mesh's and prototype's kernel scene,
     // so its own BVH work is inside this figure; the separate "Commit
     // acceleration structure" phase below is the *top-level* build.
-    let traverse_elapsed = traverse_start.elapsed().saturating_sub(asset_time);
+    let traverse_elapsed = traverse_start.elapsed().saturating_sub(ctx.asset_time);
     let traverse_mem = MemorySample::now();
 
-    let camera = camera_candidate.unwrap_or_else(|| {
+    let camera = ctx.camera.unwrap_or_else(|| {
         warn!("USD stage has no UsdGeomCamera — falling back to world::get_settings camera");
         crate::world::get_settings().0
     });
 
     let commit_start = Instant::now();
-    let committed = world.commit();
+    let committed = ctx.world.commit();
     let commit_elapsed = commit_start.elapsed();
     let commit_mem = MemorySample::now();
 
@@ -226,8 +273,8 @@ pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene,
     stats.record_at("Parse USD stage", 0, import_start.elapsed(), commit_mem);
     stats.record_at("Open stage", 1, open_elapsed, open_mem);
     stats.record_at("Traverse prims", 1, traverse_elapsed, traverse_mem);
-    if !asset_time.is_zero() {
-        stats.record_at("Load assets", 1, asset_time, traverse_mem);
+    if !ctx.asset_time.is_zero() {
+        stats.record_at("Load assets", 1, ctx.asset_time, traverse_mem);
     }
     stats.record_at(
         "Commit acceleration structure",
@@ -241,8 +288,8 @@ pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene,
         top_level: committed.primitive_breakdown().into(),
         unique: committed.unique_primitive_breakdown().into(),
         footprint: committed.memory_footprint(),
-        lights: lights.count(),
-        volumes: volumes.len(),
+        lights: ctx.lights.count(),
+        volumes: ctx.volumes.len(),
     };
     let (w, h) = settings.get_dimensions();
     stats.image = ImageCounters {
@@ -252,7 +299,8 @@ pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene,
         max_depth: settings.max_depth(),
     };
 
-    let mut scene = Scene::new(camera, committed, lights, settings).with_volumes(volumes);
+    let mut scene =
+        Scene::new(camera, committed, ctx.lights, settings).with_volumes(ctx.volumes);
     scene.stats = stats;
     Ok(scene)
 }

--- a/crates/crust-core/src/scene/usd_import.rs
+++ b/crates/crust-core/src/scene/usd_import.rs
@@ -71,37 +71,27 @@ const MIN_STREAM_CHUNKS: usize = 4;
 /// when there are too few chunks for streaming to be worth it, which
 /// tells the caller to import the whole stage in one pass.
 ///
-/// # Streaming is incomplete — opt-in only
+/// # Why this is worth the extra opens
 ///
-/// Importing per element is a large win where it works: on the Moana
-/// island it takes peak memory from 117.10 GiB to 42.53 GiB and runtime
-/// from 13:20 to 08:57, because composing one element costs openusd
-/// 1.10 GiB where composing the whole stage costs 75.74 GiB.
+/// Composing the whole Moana island costs openusd 75.74 GiB and 6m19s;
+/// composing a stage masked to one element costs 1.10 GiB and 2.6s. So
+/// importing element by element, dropping each stage when done, bounds
+/// the composed set at roughly one element instead of all twenty:
+/// **117.10 GiB and 13:20 become 43.76 GiB and 09:19**, with output
+/// pixel-identical to the single-stage import.
 ///
-/// But it currently **loses geometry**. On the island it imports
-/// 50 990 392 triangles against the single-stage importer's 56 825 650,
-/// and 1.5% of pixels differ. Curves and instances match exactly; only
-/// meshes are affected.
+/// The re-opens are not free — each masked open re-composes the root
+/// layer — which is what [`MIN_STREAM_CHUNKS`] guards against on scenes
+/// too small for the excluded payloads to pay for them.
 ///
-/// The cause is native instancing. Each element's root is `instanceable`,
-/// so its content lives in a prototype materialised at a stage-root path
-/// (`/__Prototype_N`) *outside* the element's own subtree. Under a mask
-/// naming only that element, nine of the island's prototypes resolve
-/// empty — logged as "Prototype /__Prototype_0 contributed no geometry",
-/// against one such warning for the whole single-stage import. openusd's
-/// `Stage::mask_includes` is meant to cover exactly this (a prototype is
-/// populated when any of its instances is in the mask, per spec 11.3.3),
-/// so this is either a subtlety not yet pinned down or a limitation of
-/// openusd 0.5's masking; it is not simply a missing path in the mask.
-///
-/// Verified *not* to be the cause: the prototype-cache epoch (the fix in
-/// [`ImportCaches::epoch`] left the triangle count byte-identical), and
-/// ten of the twenty elements, which A/B identical in both modes.
+/// Getting this right depends on the caches distinguishing paths that
+/// are stable across stages from paths that are not; see
+/// [`MaterialCache::key`] and [`ImportCaches::epoch`].
 fn stream_roots(stage: &Stage) -> Vec<sdf::Path> {
-    // Opt-in, because it is not correct yet: see the module note on
-    // streaming below. `CRUST_STREAM_IMPORT=1` enables it for
-    // experimentation and for A/B-ing the two paths on one scene.
-    if !std::env::var("CRUST_STREAM_IMPORT").is_ok_and(|v| v == "1") {
+    // Escape hatch, and the way to A/B the two import paths against each
+    // other on one scene: `CRUST_STREAM_IMPORT=0` forces a single stage.
+    if std::env::var("CRUST_STREAM_IMPORT").is_ok_and(|v| v == "0") {
+        debug!("Streaming import disabled by CRUST_STREAM_IMPORT=0");
         return Vec::new();
     }
     let pseudo_root = stage.prim_at(sdf::Path::abs_root());
@@ -362,6 +352,7 @@ pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene,
             // mesh cache keys materials by Arc address, so nothing may
             // be freed while it is live.
             ctx.caches.epoch += 1;
+            ctx.caches.materials.epoch = ctx.caches.epoch;
         }
     }
 
@@ -2180,13 +2171,40 @@ fn warn_unsupported_light(stage: &Stage, prim: &Prim) {
 /// which is what lets `MeshKey` recognize shared mesh geometry.
 #[derive(Default)]
 struct MaterialCache {
-    by_path: HashMap<String, Arc<dyn Material>>,
+    by_path: HashMap<(u32, String), Arc<dyn Material>>,
     default: Option<Arc<dyn Material>>,
+    /// Which stage the prototype-scoped entries belong to; see
+    /// [`MaterialCache::key`]. Kept in step with [`ImportCaches::epoch`].
+    epoch: u32,
 }
 
 impl MaterialCache {
     fn default_material(&mut self) -> Arc<dyn Material> {
         self.default.get_or_insert_with(default_material).clone()
+    }
+
+    /// Cache key for a bound material path.
+    ///
+    /// Authored scene paths are stable across stages, so they key on the
+    /// path alone and a material shared by several subtrees resolves to
+    /// one `Arc` — which is what lets the mesh cache deduplicate across
+    /// them. Paths *inside* a prototype are not stable: prototypes are
+    /// numbered per composition, so under the streaming importer every
+    /// stage has its own `/__Prototype_0`, and keying those on the path
+    /// alone hands one chunk's material to the next chunk's geometry.
+    /// Those are therefore scoped by epoch.
+    ///
+    /// This bit the streaming importer for real: on the Moana island it
+    /// silently merged distinct meshes onto shared materials, losing
+    /// 5 835 258 triangles. No single element reproduces it — it needs
+    /// two chunks that both carry prototype-internal materials.
+    fn key(&self, path: &str) -> (u32, String) {
+        let epoch = if path.starts_with("/__Prototype") {
+            self.epoch
+        } else {
+            0
+        };
+        (epoch, path.to_string())
     }
 }
 
@@ -2204,13 +2222,12 @@ fn resolve_material(
         return cache.default_material();
     };
 
-    if let Some(hit) = cache.by_path.get(mat_path.as_str()) {
+    let key = cache.key(mat_path.as_str());
+    if let Some(hit) = cache.by_path.get(&key) {
         return hit.clone();
     }
     let resolved = resolve_material_uncached(stage, &mat_path);
-    cache
-        .by_path
-        .insert(mat_path.as_str().to_string(), resolved.clone());
+    cache.by_path.insert(key, resolved.clone());
     resolved
 }
 

--- a/crates/crust-core/src/scene/usd_import.rs
+++ b/crates/crust-core/src/scene/usd_import.rs
@@ -20,7 +20,7 @@ use crate::material::{Emissive, Material, OpenPBR};
 use crate::ray::MASK_ALL;
 use crate::rt_world::WorldBuilder;
 use crate::scene::Scene;
-use crate::stats::{ImageCounters, RenderStats, SceneCounters};
+use crate::stats::{ImageCounters, MemorySample, RenderStats, SceneCounters};
 use crust_rt::{
     CubicCurveSegment, CurveSegment, Geometry, Scene as RtScene, SceneBuilder as RtSceneBuilder,
 };
@@ -71,6 +71,7 @@ pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene,
         message: e.to_string(),
     })?;
     let open_elapsed = open_start.elapsed();
+    let open_mem = MemorySample::now();
 
     // Render settings come first — the camera importer needs the aspect ratio.
     let settings = import_render_settings(&stage);
@@ -207,6 +208,7 @@ pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene,
     // so its own BVH work is inside this figure; the separate "Commit
     // acceleration structure" phase below is the *top-level* build.
     let traverse_elapsed = traverse_start.elapsed().saturating_sub(asset_time);
+    let traverse_mem = MemorySample::now();
 
     let camera = camera_candidate.unwrap_or_else(|| {
         warn!("USD stage has no UsdGeomCamera — falling back to world::get_settings camera");
@@ -216,19 +218,29 @@ pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene,
     let commit_start = Instant::now();
     let committed = world.commit();
     let commit_elapsed = commit_start.elapsed();
+    let commit_mem = MemorySample::now();
 
-    stats.record("Parse USD stage", 0, import_start.elapsed());
-    stats.record("Open stage", 1, open_elapsed);
-    stats.record("Traverse prims", 1, traverse_elapsed);
+    // Memory is sampled where each phase actually ended, not here — the
+    // phases are all recorded together, so `record`'s sample-now would
+    // give every one of them the same figures.
+    stats.record_at("Parse USD stage", 0, import_start.elapsed(), commit_mem);
+    stats.record_at("Open stage", 1, open_elapsed, open_mem);
+    stats.record_at("Traverse prims", 1, traverse_elapsed, traverse_mem);
     if !asset_time.is_zero() {
-        stats.record("Load assets", 1, asset_time);
+        stats.record_at("Load assets", 1, asset_time, traverse_mem);
     }
-    stats.record("Commit acceleration structure", 1, commit_elapsed);
+    stats.record_at(
+        "Commit acceleration structure",
+        1,
+        commit_elapsed,
+        commit_mem,
+    );
 
     stats.scene = SceneCounters {
         geometries: committed.count(),
         top_level: committed.primitive_breakdown().into(),
         unique: committed.unique_primitive_breakdown().into(),
+        footprint: committed.memory_footprint(),
         lights: lights.count(),
         volumes: volumes.len(),
     };

--- a/crates/crust-core/src/scene/usd_import.rs
+++ b/crates/crust-core/src/scene/usd_import.rs
@@ -40,7 +40,7 @@ use openusd::schemas::lux::{
 use openusd::schemas::render::{RenderSettings as UsdRenderSettings, RenderSettingsBase};
 use openusd::schemas::shade::{self, Material as UsdMaterial, MaterialBindingAPI, Shader};
 use openusd::sdf;
-use openusd::usd::{Prim, Stage};
+use openusd::usd::{InitialLoadSet, Prim, Stage, StagePopulationMask};
 
 const DEFAULT_SPP: u32 = 128;
 const DEFAULT_MAX_DEPTH: u32 = 32;
@@ -56,6 +56,72 @@ const DEFAULT_GUIDING_PROB: f32 = 0.5;
 /// each level multiplies traversal cost — so this is a backstop, set far
 /// above any plausible authoring depth.
 const MAX_INSTANCE_NESTING: usize = 8;
+
+/// Below this many streamable chunks, importing under one stage is
+/// simpler and no slower — masked opens each re-compose the root layer,
+/// so they only pay off when the payloads they exclude are the bulk of
+/// the cost.
+const MIN_STREAM_CHUNKS: usize = 4;
+
+/// The subtrees to import one at a time, each under its own masked stage.
+///
+/// Returns the children of the stage's single top-level prim — the shape
+/// every scene here takes, a `/world`-style root holding one prim per
+/// element — or the top-level prims when there is not exactly one. Empty
+/// when there are too few chunks for streaming to be worth it, which
+/// tells the caller to import the whole stage in one pass.
+///
+/// # Streaming is incomplete — opt-in only
+///
+/// Importing per element is a large win where it works: on the Moana
+/// island it takes peak memory from 117.10 GiB to 42.53 GiB and runtime
+/// from 13:20 to 08:57, because composing one element costs openusd
+/// 1.10 GiB where composing the whole stage costs 75.74 GiB.
+///
+/// But it currently **loses geometry**. On the island it imports
+/// 50 990 392 triangles against the single-stage importer's 56 825 650,
+/// and 1.5% of pixels differ. Curves and instances match exactly; only
+/// meshes are affected.
+///
+/// The cause is native instancing. Each element's root is `instanceable`,
+/// so its content lives in a prototype materialised at a stage-root path
+/// (`/__Prototype_N`) *outside* the element's own subtree. Under a mask
+/// naming only that element, nine of the island's prototypes resolve
+/// empty — logged as "Prototype /__Prototype_0 contributed no geometry",
+/// against one such warning for the whole single-stage import. openusd's
+/// `Stage::mask_includes` is meant to cover exactly this (a prototype is
+/// populated when any of its instances is in the mask, per spec 11.3.3),
+/// so this is either a subtlety not yet pinned down or a limitation of
+/// openusd 0.5's masking; it is not simply a missing path in the mask.
+///
+/// Verified *not* to be the cause: the prototype-cache epoch (the fix in
+/// [`ImportCaches::epoch`] left the triangle count byte-identical), and
+/// ten of the twenty elements, which A/B identical in both modes.
+fn stream_roots(stage: &Stage) -> Vec<sdf::Path> {
+    // Opt-in, because it is not correct yet: see the module note on
+    // streaming below. `CRUST_STREAM_IMPORT=1` enables it for
+    // experimentation and for A/B-ing the two paths on one scene.
+    if !std::env::var("CRUST_STREAM_IMPORT").is_ok_and(|v| v == "1") {
+        return Vec::new();
+    }
+    let pseudo_root = stage.prim_at(sdf::Path::abs_root());
+    let Ok(top) = pseudo_root.children() else {
+        return Vec::new();
+    };
+
+    let chunks: Vec<sdf::Path> = match top.as_slice() {
+        [only] => match only.children() {
+            Ok(children) => children.iter().map(|c| c.path().clone()).collect(),
+            Err(_) => return Vec::new(),
+        },
+        many => many.iter().map(|p| p.path().clone()).collect(),
+    };
+
+    if chunks.len() < MIN_STREAM_CHUNKS {
+        return Vec::new();
+    }
+    chunks
+}
 
 /// Everything a traversal accumulates, kept separate from the stage that
 /// feeds it so several stages can be walked into the same scene and each
@@ -208,6 +274,22 @@ fn traverse_into(stage: &Stage, root: Prim, root_xf: GMat4, ctx: &mut ImportCtx)
     }
 }
 
+/// Opens the stage with payloads loaded, optionally masked to one subtree.
+fn open_stage(
+    path: &Path,
+    path_str: &str,
+    mask: Option<sdf::Path>,
+) -> Result<Stage, crate::Error> {
+    let mut builder = Stage::builder().load(InitialLoadSet::LoadAll);
+    if let Some(p) = mask {
+        builder = builder.mask(StagePopulationMask::new([p]));
+    }
+    builder.open(path_str).map_err(|e| crate::Error::UsdOpen {
+        path: path.to_path_buf(),
+        message: e.to_string(),
+    })
+}
+
 pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene, crate::Error> {
     let import_start = Instant::now();
     let mut stats = RenderStats::new();
@@ -216,16 +298,24 @@ pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene,
         .to_str()
         .ok_or_else(|| crate::Error::NonUtf8Path(path.to_path_buf()))?;
 
+    // Open once without payloads: enough to read render settings and see
+    // the stage's shape, but none of the geometry. On a production scene
+    // the payloads *are* the cost — composing the whole Moana island
+    // costs openusd 75.74 GiB, where this costs a fraction of that.
     let open_start = Instant::now();
-    let stage = Stage::open(path_str).map_err(|e| crate::Error::UsdOpen {
-        path: path.to_path_buf(),
-        message: e.to_string(),
-    })?;
+    let index = Stage::builder()
+        .load(InitialLoadSet::LoadNone)
+        .open(path_str)
+        .map_err(|e| crate::Error::UsdOpen {
+            path: path.to_path_buf(),
+            message: e.to_string(),
+        })?;
+    // Render settings come first — the camera importer needs the aspect ratio.
+    let settings = import_render_settings(&index);
+    let chunks = stream_roots(&index);
+    drop(index);
     let open_elapsed = open_start.elapsed();
     let open_mem = MemorySample::now();
-
-    // Render settings come first — the camera importer needs the aspect ratio.
-    let settings = import_render_settings(&stage);
 
     let mut ctx = ImportCtx {
         world: WorldBuilder::new(),
@@ -244,12 +334,36 @@ pub(crate) fn load_scene(path: &Path, assets: &dyn AssetLoader) -> Result<Scene,
     };
 
     let traverse_start = Instant::now();
-    traverse_into(
-        &stage,
-        stage.prim_at(sdf::Path::abs_root()),
-        GMat4::IDENTITY,
-        &mut ctx,
-    );
+    if chunks.is_empty() {
+        // Small or flat stage: one pass, exactly as before.
+        let stage = open_stage(path, path_str, None)?;
+        traverse_into(
+            &stage,
+            stage.prim_at(sdf::Path::abs_root()),
+            GMat4::IDENTITY,
+            &mut ctx,
+        );
+    } else {
+        debug!("Streaming import over {} subtrees", chunks.len());
+        for chunk in &chunks {
+            let stage = open_stage(path, path_str, Some(chunk.clone()))?;
+            // Traverse from the root, not from `chunk`: a mask keeps the
+            // masked path's *ancestors* populated, so starting at the
+            // root picks up their transforms exactly as a full traversal
+            // would, while everything outside the chunk stays absent.
+            traverse_into(
+                &stage,
+                stage.prim_at(sdf::Path::abs_root()),
+                GMat4::IDENTITY,
+                &mut ctx,
+            );
+            // Separate this stage's prototypes from the next stage's —
+            // see ImportCaches::epoch. Deliberately not a clear: the
+            // mesh cache keys materials by Arc address, so nothing may
+            // be freed while it is live.
+            ctx.caches.epoch += 1;
+        }
+    }
 
     // The traverse also builds each mesh's and prototype's kernel scene,
     // so its own BVH work is inside this figure; the separate "Commit
@@ -904,8 +1018,24 @@ struct ImportCaches {
     materials: MaterialCache,
     /// Mesh content + material → the mesh's local-space kernel scene.
     meshes: HashMap<MeshKey, Arc<RtScene>>,
-    /// Prototype path → its parts, for both instancing mechanisms.
-    protos: HashMap<String, Arc<Vec<ProtoPart>>>,
+    /// `(epoch, prototype path)` → its parts, for both instancing
+    /// mechanisms. See [`ImportCaches::epoch`] for the epoch.
+    protos: HashMap<(u32, String), Arc<Vec<ProtoPart>>>,
+    /// Which stage the entries above came from.
+    ///
+    /// Prototype paths (`/__Prototype_N`) are numbered per composition, so
+    /// under the streaming importer the same name denotes different
+    /// geometry in each stage. Bumping the epoch between stages keeps
+    /// those apart.
+    ///
+    /// It bumps rather than clearing because [`MeshKey`] identifies a
+    /// material by its `Arc` *address*: dropping the parts would free
+    /// material `Arc`s whose addresses a later allocation could reuse,
+    /// and a stale mesh-cache entry would then match the wrong material.
+    /// Nothing here is freed before the import ends, so those addresses
+    /// stay unique — and the mesh and material caches keep deduplicating
+    /// across stages, which is what stops streaming costing extra memory.
+    epoch: u32,
 }
 
 /// One leaf geometry of a prototype: a committed kernel scene in its own
@@ -1353,14 +1483,14 @@ fn prototype_parts(
     caches: &mut ImportCaches,
     depth: usize,
 ) -> Arc<Vec<ProtoPart>> {
-    let key = proto_path.to_string();
+    let key = (caches.epoch, proto_path.to_string());
     if let Some(parts) = caches.protos.get(&key) {
         return parts.clone();
     }
     let root = stage.prim_at(proto_path.clone());
     let parts = Arc::new(collect_proto_parts(stage, &root, caches, depth));
     if parts.is_empty() {
-        warn!("Prototype {key} contributed no geometry");
+        warn!("Prototype {} contributed no geometry", key.1);
     }
     caches.protos.insert(key, parts.clone());
     parts

--- a/crates/crust-core/src/stats.rs
+++ b/crates/crust-core/src/stats.rs
@@ -20,11 +20,36 @@ use std::time::Duration;
 /// One timed phase. `depth` gives the nesting used by the execution-tree
 /// view: a phase at depth 1 is a sub-phase of the nearest preceding
 /// depth-0 phase, and its time is *included* in that parent's.
+///
+/// The two memory figures are sampled when the phase ends. `rss_end` is
+/// what is still resident; `peak_end` is the high-water mark reached at
+/// any point up to then. A large gap between them says the phase
+/// allocated far more than it kept — transient build churn, which costs
+/// page faults and time even though the final structures are small.
 #[derive(Clone, Debug)]
 pub struct Phase {
     pub name: String,
     pub depth: u8,
     pub duration: Duration,
+    pub rss_end: Option<u64>,
+    pub peak_end: Option<u64>,
+}
+
+/// Resident and peak memory at one instant. Capture at a phase boundary
+/// with [`MemorySample::now`] and hand to [`RenderStats::record_at`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct MemorySample {
+    pub rss: Option<u64>,
+    pub peak: Option<u64>,
+}
+
+impl MemorySample {
+    pub fn now() -> Self {
+        MemorySample {
+            rss: current_memory_bytes(),
+            peak: peak_memory_bytes(),
+        }
+    }
 }
 
 /// Primitives split by kind. Mirrors [`crate::rt::PrimitiveBreakdown`].
@@ -81,6 +106,11 @@ pub struct SceneCounters {
     pub unique: PrimitiveCounts,
     pub lights: usize,
     pub volumes: usize,
+    /// Exact kernel-resident bytes, by structure. Everything outside
+    /// `crust-rt` — materials, the USD stage, import caches — is *not*
+    /// counted, so this being well under peak RSS is expected and the gap
+    /// is itself informative.
+    pub footprint: crate::rt::MemoryFootprint,
 }
 
 /// Image-level parameters worth reporting next to the costs they drove.
@@ -121,14 +151,30 @@ impl RenderStats {
         Self::default()
     }
 
-    /// Records a completed phase. `depth` 0 is top level; deeper phases are
-    /// sub-phases of the nearest preceding shallower one, and their time is
-    /// counted inside it.
+    /// Records a completed phase, sampling memory **now**. Correct only
+    /// when called at the moment the phase ends; a caller that records
+    /// several phases together must capture a [`MemorySample`] at each
+    /// boundary and use [`RenderStats::record_at`] instead, or every phase
+    /// will report the same figures.
     pub fn record(&mut self, name: impl Into<String>, depth: u8, duration: Duration) {
+        self.record_at(name, depth, duration, MemorySample::now());
+    }
+
+    /// Records a completed phase with memory captured earlier — at the
+    /// phase's actual end rather than at reporting time.
+    pub fn record_at(
+        &mut self,
+        name: impl Into<String>,
+        depth: u8,
+        duration: Duration,
+        mem: MemorySample,
+    ) {
         self.phases.push(Phase {
             name: name.into(),
             depth,
             duration,
+            rss_end: mem.rss,
+            peak_end: mem.peak,
         });
     }
 
@@ -149,6 +195,19 @@ impl RenderStats {
     }
 }
 
+/// Reads one `VmXxx:` field of `/proc/self/status`, in bytes.
+#[cfg(target_os = "linux")]
+fn proc_status_bytes(field: &str) -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix(field) {
+            let kb: u64 = rest.split_whitespace().next()?.parse().ok()?;
+            return Some(kb * 1024);
+        }
+    }
+    None
+}
+
 /// Peak resident set size in bytes, if the platform can report it.
 ///
 /// Peak rather than current: the interesting number for a renderer is the
@@ -157,14 +216,21 @@ impl RenderStats {
 pub fn peak_memory_bytes() -> Option<u64> {
     #[cfg(target_os = "linux")]
     {
-        let status = std::fs::read_to_string("/proc/self/status").ok()?;
-        for line in status.lines() {
-            if let Some(rest) = line.strip_prefix("VmHWM:") {
-                let kb: u64 = rest.split_whitespace().next()?.parse().ok()?;
-                return Some(kb * 1024);
-            }
-        }
+        proc_status_bytes("VmHWM:")
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
         None
+    }
+}
+
+/// Currently resident set size in bytes. Paired with
+/// [`peak_memory_bytes`], the difference exposes transient allocation:
+/// memory a phase took and gave back.
+pub fn current_memory_bytes() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        proc_status_bytes("VmRSS:")
     }
     #[cfg(not(target_os = "linux"))]
     {
@@ -217,7 +283,7 @@ impl fmt::Display for RenderStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Wide enough that the longest phase name ("Commit acceleration
         // structure", nested one level) still clears the time column.
-        const WIDTH: usize = 62;
+        const WIDTH: usize = 84;
         const NAME: usize = 36;
         let rule = "-".repeat(WIDTH);
         let total = self.total();
@@ -280,6 +346,31 @@ impl fmt::Display for RenderStats {
         if s.volumes > 0 {
             writeln!(f, "  {:<28} {}", "volume regions", thousands(s.volumes))?;
         }
+
+        // Exact kernel bytes, then peak RSS. The difference is everything
+        // the kernel does not own — materials, the USD stage, caches — so
+        // showing both says where to look next.
+        let fp = &s.footprint;
+        if fp.total() > 0 {
+            writeln!(
+                f,
+                "  {:<28} {}",
+                "kernel memory",
+                human_bytes(fp.total() as u64)
+            )?;
+            for (label, bytes) in [
+                ("primitive nodes", fp.prim_nodes),
+                ("boxed primitives", fp.boxed_prims),
+                ("BVH nodes", fp.bvh_nodes),
+                ("triangle packets", fp.packets),
+                ("leaf indices", fp.indices),
+                ("leaves", fp.leaves),
+            ] {
+                if bytes > 0 {
+                    writeln!(f, "    {:<26} {}", label, human_bytes(bytes as u64))?;
+                }
+            }
+        }
         if let Some(peak) = peak_memory_bytes() {
             writeln!(f, "  {:<28} {}", "peak memory (RSS)", human_bytes(peak))?;
         }
@@ -291,16 +382,22 @@ impl fmt::Display for RenderStats {
         // -- Profile by execution tree ---------------------------------
         writeln!(f, "{rule}")?;
         writeln!(f, "Profile by execution tree")?;
+        // `rss` is what the phase left resident; `peak` the high-water
+        // reached by its end. peak >> rss means transient churn.
+        writeln!(f, "{:<NAME$} {:>9}  {:>5}  {:>9} {:>9}", "", "time", "%", "rss", "peak")?;
         writeln!(f, "{rule}")?;
         for p in &self.phases {
             let indent = "  ".repeat(1 + p.depth as usize);
             let name_width = NAME.saturating_sub(indent.len());
+            let mem = |b: Option<u64>| b.map(human_bytes).unwrap_or_default();
             writeln!(
                 f,
-                "{indent}{:<name_width$} {:>9}  {:>5.1}%",
+                "{indent}{:<name_width$} {:>9}  {:>5.1}%  {:>9} {:>9}",
                 p.name,
                 human_duration(p.duration),
                 pct(p.duration),
+                mem(p.rss_end),
+                mem(p.peak_end),
             )?;
         }
         writeln!(

--- a/crates/crust-rt/src/bvh.rs
+++ b/crates/crust-rt/src/bvh.rs
@@ -237,6 +237,37 @@ impl Bvh {
         b
     }
 
+    /// Adds this BVH's resident bytes to `acc`, descending into each
+    /// distinct instanced scene once. Uses `capacity`, not `len`: unused
+    /// capacity is resident too, and over-allocation is exactly the kind
+    /// of waste a memory report should not hide.
+    pub(crate) fn accumulate_footprint(
+        &self,
+        visited: &mut std::collections::HashSet<usize>,
+        acc: &mut crate::scene::MemoryFootprint,
+    ) {
+        use std::mem::size_of;
+        acc.prim_nodes += self.prims.capacity() * size_of::<PrimNode>();
+        acc.bvh_nodes += self.wide.capacity() * size_of::<WideNode>();
+        acc.leaves += self.leaves.capacity() * size_of::<Leaf>();
+        acc.packets += self.packets.capacity() * size_of::<Tri4>();
+        acc.indices += self.indices.capacity() * size_of::<u32>();
+        for p in &self.prims {
+            match p {
+                PrimNode::Instance(i) => {
+                    acc.boxed_prims += size_of::<crate::prim::InstancePrim>();
+                    if visited.insert(std::sync::Arc::as_ptr(&i.scene) as usize) {
+                        i.scene.accumulate_footprint_into(visited, acc);
+                    }
+                }
+                PrimNode::CubicCurve(_) => {
+                    acc.boxed_prims += size_of::<crate::prim::CubicCurvePrim>();
+                }
+                _ => {}
+            }
+        }
+    }
+
     /// Adds this BVH's primitives to `acc`, descending into each *distinct*
     /// instanced scene exactly once — `visited` holds the `Arc` addresses
     /// already counted. The result is the geometry actually resident in
@@ -857,8 +888,22 @@ fn build_subtree(
 
     let (left_refs, right_refs) = if let Some(s) = spatial {
         // Chop: straddling references are clipped into both children.
-        let mut left = Vec::with_capacity(count);
-        let mut right = Vec::with_capacity(count);
+        // Size each side first (bbox compares only, no clipping): a
+        // straddling reference may land in both, so this is an upper
+        // bound, but a far tighter one than the input length twice over.
+        let (mut n_left, mut n_right) = (0usize, 0usize);
+        for r in &refs {
+            if r.bbox.maximum[s.axis] <= s.pos {
+                n_left += 1;
+            } else if r.bbox.minimum[s.axis] >= s.pos {
+                n_right += 1;
+            } else {
+                n_left += 1;
+                n_right += 1;
+            }
+        }
+        let mut left = Vec::with_capacity(n_left);
+        let mut right = Vec::with_capacity(n_right);
         for r in refs {
             if r.bbox.maximum[s.axis] <= s.pos {
                 left.push(r);
@@ -895,7 +940,9 @@ fn build_subtree(
                 if count <= MAX_LEAF && o.cost >= surface_area(&bbox) * count as f32 {
                     return leaf(bbox, &refs);
                 }
-                partition_by_bin(&mut refs, &o)
+                // By value: the parent's buffer is freed here rather than
+                // staying alive through both children's parallel builds.
+                partition_by_bin(refs, &o)
             }
             // Every centroid coincides: median split by input order.
             None => {
@@ -925,7 +972,7 @@ fn build_subtree(
 /// fallback: object-partition when possible, else leaf.
 fn object_partition_or_leaf(
     prims: &[PrimNode],
-    mut refs: Vec<PrimRef>,
+    refs: Vec<PrimRef>,
     bbox: AABB,
     object: Option<ObjSplit>,
     depth: usize,
@@ -934,7 +981,7 @@ fn object_partition_or_leaf(
     let count = refs.len();
     match object {
         Some(o) if count > min_leaf_for(prims, &refs) => {
-            let (l, r) = partition_by_bin(&mut refs, &o);
+            let (l, r) = partition_by_bin(refs, &o);
             if l.is_empty() || r.is_empty() {
                 let mut all = l;
                 all.extend(r);
@@ -964,12 +1011,23 @@ fn min_leaf_for(prims: &[PrimNode], refs: &[PrimRef]) -> usize {
 
 /// Order-preserving partition of `refs` by the object split's centroid
 /// bin — deterministic for a given input order.
-fn partition_by_bin(refs: &mut Vec<PrimRef>, o: &ObjSplit) -> (Vec<PrimRef>, Vec<PrimRef>) {
-    let mut left = Vec::with_capacity(refs.len());
-    let mut right = Vec::with_capacity(refs.len());
-    for r in refs.drain(..) {
-        let bin = (((r.centroid()[o.axis] - o.cmin) * o.scale) as usize).min(BINS - 1);
-        if bin <= o.split_bin {
+///
+/// Takes `refs` **by value** and counts each side before allocating, so
+/// the two children together hold exactly one copy of the input rather
+/// than two. Sizing both sides at the full input length instead — the
+/// obvious one-pass version — wastes an allocation the size of the input
+/// at every node of the recursion, and hands the parent's buffer down
+/// alive into a parallel subtree build. On a scene with 100M references
+/// that is the difference between a build that fits and one that does
+/// not. The extra pass is a few flops per reference against an
+/// allocation it avoids touching at all.
+fn partition_by_bin(refs: Vec<PrimRef>, o: &ObjSplit) -> (Vec<PrimRef>, Vec<PrimRef>) {
+    let bin_of = |r: &PrimRef| (((r.centroid()[o.axis] - o.cmin) * o.scale) as usize).min(BINS - 1);
+    let n_left = refs.iter().filter(|r| bin_of(r) <= o.split_bin).count();
+    let mut left = Vec::with_capacity(n_left);
+    let mut right = Vec::with_capacity(refs.len() - n_left);
+    for r in refs {
+        if bin_of(&r) <= o.split_bin {
             left.push(r);
         } else {
             right.push(r);

--- a/crates/crust-rt/src/lib.rs
+++ b/crates/crust-rt/src/lib.rs
@@ -42,7 +42,8 @@ mod triangle;
 pub use aabb::AABB;
 pub use ray::{MASK_ALL, MASK_CAMERA, MASK_INDIRECT, MASK_SHADOW, Ray};
 pub use scene::{
-    CubicCurveSegment, CurveSegment, Geometry, PrimitiveBreakdown, RayHit, Scene, SceneBuilder,
+    CubicCurveSegment, CurveSegment, Geometry, MemoryFootprint, PrimitiveBreakdown, RayHit, Scene,
+    SceneBuilder,
 };
 
 /// The `geom_id`/`prim_id` value that never names a real geometry.

--- a/crates/crust-rt/src/prim.rs
+++ b/crates/crust-rt/src/prim.rs
@@ -266,7 +266,14 @@ pub(crate) struct InstancePrim {
     pub w2l: Affine3A,
     pub normal_mat: Mat3A,
     /// Local-to-world at shutter time 1, when the instance moves.
-    pub l2w_end: Option<Affine3A>,
+    ///
+    /// Boxed for the same reason as [`crate::Geometry::Instance`]'s
+    /// `transform_end`, and it matters far more here: `Geometry` values
+    /// are transient build inputs, whereas an `InstancePrim` is resident
+    /// for the whole render. Inline, the `Option` costs 80 bytes on every
+    /// instance — a scene with tens of millions of static placements pays
+    /// gigabytes for a field none of them use.
+    pub l2w_end: Option<Box<Affine3A>>,
     pub bounds: AABB,
     pub geom_id: u32,
     pub mask: u32,
@@ -316,7 +323,7 @@ impl InstancePrim {
     fn transforms_at(&self, time: f32) -> (Affine3A, Mat3A) {
         match &self.l2w_end {
             Some(end) if time > 0.0 => {
-                let w2l = lerp_affine(&self.l2w, end, time).inverse();
+                let w2l = lerp_affine(&self.l2w, end.as_ref(), time).inverse();
                 (w2l, w2l.matrix3.transpose())
             }
             _ => (self.w2l, self.normal_mat),

--- a/crates/crust-rt/src/scene.rs
+++ b/crates/crust-rt/src/scene.rs
@@ -22,6 +22,40 @@ pub struct CurveSegment {
     pub r1: f32,
 }
 
+/// Exact bytes a committed [`Scene`] holds, by structure — the kernel's
+/// side of a memory report. Counts `capacity`, not `len`, because unused
+/// capacity is resident too, and deduplicates shared instanced scenes so
+/// a prototype placed a thousand times is counted once.
+///
+/// Only the kernel's own allocations: the application's material tables,
+/// the USD stage and anything else outside `crust-rt` are not visible
+/// from here.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MemoryFootprint {
+    /// The `PrimNode` arrays — every primitive, whatever its kind.
+    pub prim_nodes: usize,
+    /// Payloads of the boxed variants (instances, cubic curves).
+    pub boxed_prims: usize,
+    /// 4-wide BVH nodes.
+    pub bvh_nodes: usize,
+    pub leaves: usize,
+    /// Triangle SIMD packets.
+    pub packets: usize,
+    /// Leaf primitive indices.
+    pub indices: usize,
+}
+
+impl MemoryFootprint {
+    pub fn total(&self) -> usize {
+        self.prim_nodes
+            + self.boxed_prims
+            + self.bvh_nodes
+            + self.leaves
+            + self.packets
+            + self.indices
+    }
+}
+
 /// Top-level primitives of a committed [`Scene`], split by kind. See
 /// [`Scene::primitive_breakdown`].
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -236,7 +270,7 @@ impl SceneBuilder {
                         l2w: transform,
                         normal_mat: w2l.matrix3.transpose(),
                         w2l,
-                        l2w_end: transform_end.map(|end| *end),
+                        l2w_end: transform_end,
                         bounds,
                         geom_id,
                         mask,
@@ -326,6 +360,23 @@ impl Scene {
         acc: &mut PrimitiveBreakdown,
     ) {
         self.bvh.accumulate_unique(visited, acc);
+    }
+
+    /// Exact resident bytes of this scene and every distinct scene it
+    /// instances — see [`MemoryFootprint`].
+    pub fn memory_footprint(&self) -> MemoryFootprint {
+        let mut visited = std::collections::HashSet::new();
+        let mut acc = MemoryFootprint::default();
+        self.accumulate_footprint_into(&mut visited, &mut acc);
+        acc
+    }
+
+    pub(crate) fn accumulate_footprint_into(
+        &self,
+        visited: &mut std::collections::HashSet<usize>,
+        acc: &mut MemoryFootprint,
+    ) {
+        self.bvh.accumulate_footprint(visited, acc);
     }
 
     /// Internal closest-hit that keeps the *outward* (unoriented) normal,


### PR DESCRIPTION
## What

Cuts peak memory on the complete Moana island by **63%** and runtime by
**30%**, with output pixel-identical.

| | before | after |
|---|---|---|
| peak memory (RSS) | 117.10 GiB | **43.76 GiB** |
| total time | 13:20.7 | **09:18.8** |
| triangles imported | 56 825 650 | 56 825 650 |
| pixels differing | — | **0 / 230 400** |

## How it was found

The per-phase profiling added in #118 said parsing was 75% of runtime, so
the first attempts were aimed at the kernel. Measurement then closed the
accounting and redirected the work:

- kernel structures: **39.12 GiB** of a 115.67 GiB peak
- openusd's stage alone, building nothing: **75.74 GiB and 6m19s**

Two thirds of the memory and about half the runtime were USD, not us. The
kernel-side fixes here (boxing `InstancePrim::l2w_end`, exact-size BVH
partitions) are real but worth only 2.53 GiB — that ceiling is the point,
and it is what motivated the rest.

Three hypotheses were tested and **disproved** rather than assumed: BVH
build churn (predicted ~85 GiB, actual 0.49), glibc arena fragmentation
(1.43 GiB), and a prototype-cache/`Arc`-lifetime theory (left the counts
byte-identical).

## The change

Composing the whole island costs openusd 75.74 GiB; composing a stage
masked to one element costs 1.10 GiB. So `load_scene` opens a cheap index
stage (`InitialLoadSet::LoadNone`) for the render settings and the list of
top-level subtrees, then composes, traverses and **drops one masked stage
per subtree**, bounding the composed set at roughly one element.

`MIN_STREAM_CHUNKS` keeps the single-stage path for scenes too small to
repay the re-opens; `CRUST_STREAM_IMPORT=0` forces it, and is how the two
paths were A/B'd against each other.

## The bug this surfaced, and why it was hard

Prototype paths (`/__Prototype_N`) are numbered **per composition**, so
every masked stage has its own `/__Prototype_0`. `MaterialCache` keyed on
the bare path handed one chunk's material to the next chunk's geometry;
because `MeshKey` identifies a material by its `Arc` *address*, distinct
meshes then collapsed onto shared cache entries — **50 990 392 triangles
instead of 56 825 650, and 1.5% of pixels wrong.**

It is invisible to targeted testing: **all twenty elements are identical in
both modes individually.** It needs two chunks that both carry
prototype-internal materials. Running the elimination to completion is what
proved it had to be an interaction, which is what pointed at the one cache
still keyed on an unstable path.

Only prototype-internal paths are now epoch-scoped, so authored paths still
deduplicate across chunks — which is what stops streaming costing memory.

An intermediate commit (`05a6fb9`) lands the feature *disabled* with the bug
documented; the next fixes it and enables it. Kept deliberately so the
hazard is on record, but happy to squash.

## Testing

- Island: pixel-identical (0/230400), all scene counters unchanged.
- 99 crust-core + 45 crust-rt + 22 USD integration tests pass.
- `scripts/test_simd_matrix.sh -p crust-rt` bit-exact across all four
  codegen configurations.
- A/B'd single-stage vs streaming on every element of the island.

## Follow-ups (not in this PR)

1. `MeshKey` still identifies materials by `Arc` address, making "no material
   `Arc` may be freed during import" an unwritten invariant. Both this bug and
   the earlier prototype one were instances of that hazard class; keying on the
   authored path would remove it.
2. `Stage::prototypes()` returns `[]` even unmasked while `prim.prototype()`
   resolves correctly — an openusd inconsistency noticed but not chased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)