### PR TITLE
Document colour management, and propose making it explicit per input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,6 +497,10 @@ Schema mapping:
     resolves. Texels are decoded to linear once at load (the island's graph gammas raw
     Ptex, and `HwPtexTexture_1` declares `sourceColorSpace = "sRGB"`; treating the data as
     already linear overshoots albedo ~4×, which `examples/tex_probe` exists to settle).
+    `docs/color_management.md` is the per-input inventory of which colour space every
+    input is assumed to be in and what curve is applied — including the two gaps that
+    are still open (`UsdPreviewSurface` colours are read undecoded, and nothing enforces
+    that a new colour input states its space at all).
   - `CRUST_PTEX=0` declines every texture so the same scene renders on its constant
     `baseColor` — the A/B switch that separates a wrong Ptex lookup from a wrong material
     or wrong lighting.

--- a/docs/color_management.md
+++ b/docs/color_management.md
@@ -1,0 +1,233 @@
+# Color management
+
+Every mathematical operation in the renderer — BSDF evaluation, MIS weighting,
+volume transport, pixel filtering, sample accumulation — assumes its inputs are
+**linear light**. Light adds and scales linearly; a display-encoded value does
+not. Mixing the two silently produces plausible-looking images that are wrong:
+a display-encoded value used directly as an albedo always *overshoots*
+reflectance, by a factor that grows as the colour gets darker — 1.4× at an
+authored 0.75, 2.3× at 0.5, 6.6× at 18% grey, 10× at 0.1. Because the factor is
+value-dependent, the error is not a brightness offset but a nonlinear
+redistribution that no exposure correction can undo.
+
+This document records, per input, what colour space it is assumed to be
+authored in and what conversion is actually applied. It exists because the
+answer is currently **not uniform** and not enforced anywhere — see
+[Known gaps](#known-gaps).
+
+## The invariant
+
+> Every colour-valued input is converted to linear at **import or asset-load
+> time**, once, before it reaches any shading, lighting, or transport code.
+> Scalar (non-colour) inputs are never transfer-converted. The only
+> re-encoding happens on output, when writing the preview PNG.
+
+Import-time conversion is a deliberate choice over converting at lookup: it
+costs O(materials + texels loaded) rather than O(samples), so it never appears
+in a per-ray profile.
+
+The work is split across the two crates along the same seam as everything else:
+`crust-core` converts values it reads from USD *attributes* itself
+(`usd_import.rs`), but decodes no **asset** — every image and Ptex decoder lives
+in the host (`crust-render/src/main.rs`), reached through `AssetLoader`. The
+`PtexTexture` trait pins the contract at that boundary
+(`crust-core/src/texture.rs:32`): values returned from `eval` are linear, not
+display-encoded, so the host must have decoded them already.
+
+## Two transfer curves, deliberately
+
+There are two decode curves in the codebase, and they are not
+interchangeable:
+
+| Curve | Formula | Where |
+| --- | --- | --- |
+| **Piecewise sRGB EOTF** | `c ≤ 0.04045 ? c/12.92 : ((c+0.055)/1.055)^2.4` | LDR environment images (`main.rs:121-129`) |
+| **Flat gamma 2.2** | `max(c,0)^2.2` | `PxrDisneyBsdf.baseColor` (`usd_import.rs:2862`), Ptex texels (`main.rs:251`) |
+
+The flat curve is *not* a sloppy approximation of the standard one — it is
+matched to what the source content actually applies. The Moana island's shading
+networks run Ptex colour through a `PxrColorCorrect` gamma-1/2.2 node, and its
+GL path declares `sourceColorSpace = "sRGB"`; reproducing the reference render
+matters more there than conforming to the sRGB standard. Both decisions carry
+that reasoning in a comment at the call site (`usd_import.rs:2856-2861`,
+`main.rs:245-250`).
+
+How much does the distinction matter? Across most of the range, very little —
+maximum absolute difference over `[0,1]` is 0.0085, and at 0.5 the two give
+0.2140 vs 0.2176 (1.7% relative). The divergence is concentrated entirely in
+the **deep shadows**, where the piecewise curve's linear toe keeps values well
+above the pure power law:
+
+| Encoded | sRGB EOTF | Gamma 2.2 | Ratio |
+| --- | --- | --- | --- |
+| 0.01 | 0.000774 | 0.000040 | 19.4× |
+| 0.02 | 0.001548 | 0.000183 | 8.5× |
+| 0.05 | 0.003936 | 0.001373 | 2.9× |
+| 0.10 | 0.010023 | 0.006310 | 1.6× |
+| 0.50 | 0.214041 | 0.217638 | 0.98× |
+
+So: swapping the curves is invisible in midtones and highlights, and up to an
+order of magnitude wrong in near-black albedo. Do not "simplify" them into one.
+
+## Input inventory
+
+The authoritative list of every colour-valued input the renderer reads, and its
+current treatment. Note that "no curve applied" is the *majority* case and is
+correct almost everywhere — the two `UsdPreviewSurface` rows are the only
+genuine bug in the table (see the Verdict column).
+
+### Material shader inputs
+
+| Input | Read at | Curve applied | Verdict |
+| --- | --- | --- | --- |
+| `UsdPreviewSurface.diffuseColor` | `usd_import.rs:2651` | **none** | ⚠️ **bug** — see [Known gaps](#known-gaps) |
+| `UsdPreviewSurface.emissiveColor` | `usd_import.rs:2665` | **none** | ⚠️ **bug** — same |
+| `PxrDisneyBsdf.baseColor` | `usd_import.rs:2740` | flat 2.2 | ✅ intentional (island `PxrColorCorrect`) |
+| `crust:openpbr` — all 7 colour fields[^1] | `usd_import.rs:2886` | **none** | ✅ intentional — native format is linear-authored |
+
+[^1]: `baseColor`, `specularColor`, `transmissionColor`, `subsurfaceColor`,
+`fuzzColor`, `coatColor`, `emissionColor` — all via the `c` closure at
+`usd_import.rs:2886`, fields assigned across `2891-2953`.
+
+`crust:openpbr` is crust's own lossless 1:1 mirror of the `OpenPBR` struct, so
+values are authored in the renderer's working space by definition. That makes
+"no conversion" correct — but note it is achieved by *not calling anything*,
+not by a stated decision.
+
+### Lights
+
+| Input | Read at | Curve applied | Verdict |
+| --- | --- | --- | --- |
+| `inputs:color` (all four lux types[^2]) | `usd_import.rs:2240` via `attr_color3f:3168` | **none** | ✅ correct — see below |
+
+[^2]: `UsdLuxDistantLight`, `UsdLuxDomeLight`, `UsdLuxSphereLight`,
+`UsdLuxRectLight` — all four share the one `lux_emission` helper, so there is a
+single place where a light's colour is read.
+
+`UsdLuxLightAPI`'s own schema documentation specifies `inputs:color` as being
+"**in the rendering color space**." For a linear-light-transport renderer that
+*is* linear, so no conversion is the right answer — not an oversight. It is
+multiplied by `intensity × 2^exposure` (both pure scalars, no colour-space
+implication) into the emission value handed to `DistantLight`/`DomeLight`/
+`Emissive`.
+
+Dome-light textures are decoded separately by the host (see below) and are
+**not** double-decoded: `usd_import.rs` only resolves the path and hands it to
+`AssetLoader::load_environment`, then multiplies the already-linear map by the
+already-linear tint.
+
+### Volume coefficients
+
+| Input | Read at | Curve applied | Verdict |
+| --- | --- | --- | --- |
+| `crust:volume:sigmaS` | `usd_import.rs:482` via `custom_color3:3130` | **none** | ✅ correct |
+| `crust:volume:sigmaA` | `usd_import.rs:483` | **none** | ✅ correct |
+| `crust:volume:emission` | `usd_import.rs:484` | **none** | ✅ correct |
+
+These are crust-custom attributes (no upstream schema to defer to) holding
+*physical quantities* — scattering and absorption cross-sections, and emitted
+radiance. They are authored directly as numbers, never picked from a colour
+swatch, so there is no display encoding to undo. Same reasoning as
+`crust:openpbr`.
+
+### Textures and environment maps
+
+| Asset | Read at | Curve applied | Verdict |
+| --- | --- | --- | --- |
+| Ptex `.ptx` colour texels | `main.rs:251` | flat 2.2 | ✅ intentional (island convention) |
+| LDR env image (PNG/JPG/…) | `main.rs:121-129` | piecewise sRGB | ✅ correct per format |
+| `.hdr` env image | `main.rs:122` | none (pass-through) | ✅ correct — HDR is scene-linear |
+| `.exr` env map | `main.rs:78` | none (pass-through) | ✅ correct — EXR is linear |
+
+The `is_hdr` branch at `main.rs:117-120` exists because `image`'s `to_rgb32f`
+rescales integer formats into `0..1` *without* removing their transfer curve,
+while leaving true HDR values as authored — so the decode must be conditional
+on the format, not applied blanket. Pinned by
+`ldr_images_are_converted_to_linear` (`main.rs:692`).
+
+Ptex texels are decoded once at load into the preloaded immutable buffer, not
+per lookup — which is also why `CRUST_PTEX_MAX_LOG2`'s mip cap and the decode
+share the same pass.
+
+## Scalar inputs are never converted
+
+Roughness, weights, IOR, anisotropy, metalness, opacity, `intensity`,
+`exposure`, volume `anisotropy`, `densityScale` — every scalar parameter is
+used at its authored value. A transfer curve encodes *perceptual* response for
+colour channels; applying one to a roughness or an IOR is meaningless.
+
+The type system already enforces this direction of the rule by accident: the
+decode helpers take `Vec3A`, and scalars are `f32`, so a scalar cannot be fed
+to one. The reverse — a colour that never passes *through* a decode — is
+unenforced, and is exactly how the `UsdPreviewSurface` gap below arose.
+
+## The output side
+
+The engine produces a linear `Buffer`. The CLI writes it two ways
+(`crust-render/src/main.rs`):
+
+- **`.exr`** — the linear values, unmodified. This is the render output.
+- **`.png`** — tone-mapped: clamp to `[0,1]`, then encode with the piecewise
+  sRGB OETF (`tone_map`, `main.rs:460-468`). A preview, not a deliverable.
+
+`tone_map` is the *inverse* of the LDR-image decode above, using the standard
+piecewise curve in the forward direction. Comparing renders numerically should
+always use the EXR (`examples/exr_diff`), never the PNG, since the PNG has both
+clamped and re-encoded.
+
+## Known gaps
+
+**1. `UsdPreviewSurface` colours are not decoded.** `diffuseColor` and
+`emissiveColor` land in `OpenPBR` raw (`usd_import.rs:2651`, `2665`). Values
+authored as DCC colour-picker swatches — the normal case for this schema — are
+therefore used as if already linear, overshooting albedo substantially. Note
+for honesty: the `UsdPreviewSurface` spec itself does **not** mandate a colour
+space for these inputs (its only explicit colour-space note concerns normal
+maps), so treating them as sRGB is a defensible convention rather than a
+standards requirement — but "no conversion at all" is not a defensible reading
+of any convention.
+
+**2. No shared abstraction, so nothing is enforced.** There is no `ColorSpace`
+type. The two curves exist as independent inline implementations
+(`usd_import.rs:2862`, `main.rs:251`) that happen to agree. Nothing forces a
+newly added colour input to state its source space; the default behaviour of
+adding one is to get gap #1 again, silently.
+
+**3. Per-attribute colour-space authoring is unsupported.** A USD attribute
+carrying an explicit `colorSpace` metadatum is ignored; the curve is chosen by
+shader family, not by what the asset declares.
+
+Gaps #1 and #2 are addressed by the OpenSpec change
+`openspec/changes/add-material-color-management/`, which introduces a
+`ColorSpace { Linear, Srgb, Gamma(f32) }` enum plus a `RawColor3` newtype at
+each of the three attribute-reading primitives (`shader_input_vec3`,
+`attr_color3f`, `custom_color3`) so that *every* colour call site must name its
+space — including the ones whose answer is `Linear`. **Not yet implemented.**
+
+## Diagnosing a suspected colour-space bug
+
+A wrong transfer curve produces a plausible image, so appearance proves
+nothing. Two switches answer in numbers instead:
+
+```bash
+# Is the surface's colour coming from the texture or the constant fallback?
+# CRUST_PTEX=0 declines every Ptex texture; surfaces fall back to baseColor.
+CRUST_PTEX=0 cargo run --release -- -i scene.usda -o out.exr
+
+# What are the actual texel values, before and after decode?
+cargo run --release -p crust-render --example tex_probe -- texture.ptx
+cargo run --release -p crust-render --example tex_probe -- render.png [x0 y0 x1 y1]
+```
+
+`tex_probe` exists specifically to settle whether a texture is
+display-encoded or linear: it prints raw values, so the overshoot signature of
+a missing decode is visible as a number rather than guessed from a render.
+Rule of thumb — a *linear* albedo should sit well below its authored value
+(18% grey encodes to ~0.46), so a linear diffuse colour that still reads
+0.5–0.9 across all three channels on a natural material is the usual tell that
+a decode was skipped.
+
+See also `docs/openpbr_reference_alignment.md` for how the OpenPBR parameters
+these colours feed are defined, and the "Ptex" section of `CLAUDE.md` for the
+face-addressing checks that are orthogonal to (and easily confused with)
+colour-space correctness.

--- a/openspec/changes/add-material-color-management/.openspec.yaml
+++ b/openspec/changes/add-material-color-management/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/add-material-color-management/design.md
+++ b/openspec/changes/add-material-color-management/design.md
@@ -1,0 +1,235 @@
+## Context
+
+See proposal.md - Why/What Changes for the motivating gap. Relevant current
+code (from investigation, not restated in full):
+
+- `usd_import.rs::preview_surface_openpbr` reads `diffuseColor`/`emissiveColor`
+  raw (no conversion) into `OpenPBR::base_color`/`emission_color`.
+- `usd_import.rs::disney_to_openpbr` converts `baseColor` via a private
+  `srgb_to_linear` that is actually a flat `powf(2.2)`, not the piecewise sRGB
+  EOTF; every other `PxrDisneyBsdf` input is a scalar, read raw, correctly.
+- `usd_import.rs::decode_crust_openpbr` reads every `crust:openpbr` color
+  field raw via `shader_input_vec3`, by design (native format is
+  linear-authored) but with nothing marking that as a decision.
+- `crust-render/src/main.rs::PtexColor::open` decodes every Ptex texel with
+  its own inline `powf(2.2)`, independent of `usd_import.rs`'s function.
+- `main.rs::load_image_environment` already picks correctly per format
+  (piecewise sRGB for LDR, linear pass-through for `.hdr`/EXR) and is not
+  broken; it is a candidate to consume the same shared primitive, not a
+  target of the bug fix.
+- `OpenPBR` (`crust-core/src/material/openpbr.rs`) stores every field as
+  plain `Vec3A` (colors) or `f32` (scalars) — the `Vec3A`/`f32` type
+  difference already prevents a scalar from being decoded as a color (decode
+  functions take `Vec3A`), so the actual, real gap is the opposite direction:
+  nothing forces a color-valued `Vec3A` read off a USD attribute to pass
+  through a decode step at all before landing in an `OpenPBR` field — which
+  is exactly how the `UsdPreviewSurface` bug happened.
+- The same "read raw, no decision made" gap exists in two more places, both
+  outside `OpenPBR`/materials entirely: `usd_import.rs::lux_emission` reads
+  `inputs:color` for `UsdLuxDistantLight`/`DomeLight`/`SphereLight`/`RectLight`
+  via `attr_color3f`, and the volume-region importer (~usd_import.rs:482-484)
+  reads `crust:volume:sigmaS`/`sigmaA`/`emission` via `custom_color3`. Neither
+  helper does any conversion today, and — unlike `UsdPreviewSurface` — neither
+  should: OpenUSD's own docs for `UsdLuxLightAPI:inputs:color` state it is "in
+  the rendering color space," which for a linear-light-transport renderer
+  *is* linear; `crust:volume:*` are project-custom attributes (not a standard
+  USD schema) representing physical scattering/absorption/emission
+  coefficients, authored the same linear-native way as `crust:openpbr`. So
+  these two are not a numeric bug like `UsdPreviewSurface` — they are the same
+  *enforcement* bug (nothing marks the "no conversion" choice as intentional).
+- Worth being precise about `UsdPreviewSurface`: its own schema spec does
+  **not** mandate a color space for `diffuseColor`/`emissiveColor` (the spec's
+  only explicit color-space note is for normal maps). Decoding it as sRGB is
+  this change's design choice — matching the common convention that such
+  values are authored as DCC color-picker swatches — not something USD
+  requires. Recorded here so the requirement text doesn't overstate it as a
+  schema mandate.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One shared place (usable from both `crust-core` and `crust-render`) that
+  defines the two color-space conversions actually in use (piecewise sRGB
+  EOTF, flat gamma 2.2) plus the identity case, replacing the two
+  independent inline implementations.
+- Make it structurally impossible to add a new color-valued shader input to
+  `usd_import.rs` without a call site explicitly stating its source color
+  space — including explicitly stating "linear, no conversion" rather than
+  achieving that by silently not calling anything.
+- Fix the `UsdPreviewSurface` gap as part of the same mechanism, not as a
+  one-off patch, so the next shader family gets the enforcement for free.
+- Apply the same mechanism to every color-valued USD attribute read by the
+  importer, not only material shader inputs — light colors and volume
+  coefficients get an explicit `ColorSpace::Linear` call site each, even
+  though (per Context) the correct value doesn't change.
+
+**Non-Goals:**
+- No change to `OpenPBR`'s own field types (`Vec3A`/`f32`) or its trait
+  contract — this is an import-time/load-time concern, not a materials
+  (`crust-core/src/material/`) capability change. Scalars are not wrapped:
+  the existing `Vec3A` vs `f32` type distinction already prevents the
+  scalar-decoded-as-color direction of the bug; only the
+  color-not-decoded-at-all direction needs new enforcement.
+- No generic/phantom-typed `Color<Space>` machinery threaded through the
+  renderer's hot path. Decode happens once at import or texture-load time,
+  never per-sample, so there is no case for a zero-cost-abstraction generic
+  here — a plain enum plus a newtype confined to the importer module is
+  enough and keeps the change's blast radius small.
+- No attempt to unify the piecewise sRGB EOTF and the flat gamma-2.2 curve
+  into one "the" sRGB conversion. They are deliberately different curves for
+  deliberately different reasons (see Decisions) and this change documents
+  that distinction rather than erasing it.
+- No per-attribute `colorSpace` override authoring in USD (e.g. a
+  hypothetical `crust:openpbr:baseColor:colorSpace` token) — see Open
+  Questions.
+
+## Decisions
+
+**1. A small `ColorSpace` enum + free conversion functions, not a generic
+`Color<Space>` wrapper type.**
+
+`ColorSpace { Linear, Srgb, Gamma(f32) }` with `ColorSpace::decode(self, Vec3A)
+-> Vec3A`, living in a new `crust-core/src/color.rs`, re-exported from
+`lib.rs` so `crust-render`'s `main.rs` can use the same `Gamma(2.2)` arm for
+Ptex that `usd_import.rs` uses for `PxrDisneyBsdf`.
+
+Alternative considered: a generic `Color<S: ColorSpaceMarker>(Vec3A)` newtype
+threaded all the way into `OpenPBR`'s fields, giving compile-time-verified
+"this field is always linear" guarantees. Rejected: it would touch the
+`materials` capability's data representation (a boundary this change
+explicitly leaves alone per Non-Goals), ripple into every BRDF read site in
+`material/brdf.rs`, and buys nothing beyond what's needed — conversion is a
+one-time, load-time operation, so there is no runtime type-safety benefit
+happening on the hot path, only at the ~30 importer call sites where the
+enum-plus-function approach already suffices.
+
+**2. A `RawColor3` newtype at every USD-color-attribute-reading boundary,
+decoded explicitly at each call site — but no equivalent wrapper for
+scalars.**
+
+`RawColor3(Vec3A)` wraps the return of all three of the importer's
+color-reading primitives, not just the material one:
+`shader_input_vec3` (material shader inputs), `attr_color3f` (`UsdLuxLightAPI
+inputs:color`, via `lux_emission`), and `custom_color3` (`crust:volume:*`
+coefficients). The only way to obtain a `Vec3A` from a `RawColor3` is
+`RawColor3::decode(self, space: ColorSpace) -> Vec3A`. Every color-field call
+site — the ~27 across `preview_surface_openpbr`/`disney_to_openpbr`/
+`decode_crust_openpbr`, plus `lux_emission` and the volume-attribute reads —
+must therefore name a `ColorSpace` explicitly, including `ColorSpace::Linear`
+for `crust:openpbr` fields, light colors, and volume coefficients — turning
+today's silent "no conversion by omission" into an explicit, greppable
+decision everywhere a color-valued USD attribute is read, not only in
+materials.
+
+`shader_input_float` (scalars) is **not** wrapped, and neither is any other
+scalar reader (light `intensity`/`exposure`, volume `anisotropy`, etc.). As
+noted in Context, the existing `Vec3A`/`f32` type split already prevents a
+scalar from being routed through a color decode by accident — there is no bug
+in that direction to guard against, so wrapping floats would be pure ceremony
+for zero enforcement benefit.
+
+**3. Preserve the two existing non-piecewise-sRGB decisions as explicit,
+documented `ColorSpace` choices rather than unifying them.**
+
+`PxrDisneyBsdf.baseColor` and Ptex color textures both keep flat
+`ColorSpace::Gamma(2.2)`, not `ColorSpace::Srgb`, because (per `CLAUDE.md`)
+this specifically matches the Moana island's `PxrColorCorrect` gamma-1/2.2
+node and `HwPtexTexture_1`'s `sourceColorSpace = "sRGB"` authoring —
+switching either to the piecewise EOTF would be a small but real numerical
+change to every already-validated island render. `UsdPreviewSurface` gets
+`ColorSpace::Srgb` (the piecewise EOTF), matching the conventional DCC
+authoring assumption for that portable schema and `main.rs`'s existing LDR
+image-decode path, which already uses the piecewise curve for the same
+reason. That assumption is this change's own convention, not a schema
+requirement (see Context) — recorded in the doc comment on the call site so
+it isn't mistaken for one.
+
+**4. Light colors and volume coefficients decode as `ColorSpace::Linear`
+(identity), on the strength of upstream documentation, not local
+convention.**
+
+Unlike `UsdPreviewSurface` (Decision 3, a judgment call this project makes),
+`UsdLuxLightAPI:inputs:color` is explicitly documented upstream as being "in
+the rendering color space" — for a linear-light-transport path tracer, that
+is linear by definition, so `ColorSpace::Linear` is not a guess. `crust:volume:*`
+coefficients are this project's own attributes (no upstream schema to defer
+to), and are treated as linear for the same reason `crust:openpbr` is: they
+are physical quantities (scattering/absorption coefficients, emission
+radiance) authored directly, not painted swatches. Both get an explicit
+`RawColor3::decode(.., ColorSpace::Linear)` call site rather than silent
+passthrough, per Decision 2 — the value is unchanged, only the decision
+becomes visible and enforced.
+
+## Risks / Trade-offs
+
+- **[Risk]** The `UsdPreviewSurface` fix changes rendered output for any
+  scene using it (proposal's **BREAKING** note) → **Mitigation**: task
+  breakdown includes regenerating golden images
+  (`scripts/check_images.sh record`) only for the specific sample scenes
+  that use `UsdPreviewSurface`, after visually confirming the new (decoded)
+  output is the intended one — not a blanket re-record.
+- **[Risk]** A future contributor sees two different "gamma 2.2-ish" curves
+  (piecewise sRGB vs flat pow 2.2) and "simplifies" them into one →
+  **Mitigation**: doc comments on both `ColorSpace::Srgb` and
+  `ColorSpace::Gamma` cite the specific upstream reasoning (DCC sRGB
+  convention vs. the island's `PxrColorCorrect`/`HwPtexTexture_1` authoring),
+  and a unit test asserts the two curves produce numerically different
+  output at a representative value (e.g. 0.5) so an accidental unification
+  fails a test instead of silently changing island renders.
+- **[Trade-off]** `RawColor3` adds one wrapper/unwrap step at ~27 material
+  call sites plus the light and volume color reads → accepted, since that
+  friction is the entire point (each site must state its color space), and
+  it is confined to `usd_import.rs` with no runtime cost and no change
+  outside the importer.
+- **[Risk]** A reviewer sees `ColorSpace::Linear` at every light/volume call
+  site and assumes it's a no-op not worth reviewing carefully, missing a
+  genuine future case where an attribute should decode differently →
+  **Mitigation**: each `Linear` call site cites *why* (upstream doc quote for
+  lights, "project-custom, linear-authored" for volumes) rather than being
+  bare, so a reviewer sees the reasoning, not just the identity conversion.
+- **[Risk]** None of this affects render throughput (decode is O(materials
+  loaded), not O(samples)) — flagged only to close the loop per this
+  project's performance-first guiding principle; no benchmark is needed for
+  this change.
+
+## Migration Plan
+
+1. Add `ColorSpace` enum + `decode` fn in a new `crust-core/src/color.rs`,
+   re-exported from `lib.rs`.
+2. Change `shader_input_vec3`, `attr_color3f`, and `custom_color3` in
+   `usd_import.rs` to return `RawColor3`; add `RawColor3::decode`.
+3. Update `preview_surface_openpbr`: decode `diffuseColor`/`emissiveColor`
+   with `ColorSpace::Srgb` (the bug fix). Scalar fields untouched.
+4. Update `disney_to_openpbr`: decode `baseColor` with `ColorSpace::Gamma(2.2)`
+   via the shared function; delete the private `srgb_to_linear` it used to
+   call.
+5. Update `decode_crust_openpbr`: decode every color field explicitly with
+   `ColorSpace::Linear` (identity — makes "intentionally no conversion"
+   explicit rather than implicit).
+6. Update `crust-render/src/main.rs`'s `PtexColor::open` to call
+   `ColorSpace::Gamma(2.2).decode(...)` from `crust-core` instead of its own
+   inline `powf(2.2)`.
+7. Update `lux_emission` (feeding `emit_distant_light`/`emit_sphere_light`/
+   `emit_rect_light`/the dome-light path) and the volume-region attribute
+   reads to decode with `ColorSpace::Linear` explicitly.
+8. Add unit tests: each shader family's chosen `ColorSpace` (regression
+   pinning), that `Srgb` and `Gamma(2.2)` remain numerically distinct, and
+   that light/volume colors pass through `ColorSpace::Linear` unchanged.
+9. Regenerate golden images only for sample scenes using
+   `UsdPreviewSurface` colors (confirm visually first, then
+   `scripts/check_images.sh record`), and rerun `scripts/check_images.sh
+   check` for everything else — light and volume scenes included — to
+   confirm no unintended change anywhere else.
+
+Rollback: this is a pure import/load-time behavior change with no persisted
+data format or schema change — reverting the commit(s) is sufficient; no
+migration of stored state is involved.
+
+## Open Questions
+
+- Should `crust:openpbr` ever gain an optional per-input `colorSpace`
+  override (e.g. for an artist who wants to author an sRGB value directly in
+  the native format) instead of always assuming linear? Deferrable: today's
+  behavior (always linear, no override) is preserved by this change either
+  way, and adding an override later is additive to the `ColorSpace` enum
+  introduced here, not a change to it.

--- a/openspec/changes/add-material-color-management/proposal.md
+++ b/openspec/changes/add-material-color-management/proposal.md
@@ -1,0 +1,106 @@
+## Why
+
+Material color inputs (`baseColor`, `emissiveColor`, Ptex-sourced colors, etc.)
+and scalar inputs (`roughness`, `ior`, `metallic`, etc.) are read through four
+independent, ad-hoc code paths today, and only two of them decode sRGB→linear:
+`PxrDisneyBsdf.baseColor` and Ptex color textures each apply a flat `powf(2.2)`
+gamma decode; `UsdPreviewSurface.diffuseColor`/`emissiveColor` are read raw with
+**no** decode at all, which is a correctness bug (`UsdPreviewSurface` colors are
+conventionally authored in a display-referred space); `crust:openpbr` colors are
+also read raw, which is currently intentional (crust's own lossless native
+mirror is documented as linear-authored) but that assumption is implicit and
+unenforced. There is no shared `ColorSpace` concept, so nothing stops a future
+shader-mapping function from decoding a scalar as if it were a color, or a
+color as if it were a scalar — the `OpenPBR` struct represents both as bare
+`Vec3A`/`f32` with no distinguishing type. Fixing the `UsdPreviewSurface` gap
+and preventing this class of bug needs one principled place to decide, per
+input, whether and how it is color-space-converted before reaching `OpenPBR`.
+
+The same gap exists beyond materials: every mathematical operation in the
+integrator is done in linear light, so every color-valued input has to be
+linearized before use, not just the three material shaders above. USD light
+colors (`UsdLuxDistantLight`/`DomeLight`/`SphereLight`/`RectLight`
+`inputs:color`, read through a shared `lux_emission` helper) and volume
+region coefficients (`crust:volume:sigmaS`/`sigmaA`/`emission`, read through
+`custom_color3`) are read exactly as raw today, with no color-space decision
+made at all — the same class of implicit gap, just not yet inventoried
+against the same mechanism.
+
+## What Changes
+
+- Introduce a `ColorSpace` concept (e.g. `Linear`, `Srgb` piecewise EOTF,
+  `Gamma(2.2)` flat power curve) and route every material-input decode in the
+  USD importer through it, replacing today's two separate inline
+  implementations (`usd_import.rs`'s `srgb_to_linear` and `main.rs`'s Ptex
+  `powf(2.2)`) with one shared conversion.
+- **Fix**: `UsdPreviewSurface`'s `diffuseColor` and `emissiveColor` are decoded
+  sRGB→linear like every other portable color input, instead of read raw.
+  **BREAKING**: any scene currently relying on `UsdPreviewSurface` colors being
+  passed through unconverted will render differently (darker, correctly).
+- Distinguish "color-like" fields (`base_color`, `specular_color`,
+  `transmission_color`, `subsurface_color`, `fuzz_color`, `coat_color`,
+  `emission_color`, …) from "scalar-like" fields (`roughness`, `weight`, `ior`,
+  anisotropy, …) on the `OpenPBR` struct at the type level, per the OpenPBR
+  parameter reference's own `color3`/`float` typing
+  (https://academysoftwarefoundation.github.io/OpenPBR/#parameterreference), so
+  a color-space conversion cannot be applied to a scalar field or omitted from
+  a color field by accident.
+- Document, per material-input source, which color space is assumed and why:
+  `UsdPreviewSurface` → sRGB (fixed by this change); `PxrDisneyBsdf.baseColor`
+  → flat gamma 2.2 (preserved — matches a specific island `PxrColorCorrect`
+  node, not a general default); `crust:openpbr` → linear, no conversion
+  (preserved, native lossless format); Ptex color textures → flat gamma 2.2
+  (preserved, same island-specific reasoning as Disney).
+- No change to environment-map decoding (`main.rs`'s LDR piecewise sRGB EOTF /
+  HDR-and-EXR-as-linear) — already correct per format, out of scope here
+  except as a candidate consumer of the new shared `ColorSpace` conversion.
+- Extend the same explicit-decision mechanism to light colors and volume
+  coefficients: `UsdLuxLightAPI:inputs:color` is documented upstream as being
+  "in the rendering color space" — i.e. already linear for a linear-light
+  path tracer — and `crust:volume:*` coefficients are project-custom
+  attributes with the same linear-authored convention as `crust:openpbr`. In
+  both cases the correct conversion is `ColorSpace::Linear` (identity): this
+  is **not** a numeric/behavioral change like the `UsdPreviewSurface` fix, it
+  makes "linear, no conversion" an explicit, enforced call site instead of an
+  accident nobody has had reason to touch.
+
+## Capabilities
+
+### New Capabilities
+
+- `color-management`: defines the `ColorSpace` conversions available to the
+  importer and texture loaders, and the type-level distinction between
+  color-valued and scalar-valued material inputs that prevents misapplying one
+  as the other.
+
+### Modified Capabilities
+
+- `usd-scene-import`: the "Material resolution by shader id" requirement gains
+  explicit, per-shader-source color-space decoding behavior, including the
+  `UsdPreviewSurface` bug fix described above. The "Light schema mapping" and
+  "Volume region import" requirements each gain an explicit statement that
+  their color-valued inputs are treated as linear (`ColorSpace::Linear`,
+  identity) rather than left undecided.
+
+## Impact
+
+- `crates/crust-core/src/scene/usd_import.rs`: `preview_surface_openpbr`,
+  `disney_to_openpbr`, `decode_crust_openpbr`, and the existing `srgb_to_linear`
+  helper.
+- `crates/crust-core/src/material/openpbr.rs`: the `OpenPBR` struct's field
+  types, if the design phase settles on typed wrappers rather than a
+  documentation-only convention.
+- `crates/crust-render/src/main.rs`: `PtexColor::open`'s texel decode, as a
+  candidate to route through the shared conversion instead of its own inline
+  `powf(2.2)`.
+- `crates/crust-core/src/scene/usd_import.rs`: `lux_emission` (feeding
+  `emit_distant_light`/`emit_sphere_light`/`emit_rect_light`/the dome-light
+  path) and the volume-region attribute reads (`custom_color3` for
+  `sigmaS`/`sigmaA`/`emission`).
+- Golden-image regression scenes/tests that use `UsdPreviewSurface` colors will
+  need their reference images regenerated (`scripts/check_images.sh record`)
+  since output changes for that path. Light and volume scenes need **no**
+  golden-image changes: their values are already effectively linear, so
+  making that explicit changes no rendered pixel.
+- No render-throughput impact expected: color-space conversion happens once at
+  import/load time, never per-sample in the integrator.

--- a/openspec/changes/add-material-color-management/proposal.md
+++ b/openspec/changes/add-material-color-management/proposal.md
@@ -37,14 +37,18 @@ against the same mechanism.
   sRGB→linear like every other portable color input, instead of read raw.
   **BREAKING**: any scene currently relying on `UsdPreviewSurface` colors being
   passed through unconverted will render differently (darker, correctly).
-- Distinguish "color-like" fields (`base_color`, `specular_color`,
-  `transmission_color`, `subsurface_color`, `fuzz_color`, `coat_color`,
-  `emission_color`, …) from "scalar-like" fields (`roughness`, `weight`, `ior`,
-  anisotropy, …) on the `OpenPBR` struct at the type level, per the OpenPBR
-  parameter reference's own `color3`/`float` typing
-  (https://academysoftwarefoundation.github.io/OpenPBR/#parameterreference), so
-  a color-space conversion cannot be applied to a scalar field or omitted from
-  a color field by accident.
+- Enforce the color/scalar distinction at the **importer boundary**, not on the
+  `OpenPBR` struct: the three attribute-reading primitives
+  (`shader_input_vec3`, `attr_color3f`, `custom_color3`) return a `RawColor3`
+  newtype whose only accessor is `RawColor3::decode(space: ColorSpace) -> Vec3A`.
+  Every color-valued call site must therefore name a color space — including the
+  ones whose answer is `Linear` — so a conversion can no longer be omitted from a
+  color input by accident. Which inputs count as colors follows the OpenPBR
+  parameter reference's own `color3` vs `float` typing
+  (https://academysoftwarefoundation.github.io/OpenPBR/#parameterreference).
+  `OpenPBR`'s field types are **unchanged**: scalars are already `f32` and so
+  cannot reach a `Vec3A` decode, meaning only the "color never decoded at all"
+  direction needs new enforcement.
 - Document, per material-input source, which color space is assumed and why:
   `UsdPreviewSurface` → sRGB (fixed by this change); `PxrDisneyBsdf.baseColor`
   → flat gamma 2.2 (preserved — matches a specific island `PxrColorCorrect`
@@ -69,9 +73,8 @@ against the same mechanism.
 ### New Capabilities
 
 - `color-management`: defines the `ColorSpace` conversions available to the
-  importer and texture loaders, and the type-level distinction between
-  color-valued and scalar-valued material inputs that prevents misapplying one
-  as the other.
+  importer and texture loaders, and which inputs are color-valued versus scalar,
+  so a conversion is never applied to a scalar or omitted from a color.
 
 ### Modified Capabilities
 
@@ -87,9 +90,10 @@ against the same mechanism.
 - `crates/crust-core/src/scene/usd_import.rs`: `preview_surface_openpbr`,
   `disney_to_openpbr`, `decode_crust_openpbr`, and the existing `srgb_to_linear`
   helper.
-- `crates/crust-core/src/material/openpbr.rs`: the `OpenPBR` struct's field
-  types, if the design phase settles on typed wrappers rather than a
-  documentation-only convention.
+- `crates/crust-core/src/material/openpbr.rs`: **not** affected — the `OpenPBR`
+  struct's field types stay as they are. Enforcement lives at the importer
+  boundary instead, keeping this change out of the `materials` capability and
+  away from every BRDF read site.
 - `crates/crust-render/src/main.rs`: `PtexColor::open`'s texel decode, as a
   candidate to route through the shared conversion instead of its own inline
   `powf(2.2)`.

--- a/openspec/changes/add-material-color-management/specs/color-management/spec.md
+++ b/openspec/changes/add-material-color-management/specs/color-management/spec.md
@@ -1,0 +1,88 @@
+## Purpose
+
+Define how the renderer interprets authored color values from every
+color-valued USD input it reads — material shader attributes, Ptex textures,
+light colors, and volume coefficients — so that every color reaches its use
+(shading, lighting, or volume transport) already converted to linear light,
+while scalar (non-color) inputs are never subjected to that conversion.
+
+## ADDED Requirements
+
+### Requirement: Material color inputs are decoded from a known source color space
+
+Every color-valued material input (e.g. `baseColor`, `diffuseColor`,
+`emissiveColor`, Ptex-sourced per-face colors) SHALL be converted from its
+source's documented color space to linear before it is used in shading. The
+conversion applied depends on the input's source, not a single global
+default:
+
+- `UsdPreviewSurface` color inputs SHALL be decoded from sRGB (piecewise
+  EOTF) to linear.
+- `PxrDisneyBsdf`'s `baseColor` and Ptex color textures SHALL be decoded with
+  a flat gamma-2.2 power curve to linear (matching the specific authoring
+  convention of content that uses these sources), not the piecewise sRGB
+  EOTF.
+- `crust:openpbr` native shader color inputs SHALL be treated as already
+  linear, with no conversion applied.
+
+#### Scenario: UsdPreviewSurface diffuseColor is converted from sRGB
+
+- **WHEN** a `UsdPreviewSurface` shader authors `diffuseColor = (0.5, 0.5,
+  0.5)`
+- **THEN** the resulting material's linear base color is the sRGB-decoded
+  value (≈0.214 per channel), not 0.5
+
+#### Scenario: PxrDisneyBsdf baseColor is converted with flat gamma 2.2
+
+- **WHEN** a `PxrDisneyBsdf` shader authors `baseColor = (0.5, 0.5, 0.5)`
+- **THEN** the resulting material's linear base color is the flat
+  gamma-2.2-decoded value (0.5^2.2 ≈ 0.218 per channel)
+
+#### Scenario: crust:openpbr color inputs pass through unconverted
+
+- **WHEN** a `crust:openpbr` shader authors `baseColor = (0.5, 0.5, 0.5)`
+- **THEN** the resulting material's linear base color is exactly (0.5, 0.5,
+  0.5), with no color-space conversion applied
+
+#### Scenario: Ptex color texture is converted with flat gamma 2.2
+
+- **WHEN** a material's per-face color comes from a Ptex texture
+- **THEN** each texel is decoded with the same flat gamma-2.2 curve used for
+  `PxrDisneyBsdf.baseColor`, before being used as the surface's base color
+
+### Requirement: Light and volume color inputs are treated as already linear
+
+Color-valued inputs that are not material shader inputs — USD light colors
+(`UsdLuxDistantLight`, `UsdLuxDomeLight`, `UsdLuxSphereLight`,
+`UsdLuxRectLight` `inputs:color`) and volume region coefficients
+(`crust:volume:sigmaS`, `crust:volume:sigmaA`, `crust:volume:emission`) —
+SHALL be treated as already linear, with no color-space conversion applied,
+and that treatment SHALL be an explicit decision rather than an omission.
+
+#### Scenario: Light color passes through unconverted
+
+- **WHEN** a `UsdLuxDistantLight`, `UsdLuxDomeLight`, `UsdLuxSphereLight`, or
+  `UsdLuxRectLight` prim authors `inputs:color = (0.5, 0.5, 0.5)`
+- **THEN** the light's linear color is exactly (0.5, 0.5, 0.5), with no
+  color-space conversion applied
+
+#### Scenario: Volume coefficient color passes through unconverted
+
+- **WHEN** a volume region prim authors `crust:volume:sigmaS`,
+  `crust:volume:sigmaA`, or `crust:volume:emission` as `(0.5, 0.5, 0.5)`
+- **THEN** the region's linear coefficient is exactly (0.5, 0.5, 0.5), with
+  no color-space conversion applied
+
+### Requirement: Scalar material inputs are never color-space converted
+
+Scalar (non-color) material inputs — including but not limited to
+roughness, metalness, IOR, weight, and anisotropy parameters — SHALL be used
+at their authored numeric value with no color-space conversion applied,
+regardless of which shader source they come from.
+
+#### Scenario: Roughness is used unconverted
+
+- **WHEN** any supported shader source authors a roughness-like scalar
+  input
+- **THEN** the value used in shading equals the authored value, with no
+  gamma or sRGB decoding applied

--- a/openspec/changes/add-material-color-management/specs/usd-scene-import/spec.md
+++ b/openspec/changes/add-material-color-management/specs/usd-scene-import/spec.md
@@ -1,0 +1,107 @@
+## MODIFIED Requirements
+
+### Requirement: Material resolution by shader id
+
+The importer SHALL resolve a bound material via `MaterialBindingAPI` and dispatch
+on the surface shader's `info:id`: `UsdPreviewSurface` maps into `OpenPBR`
+(portable field mapping), `crust:openpbr` decodes 1:1 into `OpenPBR`, and any
+geometry without a resolvable bound material falls back to a default grey `OpenPBR`.
+
+Color-valued inputs mapped by this requirement SHALL be converted to linear
+according to the color-management capability's per-source rules before being
+stored on the resulting `OpenPBR` material; scalar (non-color) inputs SHALL be
+used at their authored value with no such conversion.
+
+#### Scenario: UsdPreviewSurface binding
+
+- **WHEN** a surface binds a shader with `info:id = "UsdPreviewSurface"`
+- **THEN** its inputs are mapped into an `OpenPBR` material (e.g. `diffuseColor →
+  baseColor`, `metallic → baseMetalness`, `roughness → specularRoughness`)
+
+#### Scenario: UsdPreviewSurface color inputs are decoded from sRGB
+
+- **WHEN** a surface binds a `UsdPreviewSurface` shader authoring
+  `diffuseColor` and/or `emissiveColor`
+- **THEN** each is decoded from sRGB to linear before being stored as the
+  `OpenPBR` material's `baseColor`/`emissionColor`, rather than passed
+  through unconverted
+
+#### Scenario: crust:openpbr binding
+
+- **WHEN** a surface binds a shader with `info:id = "crust:openpbr"`
+- **THEN** each camelCase input is decoded 1:1 into the matching `OpenPBR`
+  field, with color-valued fields treated as already linear (no conversion
+  applied)
+
+#### Scenario: Unbound geometry
+
+- **WHEN** geometry has no resolvable bound material
+- **THEN** it is assigned a default grey `OpenPBR` material
+
+### Requirement: Light schema mapping
+
+The importer SHALL map `UsdLuxSphereLight` to an `Emissive` sphere that is both a
+light and visible geometry, and `UsdLuxRectLight` to two emissive triangles
+plus an `AreaLight(RectShape)` (local XY plane, emitting along -Z per UsdLux —
+effectively one-sided). Other lux schemas (`DiskLight`, `DistantLight`,
+`DomeLight`, `CylinderLight`) SHALL warn once and be skipped.
+
+Every mapped light's color (`inputs:color` on any of `UsdLuxDistantLight`,
+`UsdLuxDomeLight`, `UsdLuxSphereLight`, `UsdLuxRectLight`) SHALL be treated as
+already linear per the color-management capability, with no conversion
+applied, since it is authored in the rendering color space.
+
+#### Scenario: Sphere light
+
+- **WHEN** a `UsdLuxSphereLight` prim is traversed
+- **THEN** it becomes an emissive sphere added to both the light list and the world
+
+#### Scenario: Rect light
+
+- **WHEN** a `UsdLuxRectLight` prim is traversed
+- **THEN** it becomes two emissive triangles added to both the light list and
+  the world
+
+#### Scenario: Unsupported lux light
+
+- **WHEN** a `DiskLight`, `DistantLight`, `DomeLight`, or `CylinderLight` prim
+  is traversed
+- **THEN** a warning is emitted and the light is skipped
+
+#### Scenario: Light color passes through unconverted
+
+- **WHEN** any supported lux light prim authors `inputs:color`
+- **THEN** the value used for that light's emission is the authored value
+  unchanged, with no color-space conversion applied
+
+### Requirement: Volume region import
+
+Any prim carrying a `crust:volume:type` attribute SHALL import as a
+free-standing `VolumeRegion` rather than geometry — checked before the
+mesh/sphere/light dispatch, so its bounds never occlude shadow rays. The
+region's box comes from the prim's `size` (when it is a `Cube`) or the unit
+cube, oriented and scaled by the composed prim transform, with density
+(`homogeneous` | `smoke` procedural fBm noise | `grid` inline voxel data) and
+σₛ/σₐ/anisotropy/emission read from `crust:volume:*` attributes.
+
+The color-valued coefficients `crust:volume:sigmaS`, `crust:volume:sigmaA`,
+and `crust:volume:emission` SHALL be treated as already linear per the
+color-management capability, with no conversion applied.
+
+#### Scenario: Volume prim
+
+- **WHEN** a prim authors `crust:volume:type`
+- **THEN** it is added to the scene's volume regions, not to world geometry
+
+#### Scenario: Missing grid data
+
+- **WHEN** a `grid`-type volume's `gridData` length does not match
+  `gridDims`' `nx·ny·nz`
+- **THEN** a warning is emitted and the volume is skipped
+
+#### Scenario: Volume coefficients pass through unconverted
+
+- **WHEN** a volume region prim authors `crust:volume:sigmaS`,
+  `crust:volume:sigmaA`, or `crust:volume:emission`
+- **THEN** the coefficient value used in transport is the authored value
+  unchanged, with no color-space conversion applied

--- a/openspec/changes/add-material-color-management/tasks.md
+++ b/openspec/changes/add-material-color-management/tasks.md
@@ -1,0 +1,85 @@
+## 1. Shared color-space primitive
+
+- [ ] 1.1 Add `crates/crust-core/src/color.rs` with `ColorSpace { Linear,
+      Srgb, Gamma(f32) }` and `ColorSpace::decode(self, Vec3A) -> Vec3A`,
+      documenting on each variant why it exists (piecewise sRGB EOTF for
+      DCC-authored content vs. flat gamma matching the island's
+      `PxrColorCorrect`/`HwPtexTexture_1` authoring).
+- [ ] 1.2 Re-export `ColorSpace` from `crust-core/src/lib.rs`.
+- [ ] 1.3 Unit test: `ColorSpace::Srgb` and `ColorSpace::Gamma(2.2)` produce
+      numerically distinct output at a representative input (e.g. 0.5), so
+      an accidental future unification of the two curves fails a test.
+
+## 2. Material importer enforcement (`usd_import.rs`)
+
+- [ ] 2.1 Add a `RawColor3(Vec3A)` newtype with `RawColor3::decode(self,
+      space: ColorSpace) -> Vec3A`; change `shader_input_vec3` to return
+      `RawColor3` instead of a bare `Vec3A`.
+- [ ] 2.2 Update `preview_surface_openpbr`: decode `diffuseColor` and
+      `emissiveColor` with `ColorSpace::Srgb` (the bug fix). Leave scalar
+      fields (`metallic`, `roughness`, `opacity`, `ior`, `clearcoat`,
+      `clearcoatRoughness`) untouched.
+- [ ] 2.3 Update `disney_to_openpbr`: decode `baseColor` with
+      `ColorSpace::Gamma(2.2)` via the shared function; delete the
+      function's private `srgb_to_linear` helper it used to call.
+- [ ] 2.4 Update `decode_crust_openpbr`: decode every color field
+      (`baseColor`, `specularColor`, `transmissionColor`, `subsurfaceColor`,
+      `fuzzColor`, `coatColor`, `emissionColor`) explicitly with
+      `ColorSpace::Linear`, making the "no conversion" decision explicit at
+      each call site.
+
+## 3. Light and volume importer enforcement (`usd_import.rs`)
+
+- [ ] 3.1 Change `attr_color3f` and `custom_color3` to return `RawColor3`
+      (same newtype as task 2.1), so light and volume color reads go through
+      the same enforcement as material color reads.
+- [ ] 3.2 Update `lux_emission` (feeding `emit_distant_light`,
+      `emit_sphere_light`, `emit_rect_light`, and the dome-light path) to
+      decode `inputs:color` with `ColorSpace::Linear`, with a doc comment
+      citing `UsdLuxLightAPI`'s "in the rendering color space" wording.
+- [ ] 3.3 Update the volume-region attribute reads (`crust:volume:sigmaS`,
+      `sigmaA`, `emission`) to decode with `ColorSpace::Linear`, with a doc
+      comment noting these are project-custom, linear-authored coefficients
+      like `crust:openpbr`.
+
+## 4. Ptex texel decode (`crust-render/src/main.rs`)
+
+- [ ] 4.1 Update `PtexColor::open`'s texel decode to call
+      `ColorSpace::Gamma(2.2).decode(...)` from `crust-core` instead of its
+      own inline `powf(2.2)`.
+
+## 5. Regression coverage
+
+- [ ] 5.1 Add an integration test (or extend an existing USD-import test in
+      `crust-core/tests/usd_scene.rs`) asserting a `UsdPreviewSurface`
+      `diffuseColor` of (0.5, 0.5, 0.5) yields a linear `base_color` of
+      ≈0.214 per channel, not 0.5.
+- [ ] 5.2 Add an integration test asserting a `PxrDisneyBsdf` `baseColor` of
+      (0.5, 0.5, 0.5) yields a linear `base_color` of 0.5^2.2 ≈ 0.218 per
+      channel (pinning today's already-correct behavior against
+      regression).
+- [ ] 5.3 Add an integration test asserting a `crust:openpbr` `baseColor`
+      passes through unconverted.
+- [ ] 5.4 Add an integration test asserting a lux light's `inputs:color` and
+      a volume region's `sigmaS`/`sigmaA`/`emission` each pass through
+      `ColorSpace::Linear` unchanged.
+
+## 6. Golden-image reconciliation
+
+- [ ] 6.1 Identify which checked-in sample scenes (`samples/*.usda`) bind
+      `UsdPreviewSurface` materials with non-trivial colors.
+- [ ] 6.2 Re-render those scenes, visually confirm the new (sRGB-decoded)
+      output is correct, then re-record their golden images via
+      `scripts/check_images.sh record`.
+- [ ] 6.3 Run `scripts/check_images.sh check` across the full sample set
+      (including light- and volume-driven scenes) to confirm no scene
+      outside step 6.1's list changed — the light/volume enforcement in
+      task group 3 is `ColorSpace::Linear` (identity), so it must produce
+      zero pixel difference anywhere.
+
+## 7. Validation
+
+- [ ] 7.1 `cargo test` passes, including the new unit and integration
+      tests.
+- [ ] 7.2 `cargo build --verbose && cargo test --verbose` (the CI command)
+      passes clean.


### PR DESCRIPTION
## Why

There is no colour-management abstraction in the renderer. Two decode curves exist as independent inline implementations, and whether a given input is decoded at all is decided ad hoc per shader family. This PR writes down what actually happens today, and proposes a fix for the two gaps that fall out of doing so.

**No code changes** — documentation plus OpenSpec planning artifacts only.

## What's here

**`docs/color_management.md`** — the per-input inventory: what colour space each input is assumed to be in, what curve is applied, and a verdict, with `file:line` throughout. Four tables covering material shader inputs, lights, volume coefficients, and textures/environment maps. Plus the invariant, the output side, and a diagnosis section (`CRUST_PTEX=0`, `tex_probe`).

**`openspec/changes/add-material-color-management/`** — proposal, design, spec deltas (new `color-management` capability + modified `usd-scene-import`), and a 7-group task breakdown. Validates clean under `openspec validate --strict`.

## The two gaps found

1. **`UsdPreviewSurface`'s `diffuseColor`/`emissiveColor` are read raw** (`usd_import.rs:2651`, `2665`). Values authored as colour-picker swatches are used as if already linear, overshooting albedo by 2.3× at 0.5 and 6.6× at 18% grey. This is the one genuine behavioural bug.
2. **Nothing enforces that a new colour input states its source space.** The default behaviour of adding one is to reproduce gap 1, silently.

Worth noting for honesty: the `UsdPreviewSurface` spec does *not* actually mandate a colour space for these inputs (its only explicit note concerns normal maps), so decoding them as sRGB is a defensible convention rather than a standards requirement. The design doc says so plainly.

## Measurements

The piecewise sRGB EOTF and flat gamma 2.2 are easy to mistake for each other, so the doc pins the difference:

| Encoded | sRGB EOTF | Gamma 2.2 | Ratio |
| --- | --- | --- | --- |
| 0.01 | 0.000774 | 0.000040 | 19.4× |
| 0.02 | 0.001548 | 0.000183 | 8.5× |
| 0.50 | 0.214041 | 0.217638 | 0.98× |

They agree to 0.0085 absolute across `[0,1]` and to 2% at midtone, but diverge by up to 19× in the deep shadows. That's why the island's flat-2.2 choice must not be "simplified" into the standard curve — a unit test is specified to pin it.

## The island is not affected

Both island colour paths are already handled: it binds `PxrDisneyBsdf`, whose `baseColor` is decoded at `usd_import.rs:2740`, and its Ptex is decoded at load (`main.rs:251`). Verified on the real asset with `tex_probe`:

```
rockfacemain0001_geo.ptx — faces 11384, channels 3, uint8
mean raw (as stored, 0..1)        = 0.3064
  -> if file is sRGB, linear mean = 0.0741
```

So the gaps bite `samples/` scenes, not the island — which is where a fix should be A/B'd, and it renders in seconds rather than nine minutes.

## Review notes

- The doc deliberately describes **current** behaviour with the gaps marked open, per the project convention of not documenting unimplemented work as done. The inventory's Verdict column will need updating when the change lands.
- `CLAUDE.md` gets a pointer to the new doc from the Ptex section, alongside the other `docs/` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)