### PR TITLE
Light source geometry camera-invisible by default (industry convention)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,7 +329,9 @@ material types, `simple_scene`, `get_settings`). Prefer importing from `crust_co
   implementation is **`AreaLight`**: a `LightShape` (pure emitting geometry —
   `SphereShape`, `RectShape`) paired with the `Arc<Emissive>` its scene geometry carries.
   Lights are stored in a `LightList` and their surfaces are also attached to `world` as
-  emissive geometry (Cornell-box semantics: a light is both light and visible object) —
+  emissive geometry — masked out of **camera** rays by default (the industry convention:
+  a light in frame does not show its source; `crust:light:cameraVisible` opts back in,
+  an authored `crust:rayMask` wins outright, and shadow/indirect rays always see it) —
   the `AreaLight` records the geometry's `geom_id`, which is how the integrator
   attributes a bounce-hit emissive surface to its light (`LightList::find_by_geom`).
   **NEE samples one light per vertex** (uniform pick), so the light strategy's MIS
@@ -431,7 +433,10 @@ Schema mapping:
   - Non-invertible instance placements (a zero scale — a common "hide this" idiom) are
     skipped: `rt::Geometry::Instance` requires an invertible transform.
 - Any geometry prim may author `crust:rayMask` (int; bit 0 camera, bit 1 shadow, bit 2
-  indirect — default all) to hide from ray categories, and `crust:motion:translate`
+  indirect — default all, except **light** source geometry which defaults to shadow|indirect;
+  `crust:light:cameraVisible = 1` on a light prim re-adds the camera bit, an authored
+  `crust:rayMask` wins outright — sample: `samples/light_visibility.usda`) to hide from
+  ray categories, and `crust:motion:translate`
   (float3, world-space) to streak through that translation over the shutter (transform
   motion blur; primary rays draw a `K_TIME` shutter sample and every secondary/shadow ray
   inherits the path's time). Sample scenes: `samples/motionblur.usda`, `samples/curves.usda`.
@@ -549,6 +554,8 @@ Schema mapping:
 - `UsdLuxSphereLight` → emissive `Sphere` geometry + `AreaLight(SphereShape)`;
   `UsdLuxRectLight` → two emissive `Triangle`s + `AreaLight(RectShape)` (local XY plane,
   emitting along -Z per UsdLux; effectively one-sided). Sample scene: `samples/rectlight.usda`.
+  The source geometry is camera-invisible by default (`light_ray_mask`) — see the
+  `crust:rayMask` bullet above for the opt-ins. Sample: `samples/light_visibility.usda`.
   Other lux types (`DiskLight`, `CylinderLight`) warn once and are skipped.
 - **Volumes**: any prim carrying `crust:volume:type` imports as a `VolumeRegion` (checked
   *first* in the dispatch, so it never becomes geometry — its bounds must not occlude

--- a/README.md
+++ b/README.md
@@ -113,12 +113,21 @@ Unbound geometry falls back to a grey diffuse OpenPBR.
 
 ### 💡 Lights
 
-`UsdLuxSphereLight` maps to an `Emissive` sphere that acts as both light and
-visible geometry (matching classic Cornell-box scene semantics).
-`UsdLuxRectLight` maps to two emissive triangles + an `AreaLight` (local XY
-plane, emitting along -Z per UsdLux; effectively one-sided) — see
-`samples/rectlight.usda`. Other lux types (`DiskLight`, `DistantLight`,
-`DomeLight`, `CylinderLight`) warn once and are skipped — follow-up work.
+`UsdLuxSphereLight` maps to an `Emissive` sphere + an `AreaLight` over the
+same surface. `UsdLuxRectLight` maps to two emissive triangles + an
+`AreaLight` (local XY plane, emitting along -Z per UsdLux; effectively
+one-sided) — see `samples/rectlight.usda`. Following the industry
+convention (Arnold, RenderMan, Karma), a light's source geometry is
+**invisible to camera rays by default** — park lights inside the frame
+without them showing up — while shadow and indirect rays still see it, so
+occlusion and reflections of lights are unchanged. Author
+`custom bool crust:light:cameraVisible = 1` on the light prim to render
+the source itself (the classic Cornell-box look), or author
+`crust:rayMask` for full per-category control (it wins outright when
+present). See `samples/light_visibility.usda` for all three spellings.
+`UsdLuxDistantLight` and `UsdLuxDomeLight` import as infinite lights with
+no scene geometry; `DiskLight` and `CylinderLight` warn once and are
+skipped — follow-up work.
 
 ### 🌫️ Volumes
 

--- a/crates/crust-core/src/scene/usd_import.rs
+++ b/crates/crust-core/src/scene/usd_import.rs
@@ -17,7 +17,7 @@ use crate::light::{
 };
 use crate::scene::AssetLoader;
 use crate::material::{Emissive, Material, OpenPBR};
-use crate::ray::MASK_ALL;
+use crate::ray::{MASK_ALL, MASK_CAMERA, MASK_INDIRECT, MASK_SHADOW};
 use crate::rt_world::{FaceMap, FanSlice, WorldBuilder};
 use crate::scene::Scene;
 use crate::stats::{ImageCounters, MemorySample, RenderStats, SceneCounters};
@@ -239,9 +239,9 @@ fn traverse_into(stage: &Stage, root: Prim, root_xf: GMat4, ctx: &mut ImportCtx)
                 }
             }
         } else if let Ok(Some(light)) = SphereLight::get(stage, prim.path().clone()) {
-            emit_sphere_light(&mut ctx.world, &mut ctx.lights, &light, this_world);
+            emit_sphere_light(&mut ctx.world, &mut ctx.lights, &prim, &light, this_world);
         } else if let Ok(Some(light)) = RectLight::get(stage, prim.path().clone()) {
-            emit_rect_light(&mut ctx.world, &mut ctx.lights, &light, this_world);
+            emit_rect_light(&mut ctx.world, &mut ctx.lights, &prim, &light, this_world);
         } else if let Ok(Some(light)) = UsdDistantLight::get(stage, prim.path().clone()) {
             emit_distant_light(&mut ctx.lights, &light, this_world);
         } else if let Ok(Some(light)) = DomeLight::get(stage, prim.path().clone()) {
@@ -736,6 +736,20 @@ fn prim_ray_mask(prim: &Prim) -> u32 {
     custom_i32(prim, "crust:rayMask")
         .map(|m| m as u32)
         .unwrap_or(MASK_ALL)
+}
+
+/// Ray mask for a light's *source geometry*. Industry default (Arnold,
+/// RenderMan, Karma): the surface is invisible to camera rays — lights sit
+/// in frame without showing up — while shadow and indirect rays still see
+/// it, so occlusion and the bounce side of MIS are unchanged.
+/// `crust:light:cameraVisible = true` opts the surface back in (classic
+/// Cornell-box look); an authored `crust:rayMask` wins outright.
+fn light_ray_mask(prim: &Prim) -> u32 {
+    if let Some(m) = custom_i32(prim, "crust:rayMask") {
+        return m as u32;
+    }
+    let visible = custom_bool(prim, "crust:light:cameraVisible").unwrap_or(false);
+    MASK_SHADOW | MASK_INDIRECT | if visible { MASK_CAMERA } else { 0 }
 }
 
 /// `crust:motion:translate` — a world-space translation the prim moves
@@ -2245,6 +2259,7 @@ fn lux_emission(light: &impl UsdLight) -> Vec3A {
 fn emit_sphere_light(
     world: &mut WorldBuilder,
     lights: &mut LightList,
+    prim: &Prim,
     light: &SphereLight,
     world_xf: GMat4,
 ) {
@@ -2253,16 +2268,18 @@ fn emit_sphere_light(
     let pos_v = world_xf.transform_point3(Vec3::ZERO);
     let position = Vec3A::new(pos_v.x, pos_v.y, pos_v.z);
 
-    // The visible sphere geometry and the AreaLight share one surface;
-    // the integrator attributes a bounce hit to the light by the
-    // geometry id the attach returns.
+    // The sphere geometry and the AreaLight share one surface; the
+    // integrator attributes a bounce hit to the light by the geometry id
+    // the attach returns. The mask hides the surface from camera rays
+    // unless the prim opts in (see light_ray_mask).
     let material = Arc::new(Emissive::new(effective));
-    let geom_id = world.attach(
+    let geom_id = world.attach_masked(
         Geometry::Sphere {
             center: position,
             radius,
         },
         material.clone(),
+        light_ray_mask(prim),
     );
     lights.add(Arc::new(AreaLight::new(
         Box::new(SphereShape {
@@ -2281,6 +2298,7 @@ fn emit_sphere_light(
 fn emit_rect_light(
     world: &mut WorldBuilder,
     lights: &mut LightList,
+    prim: &Prim,
     light: &RectLight,
     world_xf: GMat4,
 ) {
@@ -2299,9 +2317,10 @@ fn emit_rect_light(
     let edge_v = Vec3A::new(ev.x, ev.y, ev.z);
     let normal = Vec3A::new(nz.x, nz.y, nz.z);
 
-    // The visible geometry (one mesh: two triangles spanning the
-    // rectangle) and the AreaLight share one surface; bounce hits are
-    // attributed to the light by the geometry id.
+    // The geometry (one mesh: two triangles spanning the rectangle) and
+    // the AreaLight share one surface; bounce hits are attributed to the
+    // light by the geometry id. The mask hides the surface from camera
+    // rays unless the prim opts in (see light_ray_mask).
     let material = Arc::new(Emissive::new(effective));
     let (c00, c10, c11, c01) = (
         origin,
@@ -2309,13 +2328,14 @@ fn emit_rect_light(
         origin + edge_u + edge_v,
         origin + edge_v,
     );
-    let geom_id = world.attach(
+    let geom_id = world.attach_masked(
         Geometry::TriangleMesh {
             vertices: vec![c00, c10, c11, c01],
             indices: vec![[0, 1, 2], [0, 2, 3]],
             normals: None,
         },
         material.clone(),
+        light_ray_mask(prim),
     );
     lights.add(Arc::new(AreaLight::new(
         Box::new(RectShape::new(origin, edge_u, edge_v, normal)),

--- a/crates/crust-core/src/world.rs
+++ b/crates/crust-core/src/world.rs
@@ -2,6 +2,7 @@ use crate::RenderSettings;
 use crate::camera::Camera;
 use crate::light::{AreaLight, LightList, SphereShape};
 use crate::material::{Emissive, Material, OpenPBR};
+use crate::ray::{MASK_INDIRECT, MASK_SHADOW};
 use crate::rt_world::{World, WorldBuilder};
 use crust_rt::Geometry;
 use glam::Vec3A;
@@ -15,7 +16,9 @@ fn add_sphere(world: &mut WorldBuilder, center: Vec3A, radius: f32, material: Ar
 
 /// Adds a sphere light to the scene: emissive sphere geometry in `world`
 /// plus an `AreaLight` over the same surface in `lights`, tied together by
-/// the geometry id (Cornell-box semantics — one surface, both roles).
+/// the geometry id (one surface, both roles). The geometry is masked out
+/// of camera rays — the industry default for light sources — while shadow
+/// and indirect rays still see it (occlusion and the bounce side of MIS).
 fn add_sphere_light(
     world: &mut WorldBuilder,
     lights: &mut LightList,
@@ -24,7 +27,11 @@ fn add_sphere_light(
     radius: f32,
 ) {
     let material = Arc::new(Emissive::new(color));
-    let geom_id = world.attach(Geometry::Sphere { center, radius }, material.clone());
+    let geom_id = world.attach_masked(
+        Geometry::Sphere { center, radius },
+        material.clone(),
+        MASK_INDIRECT | MASK_SHADOW,
+    );
     lights.add(Arc::new(AreaLight::new(
         Box::new(SphereShape { center, radius }),
         material,

--- a/crates/crust-core/tests/usd_scene.rs
+++ b/crates/crust-core/tests/usd_scene.rs
@@ -365,6 +365,47 @@ fn loads_curves_usda() {
     assert!(scene.world.intersect(&wide_up, 0.001, f32::INFINITY).is_none());
 }
 
+/// Light source geometry is camera-invisible by default (the industry
+/// convention); `crust:light:cameraVisible` opts a light back in, and an
+/// authored `crust:rayMask` wins outright. Shadow and indirect rays see
+/// every light either way — occlusion and the bounce side of MIS depend
+/// on that.
+#[test]
+fn light_geometry_camera_visibility() {
+    let scene = Scene::from_usd(&sample("light_visibility.usda"))
+        .expect("failed to open light_visibility.usda");
+
+    // Floor + three light spheres, all three in the light list.
+    assert_eq!(scene.world.count(), 4, "expected 4 geometries, got {}", scene.world.count());
+    assert_eq!(scene.lights.count(), 3, "expected 3 lights, got {}", scene.lights.count());
+
+    // Each light: radius 0.5 sphere at (x, 2, 0); a ray straight down from
+    // (x, 5, 0) meets its top at t = 2.5 and the floor at t = 5.
+    let down = |x: f32| {
+        crust_core::Ray::new(crust_core::Vec3A::new(x, 5.0, 0.0), -crust_core::Vec3A::Y)
+    };
+    let hit_t = |x: f32, mask: u32| {
+        scene
+            .world
+            .intersect(&down(x).with_mask(mask), 0.001, f32::INFINITY)
+            .expect("the floor backstops every ray")
+            .rec
+            .t
+    };
+
+    // Camera rays: the unauthored light is skipped (floor at t=5); the
+    // bool-visible and rayMask-override lights are hit (t=2.5).
+    assert!((hit_t(-3.0, crust_core::MASK_CAMERA) - 5.0).abs() < 1e-3);
+    assert!((hit_t(0.0, crust_core::MASK_CAMERA) - 2.5).abs() < 1e-3);
+    assert!((hit_t(3.0, crust_core::MASK_CAMERA) - 2.5).abs() < 1e-3);
+
+    // Shadow and indirect rays see all three light surfaces.
+    for x in [-3.0, 0.0, 3.0] {
+        assert!((hit_t(x, crust_core::MASK_SHADOW) - 2.5).abs() < 1e-3);
+        assert!((hit_t(x, crust_core::MASK_INDIRECT) - 2.5).abs() < 1e-3);
+    }
+}
+
 #[test]
 fn loads_motionblur_usda() {
     let scene =

--- a/samples/light_visibility.usda
+++ b/samples/light_visibility.usda
@@ -1,0 +1,69 @@
+#usda 1.0
+(
+    doc = "Light camera-visibility regression scene: three SphereLights floating over a floor. Default is the industry convention (source geometry hidden from camera rays); Visible opts in via crust:light:cameraVisible and Masked via an explicit crust:rayMask = 7. Shadow and indirect rays see all three."
+    defaultPrim = "World"
+    upAxis = "Y"
+)
+
+def Xform "World"
+{
+    def Camera "Cam"
+    {
+        float focalLength = 24
+        float horizontalAperture = 20.955
+        double3 xformOp:translate = (0, 2, 8)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def Mesh "Floor"
+    {
+        int[] faceVertexCounts = [4]
+        int[] faceVertexIndices = [0, 1, 2, 3]
+        point3f[] points = [(-8, 0, -8), (8, 0, -8), (8, 0, 8), (-8, 0, 8)]
+    }
+
+    # Hidden by default: no visibility attribute authored.
+    def SphereLight "Default"
+    {
+        float inputs:radius = 0.5
+        color3f inputs:color = (4, 4, 4)
+        float inputs:intensity = 1.0
+        double3 xformOp:translate = (-3, 2, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    # Opted back into camera rays with the friendly bool.
+    def SphereLight "Visible"
+    {
+        float inputs:radius = 0.5
+        color3f inputs:color = (4, 4, 4)
+        float inputs:intensity = 1.0
+        custom bool crust:light:cameraVisible = 1
+        double3 xformOp:translate = (0, 2, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    # Expert override: an authored crust:rayMask wins outright (7 = all).
+    def SphereLight "Masked"
+    {
+        float inputs:radius = 0.5
+        color3f inputs:color = (4, 4, 4)
+        float inputs:intensity = 1.0
+        custom int crust:rayMask = 7
+        double3 xformOp:translate = (3, 2, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+}
+
+def Scope "Render"
+{
+    def RenderSettings "settings"
+    {
+        int2 resolution = (64, 64)
+        int crust:samplesPerPixel = 8
+        int crust:maxDepth = 4
+        int crust:minSamplesPerPixel = 4
+        float crust:varianceThreshold = 0.05
+        int crust:frame = 0
+    }
+}

--- a/samples/openpbr_showcase.usda
+++ b/samples/openpbr_showcase.usda
@@ -215,14 +215,16 @@ def Xform "World"
     # Lights — SphereLights matching the RON's Emissive spheres. The RON
     # emitted `color=(15,15,15)` and `color=(18,12,9)` — encode that as
     # color*intensity with intensity=1 so the effective radiance is
-    # unchanged. Each SphereLight is also rendered as visible geometry
-    # (the importer adds both a `Light` entry and a sphere hittable).
+    # unchanged. Light sources are camera-invisible by default, so each
+    # SphereLight opts back in with crust:light:cameraVisible to keep the
+    # historical look (the glowing spheres are part of the composition).
     # ---------------------------------------------------------------------
     def SphereLight "Light1"
     {
         float inputs:radius = 1.5
         color3f inputs:color = (15, 15, 15)
         float inputs:intensity = 1.0
+        custom bool crust:light:cameraVisible = 1
         double3 xformOp:translate = (-2, 8, 3)
         uniform token[] xformOpOrder = ["xformOp:translate"]
     }
@@ -232,6 +234,7 @@ def Xform "World"
         float inputs:radius = 1.5
         color3f inputs:color = (18, 12, 9)
         float inputs:intensity = 1.0
+        custom bool crust:light:cameraVisible = 1
         double3 xformOp:translate = (4, 8, -2)
         uniform token[] xformOpOrder = ["xformOp:translate"]
     }

--- a/samples/veach_mis.usda
+++ b/samples/veach_mis.usda
@@ -29,12 +29,15 @@ def Xform "World"
     # -------------------------------------------------------------------
     # Lights: equal power, so radiance x radius^2 is constant (~21.9).
     # Tinted so each reflection band is attributable to its light.
+    # cameraVisible keeps the sphere row directly visible — the classic
+    # Veach framing shows the sources above their reflection bands.
     # -------------------------------------------------------------------
     def SphereLight "LightTiny"
     {
         float inputs:radius = 0.05
         color3f inputs:color = (1.0, 0.45, 0.35)
         float inputs:intensity = 8748
+        custom bool crust:light:cameraVisible = 1
         double3 xformOp:translate = (-3.375, 6, -3)
         uniform token[] xformOpOrder = ["xformOp:translate"]
     }
@@ -44,6 +47,7 @@ def Xform "World"
         float inputs:radius = 0.15
         color3f inputs:color = (1.0, 0.85, 0.45)
         float inputs:intensity = 972
+        custom bool crust:light:cameraVisible = 1
         double3 xformOp:translate = (-1.125, 6, -3)
         uniform token[] xformOpOrder = ["xformOp:translate"]
     }
@@ -53,6 +57,7 @@ def Xform "World"
         float inputs:radius = 0.45
         color3f inputs:color = (0.45, 1.0, 0.55)
         float inputs:intensity = 108
+        custom bool crust:light:cameraVisible = 1
         double3 xformOp:translate = (1.125, 6, -3)
         uniform token[] xformOpOrder = ["xformOp:translate"]
     }
@@ -62,6 +67,7 @@ def Xform "World"
         float inputs:radius = 1.35
         color3f inputs:color = (0.4, 0.6, 1.0)
         float inputs:intensity = 12
+        custom bool crust:light:cameraVisible = 1
         double3 xformOp:translate = (3.375, 6, -3)
         uniform token[] xformOpOrder = ["xformOp:translate"]
     }


### PR DESCRIPTION
Implements the industry standard for light source visibility: a light's emissive geometry is now **invisible to camera rays by default** (matching Arnold, RenderMan, Karma), while remaining visible to shadow and indirect rays so occlusion and light bounces are unchanged. This allows lights to be placed inside the frame without showing up in the render.

## Key Changes

- **New `light_ray_mask()` function** in `usd_import.rs`: computes ray visibility for light source geometry. Defaults to `MASK_SHADOW | MASK_INDIRECT` (camera-invisible), but:
  - Author `custom bool crust:light:cameraVisible = 1` on a light prim to opt back in (classic Cornell-box look)
  - Author `crust:rayMask` for full per-category control (wins outright when present)

- **Updated light emission**: `emit_sphere_light()` and `emit_rect_light()` now accept the prim and call `world.attach_masked()` with the computed mask, instead of `world.attach()`

- **Sample scene `light_visibility.usda`**: demonstrates all three spellings—default hidden, bool opt-in, and explicit rayMask override—with a test that verifies camera rays skip the default light but see the others, while shadow/indirect rays see all three

- **Updated existing scenes**: `openpbr_showcase.usda` and `veach_mis.usda` now author `crust:light:cameraVisible = 1` to preserve their historical appearance (glowing spheres visible in frame)

- **Documentation**: README and CLAUDE.md updated to explain the convention and the three control mechanisms

- **Test coverage**: `light_geometry_camera_visibility()` validates that camera rays respect the mask while shadow and indirect rays ignore it

## Implementation Details

The mask is computed per-light-prim at import time and passed through to the world builder's `attach_masked()` call. This keeps the logic localized and avoids runtime overhead—the mask is baked into the geometry's visibility state during scene construction.

https://claude.ai/code/session_01MmQzg3f8UcuMJwmSCnDeSP