### PR TITLE
Add subdivision surfaces via OpenSubdiv (opensubdiv-rs 0.1.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,9 @@ forces every mesh to be instanced instead of baking single-placement geometry fl
 is bit-identical with it set, which is what separates a deferral bug from a baking
 difference); `CRUST_PTEX=0` declines every Ptex texture so surfaces fall back to their
 constant `baseColor`; `CRUST_PTEX_MAX_LOG2` caps the per-face texture resolution loaded
-(log2 edge length, default 5 = 32x32).
+(log2 edge length, default 5 = 32x32); `CRUST_SUBDIV=0` forces every
+`crust:subdivisionLevel` to 0 so subdivision-surface meshes render their base cage — the
+A/B that separates a subdivision artifact from a material or lighting one.
 
 ## Measuring a change
 
@@ -398,6 +400,33 @@ Schema mapping:
   Non-invertible transforms still bake immediately, and a mesh authoring
   `crust:motion:translate` always instances (a baked mesh has no transform left to lerp).
   `UsdGeomSphere` → analytic `Sphere` geometry.
+- **Subdivision surfaces** (`scene/subdiv.rs`, via the pure-Rust
+  [`opensubdiv-rs`](https://github.com/doubleailes/OpenSubdiv-rs) port of OpenSubdiv's
+  Far/Sdc layers — zero dependencies, `forbid(unsafe_code)`, pinned by git tag). A mesh
+  prim authoring `crust:subdivisionLevel` (int, default 0, clamped to 6) is uniformly
+  refined that many times and **snapped to the limit surface**, with smooth per-vertex
+  shading normals (the kernel's `TriangleMesh.normals`, interpolated by barycentrics).
+  Deliberately **opt-in per prim** rather than triggered by `subdivisionScheme`: USD's
+  fallback scheme is `catmullClark`, so honouring the scheme alone would subdivide
+  virtually every mesh ever authored (all of the Moana island included), and USD has no
+  standard per-prim refinement level — Hydra treats refinement as a render setting. The
+  scheme still picks the algorithm once a level asks: unauthored/`catmullClark` →
+  Catmark, `bilinear` → Bilinear, `loop` → Loop (all-triangle cages only), `none` →
+  warn and render the cage. `creaseIndices`/`creaseLengths`/`creaseSharpnesses`
+  (per-run or per-edge sharpness, 10 = infinite), `cornerIndices`/`cornerSharpnesses`
+  and `interpolateBoundary` are honoured; `holeIndices` and
+  `faceVaryingLinearInterpolation` are not. Refinement happens in `mesh_source`,
+  *before* interning, so every path (direct bake, deferred instance-vs-bake,
+  prototypes) sees it exactly once and `MeshKey` dedupes on the refined arrays. A
+  malformed cage or refiner error warns and degrades to the cage. **Ptex keeps
+  indexing the base cage**: refined triangles carry explicit corner UVs
+  (`FaceMap.uvs`) mapping them back into their cage face's unit square (a synthetic
+  face-varying channel refined with linear-everywhere interpolation), and
+  `check_face_count` compares the texture against the *authored* face count. Baked
+  placements push normals through the inverse transpose (`bake_normals`), matching the
+  kernel's instance path exactly — mirrors included. Sample scene:
+  `samples/subdivision.usda` (levels 0–3 plus a fully edge-creased cube that stays a
+  cube); `CRUST_SUBDIV=0` is the kill switch.
 - `UsdGeomBasisCurves` → an instanced `rt::Geometry::RoundCurves` batch: `linear` curves
   directly, `cubic` (bezier | bspline | catmullRom) flattened at 8 samples per span; widths
   (USD diameters) resolve per-vertex / per-curve / constant by array length.
@@ -524,9 +553,11 @@ Schema mapping:
     `v0=(0,0)` than transposed, and 1.9–97x lower than between unrelated faces.
     Alongside those, 10 textures / 28 816 faces against 57 632 triangles (exactly 2 per
     quad). The importer warns when a texture's `numFaces` disagrees with its mesh. Not reproduced: no
-    displacement (`inputs:displacementMap` is unread), no subdivision (meshes are
-    `catmullClark`; the base cage is rendered, which Ptex is indifferent to since its
-    faces *are* cage faces), and the reference's `islandsunEnv.tex` environment is a
+    displacement (`inputs:displacementMap` is unread), no subdivision *on the island*
+    (subdivision is opt-in via `crust:subdivisionLevel`, which the island does not
+    author, so its `catmullClark` base cages render as before — Ptex is indifferent
+    either way, since face ids index cage faces and subdivided face tables map back to
+    them), and the reference's `islandsunEnv.tex` environment is a
     RenderMan-only format.
 - `UsdLuxDistantLight` → a `DistantLight` in the light list only (no scene geometry). It
   points down its local -Z; `inputs:angle` is the source's angular *diameter* (default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -427,6 +427,20 @@ Schema mapping:
   kernel's instance path exactly — mirrors included. Sample scene:
   `samples/subdivision.usda` (levels 0–3 plus a fully edge-creased cube that stays a
   cube); `CRUST_SUBDIV=0` is the kill switch.
+  **Memory, measured** (the refiner retains every level 0..L, a ×4/3 geometric series
+  over the last level): `subdivide()` transiently allocates **~313 B per refined face**,
+  ~556–592 B when the material needs Ptex sub-face UVs (the synthetic fvar channel is a
+  full parallel hierarchy); the returned mesh holds 48 B/face (84 with UVs). Pinned by
+  the allocation-counting probe `cargo test -p crust-core --lib
+  subdivision_memory_probe -- --ignored --nocapture --test-threads=1` (deterministic
+  requested-byte ceilings ~25% above those numbers). End to end
+  (`scripts/gen_subdiv_stress.py`, 1.18 M refined quads at level 3, A/B'd with
+  `CRUST_SUBDIV=0`): traverse-phase peak +310 MiB — within 6% of the model — and
+  kernel-resident memory scaling exactly ×4 per level (34.67 MiB at level 1 → 2.17 GiB
+  at level 4). The whole-process peak is **not** opensubdiv: at level 4 traversal peaks
+  at 1.16 GiB while the SBVH build over the baked result peaks at 2.19 GiB — the
+  pre-existing build transient (see "Known incomplete work"), which subdivision merely
+  feeds 4^L× more triangles.
 - `UsdGeomBasisCurves` → an instanced `rt::Geometry::RoundCurves` batch: `linear` curves
   directly, `cubic` (bezier | bspline | catmullRom) flattened at 8 samples per span; widths
   (USD diameters) resolve per-vertex / per-curve / constant by array length.
@@ -672,6 +686,14 @@ textures decode — `islandsunVIS.png` is 16384x8192 and the pair peaks at ~11 G
   transiently holds a few hundred MiB where 1 788 small builds held almost nothing. If that
   peak ever matters more than the ~20% render win, the lever is a triangle-count cap on
   baking; the real fix is a builder that does not materialise the whole binary tree.
+  Subdivision surfaces sharpen this: a level-L cage feeds 4^L× more triangles into the
+  same build, and on the `gen_subdiv_stress.py` scene at level 4 the SBVH commit peak
+  (2.19 GiB) is nearly twice the refiner's own traverse-phase peak (1.16 GiB) — so the
+  build transient, not opensubdiv, is the first lever if a subdivided scene runs out of
+  memory. Within `subdivide()` itself the tail holds ~5 copies of the last level's
+  positions (`verts`, `limit`, `points`, `verts_a`, `normals`) plus the whole retained
+  refiner; restructuring to drop the refiner before the copies would shave roughly a
+  third off its ~313 B/face transient if that ever matters.
 
 - **Instancing caveats.** The kernel nests instances to arbitrary depth (transforms
   compose, normals map back through every level, masks gate per level — pinned by

--- a/crates/crust-core/Cargo.toml
+++ b/crates/crust-core/Cargo.toml
@@ -20,6 +20,11 @@ rayon = "1.10.0"
 glam.workspace = true
 tracing.workspace = true
 openusd = { version = "0.6", default-features = false, features = ["geom", "lux", "shade", "render"] }
+# Pure-Rust OpenSubdiv port (Far topology refinement + Sdc rules) driving
+# Catmull-Clark subdivision at USD import. Not published on crates.io, so a
+# git dependency; pinned to a tag because `Cargo.lock` is not checked in —
+# same reasoning as ptex-rs in crust-render.
+opensubdiv-rs = { git = "https://github.com/doubleailes/OpenSubdiv-rs", tag = "0.1.2" }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/crust-core/Cargo.toml
+++ b/crates/crust-core/Cargo.toml
@@ -14,7 +14,7 @@ traversal-stats = ["crust-rt/traversal-stats"]
 
 [dependencies]
 utils = { path = "../utils" }
-openqmc-rs = "0.1"
+openqmc-rs = "0.2"
 crust-rt = { path = "../crust-rt" }
 rayon = "1.10.0"
 glam.workspace = true
@@ -24,7 +24,7 @@ openusd = { version = "0.6", default-features = false, features = ["geom", "lux"
 # Catmull-Clark subdivision at USD import. Not published on crates.io, so a
 # git dependency; pinned to a tag because `Cargo.lock` is not checked in —
 # same reasoning as ptex-rs in crust-render.
-opensubdiv-rs = { git = "https://github.com/doubleailes/OpenSubdiv-rs", tag = "0.1.2" }
+opensubdiv-rs = "0.1"
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/crust-core/src/rt_world.rs
+++ b/crates/crust-core/src/rt_world.rs
@@ -45,6 +45,13 @@ pub struct FaceMap {
     pub faces: Vec<u32>,
     /// Which slice of that polygon's fan the triangle is.
     pub slices: Vec<FanSlice>,
+    /// Explicit per-triangle corner UVs in the source face's unit square,
+    /// index-parallel with `faces`. Subdivided meshes only: their triangles
+    /// cover a *sub*-rectangle of the base-cage face, which no fan slice can
+    /// express — `faces` then carries base-cage ids and each triangle's
+    /// corners carry its patch of the cage face. `None` for unsubdivided
+    /// meshes, whose triangles resolve through `slices` alone.
+    pub uvs: Option<Vec<[[f32; 2]; 3]>>,
 }
 
 impl FaceMap {
@@ -65,6 +72,21 @@ impl FaceMap {
         let i = prim_id as usize;
         let (&face, &slice) = (self.faces.get(i)?, self.slices.get(i)?);
         let (u, v) = if swapped { (v, u) } else { (u, v) };
+        if let Some(uvs) = &self.uvs {
+            if slice == FanSlice::Unmappable {
+                return None;
+            }
+            // Corner UVs are stored in the triangle's *original* vertex
+            // order, so the swap above already restored the barycentrics to
+            // that order and plain interpolation is right for mirrors too.
+            let [a, b, c] = *uvs.get(i)?;
+            let w = 1.0 - u - v;
+            return Some((
+                face,
+                (w * a[0] + u * b[0] + v * c[0]).clamp(0.0, 1.0),
+                (w * a[1] + u * b[1] + v * c[1]).clamp(0.0, 1.0),
+            ));
+        }
         let (fu, fv) = match slice {
             // (v0,v1,v2) -> u·(1,0) + v·(1,1)
             FanSlice::QuadLower => (u + v, v),
@@ -302,6 +324,7 @@ mod tests {
         FaceMap {
             faces: vec![7, 7],
             slices: vec![FanSlice::QuadLower, FanSlice::QuadUpper],
+            uvs: None,
         }
     }
 
@@ -356,6 +379,7 @@ mod tests {
         let m = FaceMap {
             faces: vec![3],
             slices: vec![FanSlice::Unmappable],
+            uvs: None,
         };
         assert_eq!(m.resolve(0, 0.25, 0.25, false), None);
     }
@@ -365,5 +389,61 @@ mod tests {
     #[test]
     fn out_of_range_prim_id_declines() {
         assert_eq!(quad().resolve(99, 0.0, 0.0, false), None);
+    }
+
+    /// A subdivided quad's upper-left quadrant, fan-triangulated: the child
+    /// quad's corners are (0,0.5) (0.5,0.5) (0.5,1) (0,1) in the base face.
+    fn sub_quad() -> FaceMap {
+        FaceMap {
+            faces: vec![7, 7],
+            slices: vec![FanSlice::QuadLower, FanSlice::QuadUpper],
+            uvs: Some(vec![
+                [[0.0, 0.5], [0.5, 0.5], [0.5, 1.0]],
+                [[0.0, 0.5], [0.5, 1.0], [0.0, 1.0]],
+            ]),
+        }
+    }
+
+    /// Explicit UVs resolve each triangle corner to its patch of the *base*
+    /// face — the whole point of carrying them for subdivided meshes.
+    #[test]
+    fn explicit_uvs_map_to_the_sub_rectangle() {
+        let m = sub_quad();
+        assert_eq!(m.resolve(0, 0.0, 0.0, false), Some((7, 0.0, 0.5)));
+        assert_eq!(m.resolve(0, 1.0, 0.0, false), Some((7, 0.5, 0.5)));
+        assert_eq!(m.resolve(0, 0.0, 1.0, false), Some((7, 0.5, 1.0)));
+        assert_eq!(m.resolve(1, 1.0, 0.0, false), Some((7, 0.5, 1.0)));
+        assert_eq!(m.resolve(1, 0.0, 1.0, false), Some((7, 0.0, 1.0)));
+    }
+
+    /// Both halves land on the same point along their shared diagonal, same
+    /// contract as the fan-slice path.
+    #[test]
+    fn explicit_uv_halves_agree_on_the_shared_diagonal() {
+        let m = sub_quad();
+        assert_eq!(m.resolve(0, 0.0, 0.5, false), m.resolve(1, 0.5, 0.0, false));
+    }
+
+    /// The mirror swap composes with explicit UVs exactly as with fan
+    /// slices: corner UVs are stored in original vertex order, so unswapping
+    /// the barycentrics is the whole fix.
+    #[test]
+    fn explicit_uvs_unswap_mirrored_barycentrics() {
+        let m = sub_quad();
+        // Same hit as triangle 0's second vertex, reported swapped.
+        assert_eq!(m.resolve(0, 0.0, 1.0, true), Some((7, 0.5, 0.5)));
+    }
+
+    /// Descendants of a non-quad cage face decline even though the table
+    /// carries UVs for their neighbours.
+    #[test]
+    fn explicit_uv_unmappable_declines() {
+        let m = FaceMap {
+            faces: vec![u32::MAX],
+            slices: vec![FanSlice::Unmappable],
+            uvs: Some(vec![[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]]),
+        };
+        assert_eq!(m.resolve(0, 0.25, 0.25, false), None);
+        assert_eq!(m.resolve(9, 0.25, 0.25, false), None);
     }
 }

--- a/crates/crust-core/src/scene.rs
+++ b/crates/crust-core/src/scene.rs
@@ -48,6 +48,7 @@ impl Scene {
     }
 }
 
+mod subdiv;
 mod usd_import;
 
 impl Scene {

--- a/crates/crust-core/src/scene/subdiv.rs
+++ b/crates/crust-core/src/scene/subdiv.rs
@@ -1,0 +1,665 @@
+//! Subdivision-surface refinement for USD meshes, via the pure-Rust
+//! [`opensubdiv-rs`] port of OpenSubdiv's Far/Sdc layers.
+//!
+//! The importer hands this module a base cage (points + faceVertexCounts +
+//! faceVertexIndices, exactly as authored) and gets back a uniformly refined
+//! mesh whose positions sit **on the limit surface** and whose vertices carry
+//! smooth shading normals. Everything downstream — triangulation, interning,
+//! instancing, baking — then treats the refined mesh like any other polygon
+//! mesh.
+//!
+//! Ptex face ids index the *base cage*, so when the caller needs per-face
+//! texturing the refinement also reports, per refined face, which cage face
+//! it descends from and where its corners sit inside that face's unit square
+//! ([`SubdivFaces`]). The sub-face UVs come from a synthetic face-varying
+//! channel (each cage face owns four values at the Ptex corners, refined with
+//! [`FVarLinearInterpolation::All`], i.e. pure bilinear interpolation) — the
+//! channel *is* the parameterization, so the smoothing rules must never touch
+//! it.
+//!
+//! [`opensubdiv-rs`]: https://github.com/doubleailes/OpenSubdiv-rs
+
+use glam::Vec3A;
+use opensubdiv_rs::far::{
+    FVarChannelDescriptor, PrimvarRefiner, TopologyDescriptor, TopologyRefinerFactory,
+    UniformOptions,
+};
+use opensubdiv_rs::sdc;
+use openusd::gf::Vec3f;
+use std::fmt;
+
+/// The subdivision schemes the importer maps from `subdivisionScheme`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SubdivScheme {
+    CatmullClark,
+    Bilinear,
+    /// Loop subdivision refines triangles into triangles; the factory rejects
+    /// any non-triangular face, so the caller pre-checks the cage.
+    Loop,
+}
+
+/// Everything `subdivide` needs beyond the cage arrays, borrowed straight
+/// from the authored attributes.
+pub(crate) struct SubdivRequest<'a> {
+    pub scheme: SubdivScheme,
+    /// Uniform refinement depth, `>= 1` (level 0 never reaches this module).
+    pub level: u32,
+    pub boundary: sdc::VtxBoundaryInterpolation,
+    /// USD authors creases as runs of vertices: run `i` spans
+    /// `crease_lengths[i]` consecutive entries of `crease_indices` and
+    /// describes `crease_lengths[i] - 1` edges.
+    pub crease_indices: &'a [i32],
+    pub crease_lengths: &'a [i32],
+    /// One sharpness per run *or* one per edge — both are legal USD.
+    pub crease_sharpnesses: &'a [f32],
+    pub corner_indices: &'a [i32],
+    pub corner_sharpnesses: &'a [f32],
+    /// Build [`SubdivFaces`] (only wanted when the material samples a
+    /// per-face texture).
+    pub want_face_uvs: bool,
+}
+
+/// Per refined face: the base-cage face it descends from and its corner UVs
+/// inside that face's unit square (Ptex convention: `v0=(0,0) v1=(1,0)
+/// v2=(1,1) v3=(0,1)`).
+pub(crate) struct SubdivFaces {
+    /// `u32::MAX` marks a face with no Ptex-addressable ancestor (its cage
+    /// face was not a quad — Ptex subfaces are out of scope, matching the
+    /// unsubdivided importer's treatment of n-gons).
+    pub base_face: Vec<u32>,
+    /// Corner UVs of the refined quad, in `face_vertices` order.
+    pub corner_uvs: Vec<[[f32; 2]; 4]>,
+}
+
+/// A refined mesh in the same array shapes `triangulate` consumes.
+pub(crate) struct SubdividedMesh {
+    /// Limit-surface positions (uniform refinement, then limit snap).
+    pub points: Vec<Vec3f>,
+    /// All 4s for Catmull-Clark/Bilinear, all 3s for Loop.
+    pub counts: Vec<i32>,
+    pub indices: Vec<i32>,
+    /// Smooth per-vertex shading normals, parallel to `points`.
+    pub normals: Vec<Vec3A>,
+    /// `Some` iff the request asked for face UVs.
+    pub faces: Option<SubdivFaces>,
+}
+
+#[derive(Debug)]
+pub(crate) enum SubdivError {
+    /// The cage failed validation before it reached the refiner — unlike
+    /// `triangulate`, a topology refiner cannot skip a malformed face, so the
+    /// whole mesh degrades to its cage.
+    BadTopology(String),
+    Refine(opensubdiv_rs::far::Error),
+}
+
+impl fmt::Display for SubdivError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SubdivError::BadTopology(why) => write!(f, "{why}"),
+            SubdivError::Refine(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+/// Uniformly refines the cage to `req.level` and snaps the result to the
+/// limit surface. See the module docs for the shape of the answer.
+pub(crate) fn subdivide(
+    points: &[Vec3f],
+    counts: &[i32],
+    indices: &[i32],
+    req: &SubdivRequest,
+) -> Result<SubdividedMesh, SubdivError> {
+    let (counts_us, indices_u32) = validate_cage(points.len(), counts, indices)?;
+    let (crease_pairs, crease_weights) = expand_crease_runs(
+        req.crease_indices,
+        req.crease_lengths,
+        req.crease_sharpnesses,
+    )?;
+    let corners = validate_corners(req.corner_indices, req.corner_sharpnesses)?;
+
+    let scheme = match req.scheme {
+        SubdivScheme::CatmullClark => sdc::SchemeType::Catmark,
+        SubdivScheme::Bilinear => sdc::SchemeType::Bilinear,
+        SubdivScheme::Loop => sdc::SchemeType::Loop,
+    };
+    // The synthetic Ptex channel must interpolate bilinearly everywhere —
+    // any corner/boundary smoothing would bend the parameterization itself.
+    let options = sdc::Options::default()
+        .with_vtx_boundary_interpolation(req.boundary)
+        .with_fvar_linear_interpolation(sdc::FVarLinearInterpolation::All);
+
+    // Loop cannot refine quads at all, and the Ptex channel only makes sense
+    // for the quad-split schemes.
+    let want_uvs = req.want_face_uvs && req.scheme != SubdivScheme::Loop;
+    let (fvar_uvs, fvar_indices) = if want_uvs {
+        ptex_fvar_channel(&counts_us)
+    } else {
+        (Vec::new(), Vec::new())
+    };
+    let channels = [FVarChannelDescriptor::new(fvar_uvs.len(), &fvar_indices)];
+
+    let mut descriptor = TopologyDescriptor::new(points.len(), &counts_us, &indices_u32)
+        .with_creases(&crease_pairs, &crease_weights)
+        .with_corners(&corners.0, &corners.1);
+    if want_uvs {
+        descriptor = descriptor.with_fvar_channels(&channels);
+    }
+
+    let mut refiner =
+        TopologyRefinerFactory::create(descriptor, scheme, options).map_err(SubdivError::Refine)?;
+    let level = req.level as usize;
+    refiner.refine_uniform(UniformOptions::new(level));
+
+    // Positions: interpolate level by level, then snap the last level to the
+    // limit surface. (For Bilinear the limit is the refined mesh itself;
+    // limit_level handles that uniformly.)
+    let primvar = PrimvarRefiner::new(&refiner);
+    let mut verts: Vec<[f32; 3]> = points.iter().map(|p| [p.x, p.y, p.z]).collect();
+    for l in 1..=level {
+        let mut refined = vec![[0.0f32; 3]; refiner.level(l).num_vertices()];
+        primvar.interpolate(l, &verts, &mut refined);
+        verts = refined;
+    }
+    let mut limit = vec![[0.0f32; 3]; verts.len()];
+    primvar.limit(&verts, &mut limit);
+
+    // Topology of the last level, back in the importer's array shapes.
+    let last = refiner.level(level);
+    let n_faces = last.num_faces();
+    let mut out_counts = Vec::with_capacity(n_faces);
+    let mut out_indices = Vec::with_capacity(last.num_face_vertices_total());
+    for f in 0..n_faces {
+        let fv = last.face_vertices(f);
+        out_counts.push(fv.len() as i32);
+        out_indices.extend(fv.iter().map(|&v| v as i32));
+    }
+
+    let faces = want_uvs.then(|| {
+        // Base-cage face per refined face: compose the one-step
+        // child-to-parent maps from the last refinement down to level 0.
+        let mut base_face: Vec<u32> = (0..n_faces as u32).collect();
+        for l in (1..=level).rev() {
+            let refinement = refiner.refinement(l);
+            for f in &mut base_face {
+                *f = refinement.child_face_parent_face(*f as usize);
+            }
+        }
+        for f in &mut base_face {
+            if counts[*f as usize] != 4 {
+                *f = u32::MAX;
+            }
+        }
+
+        // Sub-face corner UVs: refine the synthetic channel the same way the
+        // positions were refined, then read each face's four values.
+        let mut uvs = fvar_uvs.clone();
+        for l in 1..=level {
+            let mut refined = vec![[0.0f32; 2]; refiner.level(l).num_fvar_values(0)];
+            primvar.interpolate_face_varying(l, 0, &uvs, &mut refined);
+            uvs = refined;
+        }
+        let corner_uvs = (0..n_faces)
+            .map(|f| {
+                let fv = last.face_fvar_values(f, 0);
+                debug_assert_eq!(fv.len(), 4, "quad-split schemes only refine into quads");
+                [
+                    uvs[fv[0] as usize],
+                    uvs[fv[1] as usize],
+                    uvs[fv[2] as usize],
+                    uvs[fv[3] as usize],
+                ]
+            })
+            .collect();
+        SubdivFaces {
+            base_face,
+            corner_uvs,
+        }
+    });
+
+    let points: Vec<Vec3f> = limit
+        .iter()
+        .map(|p| Vec3f::from([p[0], p[1], p[2]]))
+        .collect();
+    let verts_a: Vec<Vec3A> = limit.iter().map(|p| Vec3A::from_array(*p)).collect();
+    let normals = smooth_normals(&verts_a, &out_counts, &out_indices);
+
+    Ok(SubdividedMesh {
+        points,
+        counts: out_counts,
+        indices: out_indices,
+        normals,
+        faces,
+    })
+}
+
+/// Smooth per-vertex normals for a polygon mesh: each face accumulates its
+/// *unnormalized* area vector (the sum of its fan's cross products — twice
+/// the face normal scaled by area, so larger faces weigh more) onto **every**
+/// vertex of the face — per-fan-triangle accumulation would weigh a vertex
+/// by where it happens to sit in the fan. Every sum is then normalized
+/// (zero-length sums fall back to +Y rather than yield NaNs; the kernel
+/// treats shading normals as directions only).
+pub(crate) fn smooth_normals(verts: &[Vec3A], counts: &[i32], indices: &[i32]) -> Vec<Vec3A> {
+    let mut sums = vec![Vec3A::ZERO; verts.len()];
+    let mut off = 0usize;
+    for &fc in counts {
+        let fc = fc as usize;
+        let face = &indices[off..off + fc];
+        off += fc;
+        let v0 = verts[face[0] as usize];
+        let mut area = Vec3A::ZERO;
+        for k in 1..fc - 1 {
+            let (i1, i2) = (face[k] as usize, face[k + 1] as usize);
+            area += (verts[i1] - v0).cross(verts[i2] - v0);
+        }
+        for &i in face {
+            sums[i as usize] += area;
+        }
+    }
+    sums.iter()
+        .map(|n| {
+            if n.length_squared() > 1e-20 {
+                n.normalize()
+            } else {
+                Vec3A::Y
+            }
+        })
+        .collect()
+}
+
+/// The refiner indexes with `usize` counts and `u32` indices, and it cannot
+/// skip a malformed face the way `triangulate` does — so the cage is checked
+/// whole, up front.
+fn validate_cage(
+    n_verts: usize,
+    counts: &[i32],
+    indices: &[i32],
+) -> Result<(Vec<usize>, Vec<u32>), SubdivError> {
+    let mut total = 0usize;
+    let mut counts_us = Vec::with_capacity(counts.len());
+    for (face, &fc) in counts.iter().enumerate() {
+        if fc < 3 {
+            return Err(SubdivError::BadTopology(format!(
+                "face {face} has {fc} vertices (need at least 3)"
+            )));
+        }
+        counts_us.push(fc as usize);
+        total += fc as usize;
+    }
+    if total != indices.len() {
+        return Err(SubdivError::BadTopology(format!(
+            "faceVertexCounts sums to {total} but faceVertexIndices has {} entries",
+            indices.len()
+        )));
+    }
+    let mut indices_u32 = Vec::with_capacity(indices.len());
+    for &i in indices {
+        if i < 0 || i as usize >= n_verts {
+            return Err(SubdivError::BadTopology(format!(
+                "face vertex index {i} out of range (mesh has {n_verts} points)"
+            )));
+        }
+        indices_u32.push(i as u32);
+    }
+    Ok((counts_us, indices_u32))
+}
+
+/// Expands USD crease runs into the per-edge vertex pairs the refiner wants.
+/// A run of `n` vertices contributes `n - 1` edges; `sharpnesses` carries
+/// either one value per run or one per edge. Sharpness 10 is USD's "as sharp
+/// as possible", which is exactly `sdc::SHARPNESS_INFINITE`; anything at or
+/// above it is clamped there.
+fn expand_crease_runs(
+    indices: &[i32],
+    lengths: &[i32],
+    sharpnesses: &[f32],
+) -> Result<(Vec<[u32; 2]>, Vec<f32>), SubdivError> {
+    if lengths.is_empty() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    let mut n_edges = 0usize;
+    let mut n_verts = 0usize;
+    for (run, &len) in lengths.iter().enumerate() {
+        if len < 2 {
+            return Err(SubdivError::BadTopology(format!(
+                "crease run {run} has length {len} (need at least 2 vertices)"
+            )));
+        }
+        n_edges += len as usize - 1;
+        n_verts += len as usize;
+    }
+    if n_verts != indices.len() {
+        return Err(SubdivError::BadTopology(format!(
+            "creaseLengths sums to {n_verts} but creaseIndices has {} entries",
+            indices.len()
+        )));
+    }
+    let per_run = sharpnesses.len() == lengths.len();
+    if !per_run && sharpnesses.len() != n_edges {
+        return Err(SubdivError::BadTopology(format!(
+            "creaseSharpnesses has {} entries (want {} per-run or {n_edges} per-edge)",
+            sharpnesses.len(),
+            lengths.len()
+        )));
+    }
+    let clamp = |s: f32| {
+        if s >= sdc::SHARPNESS_INFINITE {
+            sdc::SHARPNESS_INFINITE
+        } else {
+            s.max(0.0)
+        }
+    };
+    let mut pairs = Vec::with_capacity(n_edges);
+    let mut weights = Vec::with_capacity(n_edges);
+    let mut off = 0usize;
+    let mut edge = 0usize;
+    for (run, &len) in lengths.iter().enumerate() {
+        for k in 0..len as usize - 1 {
+            let (a, b) = (indices[off + k], indices[off + k + 1]);
+            if a < 0 || b < 0 {
+                return Err(SubdivError::BadTopology(format!(
+                    "crease run {run} has a negative vertex index"
+                )));
+            }
+            pairs.push([a as u32, b as u32]);
+            weights.push(clamp(if per_run {
+                sharpnesses[run]
+            } else {
+                sharpnesses[edge]
+            }));
+            edge += 1;
+        }
+        off += len as usize;
+    }
+    Ok((pairs, weights))
+}
+
+fn validate_corners(
+    indices: &[i32],
+    sharpnesses: &[f32],
+) -> Result<(Vec<u32>, Vec<f32>), SubdivError> {
+    if indices.len() != sharpnesses.len() {
+        return Err(SubdivError::BadTopology(format!(
+            "cornerIndices has {} entries but cornerSharpnesses has {}",
+            indices.len(),
+            sharpnesses.len()
+        )));
+    }
+    let mut out = Vec::with_capacity(indices.len());
+    for &i in indices {
+        if i < 0 {
+            return Err(SubdivError::BadTopology(
+                "cornerIndices has a negative vertex index".into(),
+            ));
+        }
+        out.push(i as u32);
+    }
+    let weights = sharpnesses
+        .iter()
+        .map(|&s| {
+            if s >= sdc::SHARPNESS_INFINITE {
+                sdc::SHARPNESS_INFINITE
+            } else {
+                s.max(0.0)
+            }
+        })
+        .collect();
+    Ok((out, weights))
+}
+
+/// The synthetic face-varying channel carrying each cage face's Ptex
+/// parameterization: one value per face-vertex (`0..sum(counts)` in authored
+/// order, so no value is shared across faces), quads seeded with the four
+/// Ptex corners. Non-quad faces get zeros — their descendants are marked
+/// unmappable regardless, the channel just has to be well-formed.
+fn ptex_fvar_channel(counts: &[usize]) -> (Vec<[f32; 2]>, Vec<u32>) {
+    const QUAD: [[f32; 2]; 4] = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
+    let total: usize = counts.iter().sum();
+    let mut values = Vec::with_capacity(total);
+    for &fc in counts {
+        if fc == 4 {
+            values.extend_from_slice(&QUAD);
+        } else {
+            values.extend(std::iter::repeat_n([0.0f32; 2], fc));
+        }
+    }
+    let indices = (0..total as u32).collect();
+    (values, indices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// ±1 cube authored as six quads (the winding matches
+    /// `samples/subdivision.usda`).
+    fn cube() -> (Vec<Vec3f>, Vec<i32>, Vec<i32>) {
+        let points = vec![
+            Vec3f::from([-1.0, -1.0, 1.0]),
+            Vec3f::from([1.0, -1.0, 1.0]),
+            Vec3f::from([1.0, 1.0, 1.0]),
+            Vec3f::from([-1.0, 1.0, 1.0]),
+            Vec3f::from([-1.0, -1.0, -1.0]),
+            Vec3f::from([1.0, -1.0, -1.0]),
+            Vec3f::from([1.0, 1.0, -1.0]),
+            Vec3f::from([-1.0, 1.0, -1.0]),
+        ];
+        let counts = vec![4; 6];
+        let indices = vec![
+            0, 1, 2, 3, // +Z
+            5, 4, 7, 6, // -Z
+            4, 0, 3, 7, // -X
+            1, 5, 6, 2, // +X
+            3, 2, 6, 7, // +Y
+            4, 5, 1, 0, // -Y
+        ];
+        (points, counts, indices)
+    }
+
+    fn request(level: u32) -> SubdivRequest<'static> {
+        SubdivRequest {
+            scheme: SubdivScheme::CatmullClark,
+            level,
+            boundary: sdc::VtxBoundaryInterpolation::EdgeAndCorner,
+            crease_indices: &[],
+            crease_lengths: &[],
+            crease_sharpnesses: &[],
+            corner_indices: &[],
+            corner_sharpnesses: &[],
+            want_face_uvs: false,
+        }
+    }
+
+    #[test]
+    fn cube_level_one_topology() {
+        let (points, counts, indices) = cube();
+        let out = subdivide(&points, &counts, &indices, &request(1)).unwrap();
+        assert_eq!(out.points.len(), 26, "8 corners + 12 edge + 6 face points");
+        assert_eq!(out.counts.len(), 24, "each quad splits in four");
+        assert!(out.counts.iter().all(|&c| c == 4));
+        assert_eq!(out.indices.len(), 96);
+        assert_eq!(out.normals.len(), out.points.len());
+    }
+
+    #[test]
+    fn limit_shrinks_strictly_inside_the_cage() {
+        let (points, counts, indices) = cube();
+        let out = subdivide(&points, &counts, &indices, &request(2)).unwrap();
+        for p in &out.points {
+            for c in [p.x, p.y, p.z] {
+                assert!(c.abs() < 1.0, "limit point {p:?} not inside the cage");
+            }
+        }
+        let max = out
+            .points
+            .iter()
+            .flat_map(|p| [p.x.abs(), p.y.abs(), p.z.abs()])
+            .fold(0.0f32, f32::max);
+        assert!(max > 0.5, "limit surface collapsed too far ({max})");
+    }
+
+    #[test]
+    fn fully_creased_cube_keeps_its_cage() {
+        let (points, counts, indices) = cube();
+        // All 12 edges as runs of 2 vertices, one sharpness per run.
+        let crease_indices: Vec<i32> = vec![
+            0, 1, 1, 2, 2, 3, 3, 0, // +Z ring
+            4, 5, 5, 6, 6, 7, 7, 4, // -Z ring
+            0, 4, 1, 5, 2, 6, 3, 7, // connecting edges
+        ];
+        let crease_lengths = vec![2; 12];
+        let crease_sharpnesses = vec![10.0f32; 12];
+        let req = SubdivRequest {
+            crease_indices: &crease_indices,
+            crease_lengths: &crease_lengths,
+            crease_sharpnesses: &crease_sharpnesses,
+            ..request(2)
+        };
+        let out = subdivide(&points, &counts, &indices, &req).unwrap();
+        for axis in 0..3 {
+            let coords = out.points.iter().map(|p| [p.x, p.y, p.z][axis]);
+            let max = coords.clone().fold(f32::MIN, f32::max);
+            let min = coords.fold(f32::MAX, f32::min);
+            assert!((max - 1.0).abs() < 1e-5, "axis {axis} max {max}");
+            assert!((min + 1.0).abs() < 1e-5, "axis {axis} min {min}");
+        }
+    }
+
+    #[test]
+    fn crease_runs_expand_per_run_and_per_edge() {
+        // One run of 3 vertices = 2 edges.
+        let (pairs, w) = expand_crease_runs(&[0, 1, 2], &[3], &[10.0]).unwrap();
+        assert_eq!(pairs, vec![[0, 1], [1, 2]]);
+        assert_eq!(w, vec![10.0, 10.0], "per-run sharpness covers every edge");
+
+        let (_, w) = expand_crease_runs(&[0, 1, 2], &[3], &[2.0, 4.0]).unwrap();
+        assert_eq!(w, vec![2.0, 4.0], "per-edge sharpness passes through");
+
+        assert!(
+            expand_crease_runs(&[0, 1, 2], &[3], &[1.0, 2.0, 3.0]).is_err(),
+            "3 sharpnesses fit neither 1 run nor 2 edges"
+        );
+        assert!(expand_crease_runs(&[0, 1], &[3], &[1.0]).is_err());
+        assert!(expand_crease_runs(&[0], &[1], &[1.0]).is_err());
+    }
+
+    #[test]
+    fn malformed_cages_are_rejected_whole() {
+        let (points, mut counts, indices) = cube();
+        counts[0] = 2;
+        assert!(matches!(
+            subdivide(&points, &counts, &indices, &request(1)),
+            Err(SubdivError::BadTopology(_))
+        ));
+
+        let (points, counts, mut indices) = cube();
+        indices[0] = 8;
+        assert!(subdivide(&points, &counts, &indices, &request(1)).is_err());
+
+        let (points, counts, _) = cube();
+        assert!(subdivide(&points, &counts, &[0, 1, 2], &request(1)).is_err());
+    }
+
+    #[test]
+    fn level_one_face_uvs_tile_the_quadrants() {
+        let (points, counts, indices) = cube();
+        let req = SubdivRequest {
+            want_face_uvs: true,
+            ..request(1)
+        };
+        let out = subdivide(&points, &counts, &indices, &req).unwrap();
+        let faces = out.faces.expect("face UVs were requested");
+        assert_eq!(faces.base_face.len(), 24);
+        assert_eq!(faces.corner_uvs.len(), 24);
+        // Children of one parent are contiguous and in corner order, so the
+        // base_face map is 4 children per cage face...
+        for (child, &base) in faces.base_face.iter().enumerate() {
+            assert_eq!(base, (child / 4) as u32);
+        }
+        // ...and each cage face's four children tile its unit square: every
+        // child covers a quarter, together they cover the whole, and every
+        // Ptex corner of the parent appears in exactly one child.
+        for parent in 0..6 {
+            let children = &faces.corner_uvs[parent * 4..parent * 4 + 4];
+            let mut corner_hits = 0;
+            for quad in children {
+                let (mut umin, mut umax) = (f32::MAX, f32::MIN);
+                let (mut vmin, mut vmax) = (f32::MAX, f32::MIN);
+                for [u, v] in quad {
+                    umin = umin.min(*u);
+                    umax = umax.max(*u);
+                    vmin = vmin.min(*v);
+                    vmax = vmax.max(*v);
+                }
+                assert!((umax - umin - 0.5).abs() < 1e-6, "child spans half of u");
+                assert!((vmax - vmin - 0.5).abs() < 1e-6, "child spans half of v");
+                for corner in [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]] {
+                    if quad
+                        .iter()
+                        .any(|c| (c[0] - corner[0]).abs() < 1e-6 && (c[1] - corner[1]).abs() < 1e-6)
+                    {
+                        corner_hits += 1;
+                    }
+                }
+            }
+            assert_eq!(corner_hits, 4, "parent {parent}'s corners split 1:1");
+        }
+    }
+
+    #[test]
+    fn non_quad_base_faces_are_unmappable() {
+        // A quad with one corner cut off: one triangle + one pentagon.
+        let points = vec![
+            Vec3f::from([0.0, 0.0, 0.0]),
+            Vec3f::from([2.0, 0.0, 0.0]),
+            Vec3f::from([2.0, 1.0, 0.0]),
+            Vec3f::from([1.0, 2.0, 0.0]),
+            Vec3f::from([0.0, 2.0, 0.0]),
+            Vec3f::from([2.0, 2.0, 0.0]),
+        ];
+        let counts = vec![5, 3];
+        let indices = vec![0, 1, 2, 3, 4, 2, 5, 3];
+        let req = SubdivRequest {
+            want_face_uvs: true,
+            ..request(1)
+        };
+        let out = subdivide(&points, &counts, &indices, &req).unwrap();
+        let faces = out.faces.unwrap();
+        assert_eq!(faces.base_face.len(), 8, "5 + 3 children");
+        assert!(faces.base_face.iter().all(|&f| f == u32::MAX));
+    }
+
+    #[test]
+    fn smooth_cube_normals_point_along_the_corner_diagonals() {
+        let (points, counts, indices) = cube();
+        let verts: Vec<Vec3A> = points.iter().map(|p| Vec3A::new(p.x, p.y, p.z)).collect();
+        let normals = smooth_normals(&verts, &counts, &indices);
+        for (v, n) in verts.iter().zip(&normals) {
+            let expect = v.normalize();
+            assert!(
+                n.dot(expect) > 0.99,
+                "corner {v:?} normal {n:?} not along its diagonal"
+            );
+        }
+    }
+
+    #[test]
+    fn loop_refines_triangles() {
+        let points = vec![
+            Vec3f::from([0.0, 0.0, 0.0]),
+            Vec3f::from([1.0, 0.0, 0.0]),
+            Vec3f::from([0.0, 1.0, 0.0]),
+            Vec3f::from([1.0, 1.0, 1.0]),
+        ];
+        let counts = vec![3, 3];
+        let indices = vec![0, 1, 2, 1, 3, 2];
+        let req = SubdivRequest {
+            scheme: SubdivScheme::Loop,
+            ..request(1)
+        };
+        let out = subdivide(&points, &counts, &indices, &req).unwrap();
+        assert_eq!(out.counts.len(), 8, "each triangle splits in four");
+        assert!(out.counts.iter().all(|&c| c == 3));
+    }
+}

--- a/crates/crust-core/src/scene/subdiv.rs
+++ b/crates/crust-core/src/scene/subdiv.rs
@@ -662,4 +662,134 @@ mod tests {
         assert_eq!(out.counts.len(), 8, "each triangle splits in four");
         assert!(out.counts.iter().all(|&c| c == 3));
     }
+
+    // -------------------------------------------------------------------
+    // Memory probe
+    // -------------------------------------------------------------------
+
+    /// `System` wrapped in two counters, so the probe below measures
+    /// *requested* bytes — deterministic across platforms and allocators,
+    /// unlike RSS. Registered for the whole `crust_core` test binary (a
+    /// `#[global_allocator]` cannot be scoped tighter), which costs every
+    /// other test two relaxed atomics per allocation and changes nothing
+    /// else.
+    struct CountingAlloc;
+
+    static LIVE: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    static PEAK: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+    unsafe impl std::alloc::GlobalAlloc for CountingAlloc {
+        unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+            use std::sync::atomic::Ordering::Relaxed;
+            let now = LIVE.fetch_add(layout.size(), Relaxed) + layout.size();
+            PEAK.fetch_max(now, Relaxed);
+            unsafe { std::alloc::System.alloc(layout) }
+        }
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
+            LIVE.fetch_sub(layout.size(), std::sync::atomic::Ordering::Relaxed);
+            unsafe { std::alloc::System.dealloc(ptr, layout) }
+        }
+    }
+
+    #[global_allocator]
+    static COUNTING_ALLOC: CountingAlloc = CountingAlloc;
+
+    /// An open N×N quad grid on the z = 0 plane — (N+1)² points, N² quads.
+    fn quad_grid(n: usize) -> (Vec<Vec3f>, Vec<i32>, Vec<i32>) {
+        let mut points = Vec::with_capacity((n + 1) * (n + 1));
+        for j in 0..=n {
+            for i in 0..=n {
+                points.push(Vec3f::from([i as f32, j as f32, 0.0]));
+            }
+        }
+        let mut counts = Vec::with_capacity(n * n);
+        let mut indices = Vec::with_capacity(4 * n * n);
+        for j in 0..n {
+            for i in 0..n {
+                let v0 = (j * (n + 1) + i) as i32;
+                let v1 = v0 + 1;
+                let v2 = v1 + (n + 1) as i32;
+                let v3 = v0 + (n + 1) as i32;
+                counts.push(4);
+                indices.extend_from_slice(&[v0, v1, v2, v3]);
+            }
+        }
+        (points, counts, indices)
+    }
+
+    /// What subdivision costs in memory, measured at the `subdivide()`
+    /// boundary: `transient` is the peak of live requested bytes while it
+    /// runs (dominated by the refiner, which retains every level 0..L —
+    /// a ×4/3 geometric series over the last level — plus the position
+    /// copies at the tail of the function), `resident` is what the returned
+    /// [`SubdividedMesh`] itself holds. The ceilings pin the per-face costs
+    /// so a regression (say, an accidentally retained per-level buffer)
+    /// fails loudly; they sit ~25% above the values measured at the time of
+    /// writing, printed by the table for recalibration.
+    ///
+    /// Ignored because the counters are process-global: run it alone —
+    /// `cargo test -p crust-core --lib subdivision_memory_probe -- --ignored --nocapture --test-threads=1`
+    #[test]
+    #[ignore = "allocation probe; run alone with --ignored --nocapture --test-threads=1"]
+    fn subdivision_memory_probe() {
+        use std::sync::atomic::Ordering::Relaxed;
+
+        const GRID: usize = 64; // 4096 cage quads
+        let (points, counts, indices) = quad_grid(GRID);
+
+        println!(
+            "\n{:>5} {:>4} {:>14} {:>14} {:>10} {:>10}",
+            "level", "uvs", "faces", "transient", "B/face", "resid B/f"
+        );
+        for level in 1..=4u32 {
+            for want_uvs in [false, true] {
+                let req = SubdivRequest {
+                    want_face_uvs: want_uvs,
+                    ..request(level)
+                };
+
+                let before = LIVE.load(Relaxed);
+                PEAK.store(before, Relaxed);
+                let out = subdivide(&points, &counts, &indices, &req).unwrap();
+                let peak = PEAK.load(Relaxed);
+                let after = LIVE.load(Relaxed);
+
+                let n_faces = out.counts.len();
+                let transient = peak - before;
+                let resident = after - before;
+                let per_face = transient as f64 / n_faces as f64;
+                let res_per_face = resident as f64 / n_faces as f64;
+                println!(
+                    "{:>5} {:>4} {:>14} {:>14} {:>10.1} {:>10.1}",
+                    level,
+                    if want_uvs { "yes" } else { "no" },
+                    n_faces,
+                    transient,
+                    per_face,
+                    res_per_face
+                );
+
+                assert_eq!(n_faces, counts.len() * 4usize.pow(level));
+                // Ceilings only bind once the per-cage-face constants have
+                // amortized away; shallow levels are all fixed overhead.
+                if level >= 3 {
+                    // Measured on a 64×64 cage: ~313 B/face without UVs,
+                    // ~556-564 with; resident 48.1 / 84.1. Ceilings ~25%
+                    // above those.
+                    let ceiling = if want_uvs { 700.0 } else { 400.0 };
+                    assert!(
+                        per_face < ceiling,
+                        "transient {per_face:.1} B/face at level {level} \
+                         (uvs: {want_uvs}) exceeds the {ceiling} B/face ceiling"
+                    );
+                    assert!(
+                        res_per_face < 105.0,
+                        "resident {res_per_face:.1} B/face at level {level} \
+                         (uvs: {want_uvs}) exceeds the 105 B/face ceiling"
+                    );
+                }
+                drop(out);
+            }
+        }
+    }
 }

--- a/crates/crust-core/src/scene/usd_import.rs
+++ b/crates/crust-core/src/scene/usd_import.rs
@@ -29,10 +29,12 @@ use crate::tracer::{RenderSettings, SamplingStrategy};
 use crate::volume::{DensityField, VolumeRegion};
 use glam::{Affine3A, Mat3A, Vec3, Vec3A};
 
+use super::subdiv;
 use openusd::gf::{Matrix4d, Vec3f};
 use openusd::schemas::geom::{
-    BasisCurves as UsdBasisCurves, Camera as UsdCamera, Curves as UsdCurves, Mesh as UsdMesh,
-    PointBased, PointInstancer, Sphere as UsdSphere, Xform, Xformable,
+    BasisCurves as UsdBasisCurves, Camera as UsdCamera, Curves as UsdCurves, InterpolateBoundary,
+    Mesh as UsdMesh, PointBased, PointInstancer, Sphere as UsdSphere, SubdivisionScheme, Xform,
+    Xformable,
 };
 use openusd::schemas::lux::{
     CylinderLight, DiskLight, DistantLight as UsdDistantLight, DomeLight, Light as UsdLight,
@@ -758,6 +760,37 @@ fn prim_motion_translate(prim: &Prim) -> Option<Vec3> {
     custom_color3(prim, "crust:motion:translate").map(|v| Vec3::new(v.x, v.y, v.z))
 }
 
+/// Hard cap on `crust:subdivisionLevel` — each level quadruples the face
+/// count, so 6 turns one quad into 4096 and is already past what any of the
+/// checked-in scenes could resolve.
+const MAX_SUBDIV_LEVEL: i32 = 6;
+
+/// `crust:subdivisionLevel` — uniform subdivision-surface refinement depth
+/// (default 0 = render the base cage). Deliberately opt-in per prim rather
+/// than triggered by `subdivisionScheme`: USD's fallback scheme is
+/// `catmullClark`, so honouring the scheme alone would subdivide virtually
+/// every mesh ever authored (all of the Moana island included), and USD has
+/// no standard per-prim refinement level — Hydra treats refinement as a
+/// render setting. The scheme still decides *how* to subdivide once a level
+/// asks for it.
+///
+/// `CRUST_SUBDIV=0` forces 0 everywhere — the A/B switch that separates a
+/// subdivision artifact from a material or lighting one, like
+/// `CRUST_MESH_BAKE`.
+fn subdiv_level(prim: &Prim) -> u32 {
+    if std::env::var("CRUST_SUBDIV").as_deref() == Ok("0") {
+        return 0;
+    }
+    let level = custom_i32(prim, "crust:subdivisionLevel").unwrap_or(0);
+    if level > MAX_SUBDIV_LEVEL {
+        warn!(
+            "Mesh at {}: crust:subdivisionLevel = {level} clamped to {MAX_SUBDIV_LEVEL}",
+            prim.path()
+        );
+    }
+    level.clamp(0, MAX_SUBDIV_LEVEL) as u32
+}
+
 // -----------------------------------------------------------------------
 // Mesh
 // -----------------------------------------------------------------------
@@ -802,6 +835,9 @@ impl MeshKey {
 struct MeshGeom {
     verts: Vec<Vec3A>,
     tris: Vec<[u32; 3]>,
+    /// Smooth shading normals, parallel to `verts` — only subdivided meshes
+    /// carry them.
+    normals: Option<Vec<Vec3A>>,
 }
 
 /// What the importer knows about one distinct mesh (one [`MeshKey`]).
@@ -853,30 +889,37 @@ impl MeshArena {
     /// Interns a mesh by content, returning its slot index. Triangulates on
     /// first sight; `None` if nothing survives triangulation (matching the
     /// old behaviour, which also did not cache a failed mesh).
-    fn intern(
-        &mut self,
-        prim: &Prim,
-        points: &[Vec3f],
-        counts: &[i32],
-        indices: &[i32],
-        material: &Arc<dyn Material>,
-    ) -> Option<u32> {
-        let key = MeshKey::new(points, counts, indices, material);
+    fn intern(&mut self, prim: &Prim, src: &MeshSource, material: &Arc<dyn Material>) -> Option<u32> {
+        let key = MeshKey::new(&src.points, &src.counts, &src.indices, material);
         if let Some(&slot) = self.by_key.get(&key) {
             debug!("Mesh at {} shares geometry with an earlier prim", prim.path());
             return Some(slot);
         }
-        let verts: Vec<Vec3A> = points.iter().map(|p| Vec3A::new(p.x, p.y, p.z)).collect();
+        let verts: Vec<Vec3A> = src
+            .points
+            .iter()
+            .map(|p| Vec3A::new(p.x, p.y, p.z))
+            .collect();
         let want_faces = material.face_texture().is_some();
-        let (tris, faces) =
-            triangulate(counts, indices, verts.len(), want_faces).or_else(|| {
+        let (tris, faces) = triangulate(&src.counts, &src.indices, verts.len(), want_faces)
+            .or_else(|| {
                 debug!("Mesh at {} produced no triangles", prim.path());
                 None
             })?;
-        check_face_count(prim, counts, material.as_ref());
+        // A subdivided face table numbers *refined* faces; rewrite it to the
+        // base-cage ids Ptex actually indexes before anything caches it.
+        let faces = match (&src.subdiv_faces, faces) {
+            (Some(sub), Some(map)) => Some(remap_subdivided_faces(map, sub)),
+            (_, faces) => faces,
+        };
+        check_face_count(prim, src.base_face_count, material.as_ref());
         let slot = self.slots.len() as u32;
         self.slots.push(MeshSlot {
-            local: Some(MeshGeom { verts, tris }),
+            local: Some(MeshGeom {
+                verts,
+                tris,
+                normals: src.normals.clone(),
+            }),
             faces: faces.map(Arc::new),
             committed: None,
             n_place: 0,
@@ -901,7 +944,7 @@ impl MeshArena {
         b.attach(Geometry::TriangleMesh {
             vertices: geom.verts,
             indices: geom.tris,
-            normals: None,
+            normals: geom.normals,
         });
         let scene = Arc::new(b.commit());
         s.committed = Some(Arc::clone(&scene));
@@ -918,7 +961,8 @@ fn emit_mesh(
     meshes: &mut MeshArena,
     pending: &mut Vec<MeshPlacement>,
 ) {
-    let Some((points, counts, indices)) = mesh_arrays(mesh) else {
+    let want_faces = material.face_texture().is_some();
+    let Some(src) = mesh_source(prim, mesh, want_faces) else {
         debug!(
             "Mesh at {} missing points / faceVertexCounts / faceVertexIndices — skipped",
             prim.path()
@@ -942,22 +986,33 @@ fn emit_mesh(
                 prim.path()
             );
         }
-        let verts: Vec<Vec3A> = points
+        let verts: Vec<Vec3A> = src
+            .points
             .iter()
             .map(|p| {
                 let v = world_xf.transform_point3(Vec3::new(p.x, p.y, p.z));
                 Vec3A::new(v.x, v.y, v.z)
             })
             .collect();
-        let want_faces = material.face_texture().is_some();
-        check_face_count(prim, &counts, material.as_ref());
-        match triangulate(&counts, &indices, verts.len(), want_faces) {
+        check_face_count(prim, src.base_face_count, material.as_ref());
+        match triangulate(&src.counts, &src.indices, verts.len(), want_faces) {
             Some((tris, faces)) => {
+                // A singular transform has no inverse-transpose to push the
+                // prototype's normals through, but the smooth normals of the
+                // *transformed* mesh are still well-defined — recompute them.
+                let normals = src
+                    .normals
+                    .is_some()
+                    .then(|| subdiv::smooth_normals(&verts, &src.counts, &src.indices));
+                let faces = match (&src.subdiv_faces, faces) {
+                    (Some(sub), Some(map)) => Some(remap_subdivided_faces(map, sub)),
+                    (_, faces) => faces,
+                };
                 let geom_id = world.attach_masked(
                     Geometry::TriangleMesh {
                         vertices: verts,
                         indices: tris,
-                        normals: None,
+                        normals,
                     },
                     material,
                     mask,
@@ -979,7 +1034,7 @@ fn emit_mesh(
     // depends on how many times it is placed in total, which is not known
     // until the whole stage has been walked — so claim the `geom_id` now (it
     // must keep its traversal order) and decide in `flush_meshes`.
-    let Some(slot) = meshes.intern(prim, &points, &counts, &indices, &material) else {
+    let Some(slot) = meshes.intern(prim, &src, &material) else {
         return;
     };
     meshes.slots[slot as usize].n_place += 1;
@@ -1048,7 +1103,7 @@ fn flush_meshes(world: &mut WorldBuilder, meshes: &mut MeshArena, pending: Vec<M
                 Geometry::TriangleMesh {
                     vertices: bake_verts(&geom.verts, &p.l2w),
                     indices: bake_indices(geom.tris, &p.l2w),
-                    normals: None,
+                    normals: geom.normals.map(|ns| bake_normals(&ns, &p.l2w)),
                 },
             );
             // `bake_indices` swaps a triangle's second and third vertices for a
@@ -1093,6 +1148,15 @@ fn bake_verts(verts: &[Vec3A], l2w: &Affine3A) -> Vec<Vec3A> {
     verts.iter().map(|v| l2w.transform_point3a(*v)).collect()
 }
 
+/// Local-space shading normals into world space: the inverse transpose —
+/// exactly the matrix the kernel's instance path applies (`normal_mat` in
+/// `crust-rt`), so a baked placement shades identically to an instanced one,
+/// mirrors included.
+fn bake_normals(normals: &[Vec3A], l2w: &Affine3A) -> Vec<Vec3A> {
+    let m = l2w.matrix3.inverse().transpose();
+    normals.iter().map(|n| (m * *n).normalize()).collect()
+}
+
 /// Triangle winding for baked geometry, flipped under a mirroring transform.
 ///
 /// The instanced path derives its geometric normal inside the prototype and
@@ -1131,22 +1195,199 @@ fn mesh_arrays(mesh: &UsdMesh) -> Option<(Vec<Vec3f>, Vec<i32>, Vec<i32>)> {
     Some((points, counts, indices))
 }
 
+/// One mesh's geometry as the rest of the importer consumes it — either the
+/// authored cage verbatim, or its subdivision-surface refinement when the
+/// prim opts in (see [`subdiv_level`]). Refinement happens *here*, before
+/// interning, so every downstream path — direct bake, deferred
+/// instance-vs-bake, prototypes — sees it exactly once, and [`MeshKey`]
+/// dedupes on the refined arrays (two prims sharing a cage at different
+/// levels hash differently, at the same level they still share).
+struct MeshSource {
+    points: Vec<Vec3f>,
+    counts: Vec<i32>,
+    indices: Vec<i32>,
+    /// Smooth shading normals — `Some` iff subdivided (a cage renders
+    /// faceted, exactly as before).
+    normals: Option<Vec<Vec3A>>,
+    /// Refined-face → base-cage-face mapping, `Some` iff subdivided and the
+    /// material wants a face table.
+    subdiv_faces: Option<subdiv::SubdivFaces>,
+    /// The *authored* cage's face count — what Ptex face ids index, whether
+    /// or not the mesh was refined.
+    base_face_count: usize,
+}
+
+/// Reads a mesh prim's arrays and applies subdivision when requested.
+/// `None` when the required attributes are missing (matching
+/// [`mesh_arrays`]); any subdivision problem warns and degrades to the cage.
+fn mesh_source(prim: &Prim, mesh: &UsdMesh, want_faces: bool) -> Option<MeshSource> {
+    let (points, counts, indices) = mesh_arrays(mesh)?;
+    let base_face_count = counts.len();
+    let cage = |points, counts, indices| MeshSource {
+        points,
+        counts,
+        indices,
+        normals: None,
+        subdiv_faces: None,
+        base_face_count,
+    };
+
+    let level = subdiv_level(prim);
+    if level == 0 {
+        return Some(cage(points, counts, indices));
+    }
+
+    let usd_scheme = mesh
+        .subdivision_scheme_attr()
+        .get::<SubdivisionScheme>()
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    let scheme = match usd_scheme {
+        SubdivisionScheme::CatmullClark => subdiv::SubdivScheme::CatmullClark,
+        SubdivisionScheme::Bilinear => subdiv::SubdivScheme::Bilinear,
+        SubdivisionScheme::Loop => {
+            if counts.iter().any(|&c| c != 3) {
+                warn!(
+                    "Mesh at {}: subdivisionScheme = loop needs an all-triangle \
+                     mesh — rendering the base cage",
+                    prim.path()
+                );
+                return Some(cage(points, counts, indices));
+            }
+            subdiv::SubdivScheme::Loop
+        }
+        SubdivisionScheme::None => {
+            warn!(
+                "Mesh at {}: crust:subdivisionLevel = {level} ignored \
+                 (subdivisionScheme = none)",
+                prim.path()
+            );
+            return Some(cage(points, counts, indices));
+        }
+    };
+
+    let boundary = match mesh
+        .interpolate_boundary_attr()
+        .get::<InterpolateBoundary>()
+        .ok()
+        .flatten()
+        .unwrap_or_default()
+    {
+        InterpolateBoundary::None => opensubdiv_rs::sdc::VtxBoundaryInterpolation::None,
+        InterpolateBoundary::EdgeOnly => opensubdiv_rs::sdc::VtxBoundaryInterpolation::EdgeOnly,
+        InterpolateBoundary::EdgeAndCorner => {
+            opensubdiv_rs::sdc::VtxBoundaryInterpolation::EdgeAndCorner
+        }
+    };
+
+    let int_array = |attr: openusd::usd::Attribute| match attr.get::<sdf::Value>().ok().flatten() {
+        Some(sdf::Value::IntVec(v)) => v,
+        _ => Vec::new(),
+    };
+    let float_array =
+        |attr: openusd::usd::Attribute| match attr.get::<sdf::Value>().ok().flatten() {
+            Some(sdf::Value::FloatVec(v)) => v,
+            _ => Vec::new(),
+        };
+    let crease_indices = int_array(mesh.crease_indices_attr());
+    let crease_lengths = int_array(mesh.crease_lengths_attr());
+    let crease_sharpnesses = float_array(mesh.crease_sharpnesses_attr());
+    let corner_indices = int_array(mesh.corner_indices_attr());
+    let corner_sharpnesses = float_array(mesh.corner_sharpnesses_attr());
+
+    let req = subdiv::SubdivRequest {
+        scheme,
+        level,
+        boundary,
+        crease_indices: &crease_indices,
+        crease_lengths: &crease_lengths,
+        crease_sharpnesses: &crease_sharpnesses,
+        corner_indices: &corner_indices,
+        corner_sharpnesses: &corner_sharpnesses,
+        want_face_uvs: want_faces,
+    };
+    match subdiv::subdivide(&points, &counts, &indices, &req) {
+        Ok(refined) => {
+            debug!(
+                "Mesh at {}: subdivided to level {level} ({} -> {} faces)",
+                prim.path(),
+                base_face_count,
+                refined.counts.len()
+            );
+            Some(MeshSource {
+                points: refined.points,
+                counts: refined.counts,
+                indices: refined.indices,
+                normals: Some(refined.normals),
+                subdiv_faces: refined.faces,
+                base_face_count,
+            })
+        }
+        Err(e) => {
+            warn!(
+                "Mesh at {}: subdivision failed ({e}) — rendering the base cage",
+                prim.path()
+            );
+            Some(cage(points, counts, indices))
+        }
+    }
+}
+
+/// Rewrites a [`FaceMap`] built by triangulating *refined* quads — whose
+/// `faces` therefore number refined faces — into base-cage face ids plus
+/// explicit sub-face UVs. The fan of a refined quad is `k=1 -> (v0,v1,v2)`
+/// (`QuadLower`) and `k=2 -> (v0,v2,v3)` (`QuadUpper`), so each triangle
+/// takes the matching three of its face's four corner UVs.
+fn remap_subdivided_faces(map: FaceMap, sub: &subdiv::SubdivFaces) -> FaceMap {
+    let n = map.faces.len();
+    let mut faces = Vec::with_capacity(n);
+    let mut slices = Vec::with_capacity(n);
+    let mut uvs = Vec::with_capacity(n);
+    for (&refined, &slice) in map.faces.iter().zip(&map.slices) {
+        let base = sub.base_face[refined as usize];
+        if base == u32::MAX {
+            faces.push(u32::MAX);
+            slices.push(FanSlice::Unmappable);
+            uvs.push([[0.0f32; 2]; 3]);
+            continue;
+        }
+        let [c0, c1, c2, c3] = sub.corner_uvs[refined as usize];
+        faces.push(base);
+        slices.push(slice);
+        uvs.push(match slice {
+            FanSlice::QuadUpper => [c0, c2, c3],
+            // Refined faces are always quads, so anything else is the lower
+            // half. (Loop never builds a face table.)
+            _ => [c0, c1, c2],
+        });
+    }
+    FaceMap {
+        faces,
+        slices,
+        uvs: Some(uvs),
+    }
+}
+
 /// Warns when a per-face texture's face count disagrees with the mesh's.
 ///
 /// A Ptex face id *is* a mesh face index, so the two counts must match
 /// exactly. When they do not, the texture belongs to different geometry and
 /// every lookup is quietly wrong — the render still completes, and still looks
 /// like a plausible rock, which is precisely what makes it worth a warning.
-fn check_face_count(prim: &Prim, counts: &[i32], material: &dyn Material) {
+/// `n_base_faces` is the *authored cage's* face count
+/// ([`MeshSource::base_face_count`]) — never the refined count: subdivision
+/// changes the mesh's face count but Ptex ids keep indexing the cage.
+fn check_face_count(prim: &Prim, n_base_faces: usize, material: &dyn Material) {
     let Some(tex) = material.face_texture() else {
         return;
     };
-    if tex.num_faces() != counts.len() {
+    if tex.num_faces() != n_base_faces {
         warn!(
             "Mesh at {} has {} faces but its per-face texture has {} — \
              the texture does not match this geometry, so shading will be wrong",
             prim.path(),
-            counts.len(),
+            n_base_faces,
             tex.num_faces()
         );
     }
@@ -1209,7 +1450,11 @@ fn triangulate(
     }
     // `then_some` rather than `then`: the value is two already-built vectors
     // being moved, so there is no work for a closure to defer.
-    let map = want_faces.then_some(FaceMap { faces, slices });
+    let map = want_faces.then_some(FaceMap {
+        faces,
+        slices,
+        uvs: None,
+    });
     Some((tris, map))
 }
 
@@ -1448,11 +1693,8 @@ fn collect_proto_parts(
             // always needs a real kernel scene — committing here is also what
             // marks the slot as ineligible for baking, so a mesh used both
             // directly and as a prototype is not stored twice.
-            if let Some((points, counts, indices)) = mesh_arrays(&mesh)
-                && let Some(slot) =
-                    caches
-                        .meshes
-                        .intern(&prim, &points, &counts, &indices, &material)
+            if let Some(src) = mesh_source(&prim, &mesh, material.face_texture().is_some())
+                && let Some(slot) = caches.meshes.intern(&prim, &src, &material)
             {
                 let faces = caches.meshes.slots[slot as usize].faces.clone();
                 parts.push(ProtoPart {
@@ -3208,6 +3450,7 @@ mod bake_tests {
                 Vec3A::new(-1.0, 1.0, 0.0),
             ],
             tris: vec![[0, 1, 2], [0, 2, 3]],
+            normals: None,
         }
     }
 
@@ -3288,6 +3531,71 @@ mod bake_tests {
         assert!(baked.2 > 0.0, "the ray-facing normal points back up +z");
     }
 
+    /// Shading normals through the same two placements: `bake_normals` must
+    /// be the exact matrix the kernel's instance path applies (the inverse
+    /// transpose), or a mesh shades differently depending on whether the
+    /// importer happened to bake or instance it — including under a mirror,
+    /// where a plain rotation of the normal would come out backwards.
+    #[test]
+    fn baked_shading_normals_match_the_instanced_path() {
+        // Tilted shading normals, deliberately not the geometric one.
+        let tilt = Vec3A::new(0.3, -0.2, 1.0).normalize();
+        let normals = vec![tilt; 4];
+        let geom = quad();
+        let mat = || -> Arc<dyn Material> { Arc::new(OpenPBR::diffuse(Vec3A::splat(0.5))) };
+        let ray = crate::ray::Ray::new(Vec3A::new(0.0, 0.0, 5.0), Vec3A::new(0.0, 0.0, -1.0));
+        let probe = |w: &crate::rt_world::World| {
+            let h = w.intersect(&ray, 1e-4, f32::MAX).expect("the quad is hit");
+            (h.rec.front_face, h.rec.normal)
+        };
+
+        for l2w in [
+            Affine3A::from_scale_rotation_translation(
+                glam::Vec3::new(2.0, 1.5, 1.0),
+                glam::Quat::from_rotation_z(0.7),
+                glam::Vec3::new(0.3, -0.2, 0.0),
+            ),
+            // The mirror is the case that breaks naive normal transforms.
+            Affine3A::from_scale(glam::Vec3::new(-1.0, 1.0, 1.0)),
+        ] {
+            let mut baked = WorldBuilder::new();
+            baked.attach(
+                Geometry::TriangleMesh {
+                    vertices: bake_verts(&geom.verts, &l2w),
+                    indices: bake_indices(geom.tris.clone(), &l2w),
+                    normals: Some(bake_normals(&normals, &l2w)),
+                },
+                mat(),
+            );
+            let baked = baked.commit();
+
+            let mut inner = RtSceneBuilder::new();
+            inner.attach(Geometry::TriangleMesh {
+                vertices: geom.verts.clone(),
+                indices: geom.tris.clone(),
+                normals: Some(normals.clone()),
+            });
+            let mut inst = WorldBuilder::new();
+            inst.attach(
+                Geometry::Instance {
+                    scene: Arc::new(inner.commit()),
+                    transform: l2w,
+                    transform_end: None,
+                },
+                mat(),
+            );
+            let inst = inst.commit();
+
+            let (b_front, b_n) = probe(&baked);
+            let (i_front, i_n) = probe(&inst);
+            assert_eq!(b_front, i_front, "front_face split under {l2w:?}");
+            assert!(
+                b_n.abs_diff_eq(i_n, 1e-6),
+                "normals split under {l2w:?}: baked {b_n:?} vs instanced {i_n:?}"
+            );
+        }
+    }
+
     /// Without the swap the test above would pass for the wrong reason if
     /// `bake_indices` were a no-op and the kernel happened to agree, so pin
     /// the swap itself.
@@ -3350,6 +3658,86 @@ mod curve_basis_tests {
 #[cfg(test)]
 mod face_table_tests {
     use super::*;
+
+    /// The remap end to end: subdivide one textured quad, triangulate the
+    /// refinement, remap — every triangle must resolve into the *base* face,
+    /// and the refined corners must land on their sub-rectangle of it.
+    #[test]
+    fn subdivided_face_table_resolves_into_the_base_face() {
+        let points = vec![
+            Vec3f::from([0.0, 0.0, 0.0]),
+            Vec3f::from([1.0, 0.0, 0.0]),
+            Vec3f::from([1.0, 1.0, 0.0]),
+            Vec3f::from([0.0, 1.0, 0.0]),
+        ];
+        let counts = [4];
+        let indices = [0, 1, 2, 3];
+        let req = subdiv::SubdivRequest {
+            scheme: subdiv::SubdivScheme::CatmullClark,
+            level: 1,
+            boundary: opensubdiv_rs::sdc::VtxBoundaryInterpolation::EdgeAndCorner,
+            crease_indices: &[],
+            crease_lengths: &[],
+            crease_sharpnesses: &[],
+            corner_indices: &[],
+            corner_sharpnesses: &[],
+            want_face_uvs: true,
+        };
+        let refined = subdiv::subdivide(&points, &counts, &indices, &req).unwrap();
+        let sub = refined.faces.as_ref().unwrap();
+        let (tris, map) =
+            triangulate(&refined.counts, &refined.indices, refined.points.len(), true).unwrap();
+        let map = remap_subdivided_faces(map.unwrap(), sub);
+
+        assert_eq!(tris.len(), 8, "4 child quads, 2 triangles each");
+        let uvs = map.uvs.as_ref().expect("subdivided tables carry UVs");
+        assert_eq!(map.faces.len(), tris.len());
+        assert_eq!(uvs.len(), tris.len());
+        assert!(map.faces.iter().all(|&f| f == 0), "one base face only");
+
+        // Each triangle's interior resolves inside its child's quadrant of
+        // the base face — quadrants are half-open squares of side 0.5.
+        for (i, tri_uvs) in uvs.iter().enumerate() {
+            let (got_face, u, v) = map
+                .resolve(i as u32, 1.0 / 3.0, 1.0 / 3.0, false)
+                .expect("every child of a quad resolves");
+            assert_eq!(got_face, 0);
+            let centroid_u = tri_uvs.iter().map(|c| c[0]).sum::<f32>() / 3.0;
+            let centroid_v = tri_uvs.iter().map(|c| c[1]).sum::<f32>() / 3.0;
+            assert!((u - centroid_u).abs() < 1e-6);
+            assert!((v - centroid_v).abs() < 1e-6);
+            assert!((0.0..=1.0).contains(&u) && (0.0..=1.0).contains(&v));
+        }
+
+        // The whole refinement still covers the base face: some corner of
+        // some triangle touches each of the four Ptex corners.
+        for corner in [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]] {
+            assert!(
+                uvs.iter().flatten().any(|c| (c[0] - corner[0]).abs() < 1e-6
+                    && (c[1] - corner[1]).abs() < 1e-6),
+                "no triangle corner reaches base corner {corner:?}"
+            );
+        }
+    }
+
+    /// Children of a non-quad cage face must decline the lookup — same
+    /// contract as an unsubdivided n-gon.
+    #[test]
+    fn subdivided_ngon_descendants_are_unmappable() {
+        let map = FaceMap {
+            faces: vec![0, 1],
+            slices: vec![FanSlice::QuadLower, FanSlice::QuadUpper],
+            uvs: None,
+        };
+        let sub = subdiv::SubdivFaces {
+            base_face: vec![u32::MAX, u32::MAX],
+            corner_uvs: vec![[[0.0; 2]; 4]; 2],
+        };
+        let map = remap_subdivided_faces(map, &sub);
+        assert!(map.slices.iter().all(|&s| s == FanSlice::Unmappable));
+        assert_eq!(map.resolve(0, 0.2, 0.2, false), None);
+        assert_eq!(map.resolve(1, 0.2, 0.2, false), None);
+    }
 
     /// The triangle list and the face table must stay index-parallel, because
     /// the kernel's `prim_id` indexes one to look up the other.

--- a/crates/crust-core/tests/usd_scene.rs
+++ b/crates/crust-core/tests/usd_scene.rs
@@ -1043,3 +1043,134 @@ def Xform "World"
 
     std::fs::remove_dir_all(&dir).ok();
 }
+
+/// `samples/subdivision.usda`: five identical cube cages, four at
+/// `crust:subdivisionLevel` 0–3 and one fully edge-creased at level 3.
+/// Probed with rays rather than counts — the *shape* is what subdivision
+/// changes: the limit surface sags strictly inside the cage and rounds its
+/// corners away, while infinite creases pin the cage exactly.
+#[test]
+fn loads_subdivision_usda() {
+    let scene =
+        Scene::from_usd(&sample("subdivision.usda")).expect("failed to open subdivision.usda");
+
+    // 5 cubes + floor + rect-light mesh.
+    assert_eq!(
+        scene.world.count(),
+        7,
+        "expected 7 geometries (5 cubes, floor, rect-light mesh), got {}",
+        scene.world.count()
+    );
+
+    // Cube centers sit at x = -6 (L0), -3 (L1), 0 (L2), 3 (L3), 6 (creased),
+    // all spanning y in [0, 2]. Rays fire straight down from y = 8; the
+    // floor at y = 0 answers t = 8 for anything the cube no longer covers.
+    let down = -crust_core::Vec3A::Y;
+    let probe = |x: f32, z: f32| {
+        let ray = crust_core::Ray::new(crust_core::Vec3A::new(x, 8.0, z), down);
+        scene
+            .world
+            .intersect(&ray, 0.001, f32::INFINITY)
+            .unwrap_or_else(|| panic!("the floor backs every probe (x={x}, z={z})"))
+            .rec
+            .t
+    };
+
+    // Down the centers: the cage tops out at y = 2 (t = 6); every subdivided
+    // top sags strictly below it, deeper than any float slop; the creased
+    // limit surface *is* the cage.
+    let t_l0 = probe(-6.0, 0.0);
+    let t_l3 = probe(3.0, 0.0);
+    let t_creased = probe(6.0, 0.0);
+    assert!((t_l0 - 6.0).abs() < 1e-3, "L0 cage top at t={t_l0}");
+    assert!(
+        t_l3 > t_l0 + 0.1,
+        "the level-3 limit surface must sag below the cage (t={t_l3})"
+    );
+    assert!(
+        (t_creased - 6.0).abs() < 1e-3,
+        "infinite creases keep the cage top (t={t_creased})"
+    );
+
+    // Near a top corner: the cage still stands at y = 2 there, the rounded
+    // level-3 surface has pulled away entirely (the ray falls through to the
+    // floor), and the creased cube again keeps its corner.
+    let (dx, dz) = (0.95, 0.95);
+    let c_l0 = probe(-6.0 + dx, dz);
+    let c_l3 = probe(3.0 + dx, dz);
+    let c_creased = probe(6.0 + dx, dz);
+    assert!((c_l0 - 6.0).abs() < 1e-3, "L0 corner at t={c_l0}");
+    assert!(
+        (c_l3 - 8.0).abs() < 1e-3,
+        "the rounded corner must miss to the floor (t={c_l3})"
+    );
+    assert!(
+        (c_creased - 6.0).abs() < 1e-3,
+        "the creased corner stays sharp (t={c_creased})"
+    );
+
+    // Subdivided geometry carries smooth shading normals: on the level-3
+    // dome the ray-facing normal at an off-center point tilts away from
+    // straight up, which a faceted cage top could never report; the level-0
+    // cage top reports exactly +Y.
+    let normal_at = |x: f32, z: f32| {
+        let ray = crust_core::Ray::new(crust_core::Vec3A::new(x, 8.0, z), down);
+        scene
+            .world
+            .intersect(&ray, 0.001, f32::INFINITY)
+            .expect("probe hits")
+            .rec
+            .normal
+    };
+    let n_l0 = normal_at(-6.0 + 0.5, 0.5);
+    assert!(
+        (n_l0.y - 1.0).abs() < 1e-5,
+        "the cage top is flat, normal {n_l0:?}"
+    );
+    let n_l3 = normal_at(3.0 + 0.5, 0.5);
+    assert!(
+        n_l3.y < 0.999 && n_l3.x > 1e-3 && n_l3.z > 1e-3,
+        "the dome's smooth normal must tilt outward, got {n_l3:?}"
+    );
+}
+
+/// `subdivisionScheme = none` refuses refinement no matter what level is
+/// asked for — warn-and-ignore, so the cage renders unchanged.
+#[test]
+fn subdivision_scheme_none_keeps_the_cage() {
+    let dir = std::env::temp_dir().join("crust_subdiv_none_probe");
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let path = dir.join("subdiv_none.usda");
+    std::fs::write(
+        &path,
+        r#"#usda 1.0
+(defaultPrim = "W")
+def Xform "W" {
+    def Mesh "Cube" {
+        int crust:subdivisionLevel = 2
+        uniform token subdivisionScheme = "none"
+        point3f[] points = [(-1, -1, 1), (1, -1, 1), (1, 1, 1), (-1, 1, 1),
+                            (-1, -1, -1), (1, -1, -1), (1, 1, -1), (-1, 1, -1)]
+        int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+        int[] faceVertexIndices = [0, 1, 2, 3, 5, 4, 7, 6, 4, 0, 3, 7,
+                                   1, 5, 6, 2, 3, 2, 6, 7, 4, 5, 1, 0]
+    }
+}
+"#,
+    )
+    .expect("write probe stage");
+    let scene = Scene::from_usd(&path).expect("stage must load");
+    // The cage's corner must still be there: a down ray just inside (1,1)
+    // hits the flat top at y = 1 exactly.
+    let ray = crust_core::Ray::new(crust_core::Vec3A::new(0.95, 8.0, 0.95), -crust_core::Vec3A::Y);
+    let hit = scene
+        .world
+        .intersect(&ray, 0.001, f32::INFINITY)
+        .expect("the unsubdivided cage corner still stands");
+    assert!(
+        (hit.rec.t - 7.0).abs() < 1e-3,
+        "cage top expected at t=7, got {}",
+        hit.rec.t
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/docs/embree_comparison.md
+++ b/docs/embree_comparison.md
@@ -139,7 +139,7 @@ when this document was first written; see the addendum in §4.)*
 | Language / safety | C++ (+ ISPC, SYCL), unsafe by nature | 100 % safe Rust |
 | Triangles | ✅ watertight | ✅⁺ watertight (Woop 2013, f64 tie fallback) |
 | Spheres / points | ✅ spheres + 2 disc types | ✅ analytic sphere (also a `LightShape`) |
-| Quads / grids / subdivision | ✅ | ❌ (USD import triangulates) |
+| Quads / grids / subdivision | ✅ | ✅-ish (opt-in uniform Catmull-Clark/Bilinear/Loop at USD import via pure-Rust opensubdiv-rs — limit snap, creases, corners, boundary rules; kernel still traces triangles; no feature-adaptive, no holes) |
 | Curves / hair | ✅ 5 bases × 3 modes | ✅⁺ round linear segments; cubic bezier/bspline/catmullRom flattened |
 | User geometry | ✅ callbacks | ✅-ish (`Hittable` trait — same idea, idiomatic Rust) |
 | Instancing | ✅ multi-level + arrays | ✅ multi-level `Instance` (nests to any depth), shared local-space BLAS with content dedup; no instance *arrays* |

--- a/samples/subdivision.usda
+++ b/samples/subdivision.usda
@@ -1,0 +1,216 @@
+#usda 1.0
+(
+    doc = """Subdivision-surface showcase: five identical cube cages in a row.
+
+    The first four author crust:subdivisionLevel = 0/1/2/3 — the cage, then
+    progressively smoother Catmull-Clark limit surfaces (level 3 is nearly a
+    sphere). The fifth subdivides at level 3 too, but creases all twelve cage
+    edges at sharpness 10, so its limit surface *is* the cube: creases carry
+    through refinement. Subdivided meshes shade with smooth per-vertex
+    normals; the level-0 cage stays faceted.
+
+    A/B: render with CRUST_SUBDIV=0 to force every level to 0 — five
+    identical sharp cubes."""
+    defaultPrim = "World"
+    upAxis = "Y"
+)
+
+def Xform "World"
+{
+    def Camera "Cam"
+    {
+        float focalLength = 18
+        float horizontalAperture = 20.955
+        double3 xformOp:translate = (0, 3.5, 14)
+        float xformOp:rotateX = -10
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateX"]
+    }
+
+    def Scope "Materials"
+    {
+        def Material "blue"
+        {
+            token outputs:surface.connect = </World/Materials/blue/Surface.outputs:surface>
+            def Shader "Surface"
+            {
+                uniform token info:id = "crust:openpbr"
+                color3f inputs:baseColor = (0.25, 0.45, 0.8)
+                token outputs:surface
+            }
+        }
+
+        def Material "teal"
+        {
+            token outputs:surface.connect = </World/Materials/teal/Surface.outputs:surface>
+            def Shader "Surface"
+            {
+                uniform token info:id = "crust:openpbr"
+                color3f inputs:baseColor = (0.2, 0.65, 0.6)
+                token outputs:surface
+            }
+        }
+
+        def Material "green"
+        {
+            token outputs:surface.connect = </World/Materials/green/Surface.outputs:surface>
+            def Shader "Surface"
+            {
+                uniform token info:id = "crust:openpbr"
+                color3f inputs:baseColor = (0.45, 0.7, 0.25)
+                token outputs:surface
+            }
+        }
+
+        def Material "amber"
+        {
+            token outputs:surface.connect = </World/Materials/amber/Surface.outputs:surface>
+            def Shader "Surface"
+            {
+                uniform token info:id = "crust:openpbr"
+                color3f inputs:baseColor = (0.85, 0.6, 0.2)
+                token outputs:surface
+            }
+        }
+
+        def Material "red"
+        {
+            token outputs:surface.connect = </World/Materials/red/Surface.outputs:surface>
+            def Shader "Surface"
+            {
+                uniform token info:id = "crust:openpbr"
+                color3f inputs:baseColor = (0.8, 0.25, 0.2)
+                token outputs:surface
+            }
+        }
+    }
+
+    # The five cages are identical ±1 cubes; only the subdivision request
+    # differs. Class-less duplication keeps the file trivially greppable.
+    def Mesh "CubeL0" (prepend apiSchemas = ["MaterialBindingAPI"])
+    {
+        # Level 0 is the default — authored anyway to document the knob.
+        int crust:subdivisionLevel = 0
+        point3f[] points = [(-1, -1, 1), (1, -1, 1), (1, 1, 1), (-1, 1, 1),
+                            (-1, -1, -1), (1, -1, -1), (1, 1, -1), (-1, 1, -1)]
+        int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+        int[] faceVertexIndices = [0, 1, 2, 3,
+                                   5, 4, 7, 6,
+                                   4, 0, 3, 7,
+                                   1, 5, 6, 2,
+                                   3, 2, 6, 7,
+                                   4, 5, 1, 0]
+        rel material:binding = </World/Materials/blue>
+        double3 xformOp:translate = (-6, 1, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def Mesh "CubeL1" (prepend apiSchemas = ["MaterialBindingAPI"])
+    {
+        int crust:subdivisionLevel = 1
+        point3f[] points = [(-1, -1, 1), (1, -1, 1), (1, 1, 1), (-1, 1, 1),
+                            (-1, -1, -1), (1, -1, -1), (1, 1, -1), (-1, 1, -1)]
+        int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+        int[] faceVertexIndices = [0, 1, 2, 3,
+                                   5, 4, 7, 6,
+                                   4, 0, 3, 7,
+                                   1, 5, 6, 2,
+                                   3, 2, 6, 7,
+                                   4, 5, 1, 0]
+        rel material:binding = </World/Materials/teal>
+        double3 xformOp:translate = (-3, 1, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def Mesh "CubeL2" (prepend apiSchemas = ["MaterialBindingAPI"])
+    {
+        int crust:subdivisionLevel = 2
+        point3f[] points = [(-1, -1, 1), (1, -1, 1), (1, 1, 1), (-1, 1, 1),
+                            (-1, -1, -1), (1, -1, -1), (1, 1, -1), (-1, 1, -1)]
+        int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+        int[] faceVertexIndices = [0, 1, 2, 3,
+                                   5, 4, 7, 6,
+                                   4, 0, 3, 7,
+                                   1, 5, 6, 2,
+                                   3, 2, 6, 7,
+                                   4, 5, 1, 0]
+        rel material:binding = </World/Materials/green>
+        double3 xformOp:translate = (0, 1, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def Mesh "CubeL3" (prepend apiSchemas = ["MaterialBindingAPI"])
+    {
+        int crust:subdivisionLevel = 3
+        uniform token subdivisionScheme = "catmullClark"
+        point3f[] points = [(-1, -1, 1), (1, -1, 1), (1, 1, 1), (-1, 1, 1),
+                            (-1, -1, -1), (1, -1, -1), (1, 1, -1), (-1, 1, -1)]
+        int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+        int[] faceVertexIndices = [0, 1, 2, 3,
+                                   5, 4, 7, 6,
+                                   4, 0, 3, 7,
+                                   1, 5, 6, 2,
+                                   3, 2, 6, 7,
+                                   4, 5, 1, 0]
+        rel material:binding = </World/Materials/amber>
+        double3 xformOp:translate = (3, 1, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    # Same refinement as CubeL3, but all 12 cage edges creased at USD's
+    # maximum sharpness (10 = infinitely sharp): the limit surface is the
+    # cage itself, so this renders as an exact cube beside its rounded twin.
+    def Mesh "CubeCreased" (prepend apiSchemas = ["MaterialBindingAPI"])
+    {
+        int crust:subdivisionLevel = 3
+        uniform token subdivisionScheme = "catmullClark"
+        point3f[] points = [(-1, -1, 1), (1, -1, 1), (1, 1, 1), (-1, 1, 1),
+                            (-1, -1, -1), (1, -1, -1), (1, 1, -1), (-1, 1, -1)]
+        int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+        int[] faceVertexIndices = [0, 1, 2, 3,
+                                   5, 4, 7, 6,
+                                   4, 0, 3, 7,
+                                   1, 5, 6, 2,
+                                   3, 2, 6, 7,
+                                   4, 5, 1, 0]
+        int[] creaseIndices = [0, 1, 1, 2, 2, 3, 3, 0,
+                               4, 5, 5, 6, 6, 7, 7, 4,
+                               0, 4, 1, 5, 2, 6, 3, 7]
+        int[] creaseLengths = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
+        float[] creaseSharpnesses = [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]
+        rel material:binding = </World/Materials/red>
+        double3 xformOp:translate = (6, 1, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def Mesh "Floor"
+    {
+        int[] faceVertexCounts = [4]
+        int[] faceVertexIndices = [0, 1, 2, 3]
+        point3f[] points = [(-14, 0, -10), (14, 0, -10), (14, 0, 10), (-14, 0, 10)]
+    }
+
+    # Wide rect light above and in front of the row, tilted down at it.
+    def RectLight "KeyLight"
+    {
+        float inputs:width = 10
+        float inputs:height = 4
+        color3f inputs:color = (5, 5, 5)
+        float inputs:intensity = 1.0
+        double3 xformOp:translate = (0, 8, 7)
+        float xformOp:rotateX = -50
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateX"]
+    }
+}
+
+def Scope "Render"
+{
+    def RenderSettings "settings"
+    {
+        int2 resolution = (320, 180)
+        int crust:samplesPerPixel = 64
+        int crust:maxDepth = 4
+        int crust:minSamplesPerPixel = 16
+        float crust:varianceThreshold = 0.05
+        int crust:frame = 0
+    }
+}

--- a/scripts/gen_subdiv_stress.py
+++ b/scripts/gen_subdiv_stress.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Generate a subdivision-heavy stress scene for memory measurement.
+
+The checked-in samples/subdivision.usda is far too small to move RSS, so
+this emits quad cages big enough that the refiner's transient and the
+refined mesh's resident cost stand well clear of page-granularity noise:
+
+  - one GRID x GRID quad-grid cage authoring crust:subdivisionLevel = LEVEL
+    (defaults: 128^2 = 16 384 cage quads, level 3 -> 1 048 576 refined quads
+    -> 2 097 152 triangles), placed once so it takes the bake path;
+  - two placements of an identical smaller cage (same points/topology/
+    material, so the importer interns them to one slot) at the same LEVEL,
+    exercising the committed-prototype/instance path;
+  - a floor, a RectLight, a camera, and a tiny RenderSettings (memory, not
+    render time, is the subject).
+
+Measure with the --stats report, A/B'd by the kill switch:
+
+    python3 scripts/gen_subdiv_stress.py /tmp/subdiv_stress.usda
+    target/release/crust-render -i /tmp/subdiv_stress.usda --stats -l error
+    CRUST_SUBDIV=0 target/release/crust-render -i /tmp/subdiv_stress.usda --stats -l error
+
+Subdivision runs during traversal, so its transient lands in the `peak`
+column of the `Traverse prims` row; the refined triangles' resident cost is
+the `kernel memory` delta between the two runs.
+
+Usage: gen_subdiv_stress.py [out.usda]
+The scene is deliberately NOT checked in -- it is generated text.
+"""
+
+import sys
+
+GRID = 128            # big cage: GRID x GRID quads, placed once (bake path)
+INSTANCED_GRID = 32   # small cage: authored twice -> interned, instanced
+LEVEL = 3             # crust:subdivisionLevel for every cage
+
+
+def quad_grid(n, size):
+    """(points, counts, indices) of an n x n quad grid spanning size units."""
+    step = size / n
+    pts = [
+        (i * step - size / 2.0, 0.0, j * step - size / 2.0)
+        for j in range(n + 1)
+        for i in range(n + 1)
+    ]
+    counts = [4] * (n * n)
+    idx = []
+    for j in range(n):
+        for i in range(n):
+            v0 = j * (n + 1) + i
+            idx += [v0, v0 + 1, v0 + n + 2, v0 + n + 1]
+    return pts, counts, idx
+
+
+def fmt_pts(pts):
+    return ", ".join(f"({x:.4g}, {y:.4g}, {z:.4g})" for x, y, z in pts)
+
+
+def mesh(name, n, size, translate, level):
+    pts, counts, idx = quad_grid(n, size)
+    return f"""
+    def Mesh "{name}" (prepend apiSchemas = ["MaterialBindingAPI"])
+    {{
+        int crust:subdivisionLevel = {level}
+        uniform token subdivisionScheme = "catmullClark"
+        point3f[] points = [{fmt_pts(pts)}]
+        int[] faceVertexCounts = [{", ".join(map(str, counts))}]
+        int[] faceVertexIndices = [{", ".join(map(str, idx))}]
+        rel material:binding = </World/Materials/grey>
+        double3 xformOp:translate = ({translate[0]}, {translate[1]}, {translate[2]})
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }}
+"""
+
+
+def main(out_path):
+    parts = [
+        f"""#usda 1.0
+(
+    doc = "Generated subdivision memory stress scene (scripts/gen_subdiv_stress.py): {GRID}x{GRID} cage + 2x {INSTANCED_GRID}x{INSTANCED_GRID} instanced cages, all at crust:subdivisionLevel = {LEVEL}."
+    defaultPrim = "World"
+    upAxis = "Y"
+)
+
+def Xform "World"
+{{
+    def Camera "Cam"
+    {{
+        float focalLength = 18
+        float horizontalAperture = 20.955
+        double3 xformOp:translate = (0, 10, 30)
+        float xformOp:rotateX = -18
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateX"]
+    }}
+
+    def Scope "Materials"
+    {{
+        def Material "grey"
+        {{
+            token outputs:surface.connect = </World/Materials/grey/Surface.outputs:surface>
+            def Shader "Surface"
+            {{
+                uniform token info:id = "crust:openpbr"
+                color3f inputs:baseColor = (0.6, 0.6, 0.6)
+                token outputs:surface
+            }}
+        }}
+    }}
+"""
+    ]
+    # The big cage, placed exactly once -> baked flat after flush_meshes.
+    parts.append(mesh("BigCage", GRID, 20.0, (0, 2, 0), LEVEL))
+    # Two placements of the identical small cage -> one interned slot, two
+    # kernel instances of one committed scene.
+    parts.append(mesh("SmallCageA", INSTANCED_GRID, 6.0, (-14, 2, 0), LEVEL))
+    parts.append(mesh("SmallCageB", INSTANCED_GRID, 6.0, (14, 2, 0), LEVEL))
+    parts.append(
+        """
+    def Mesh "Floor"
+    {
+        int[] faceVertexCounts = [4]
+        int[] faceVertexIndices = [0, 1, 2, 3]
+        point3f[] points = [(-40, 0, -40), (40, 0, -40), (40, 0, 40), (-40, 0, 40)]
+    }
+
+    def RectLight "KeyLight"
+    {
+        float inputs:width = 20
+        float inputs:height = 8
+        color3f inputs:color = (5, 5, 5)
+        float inputs:intensity = 1.0
+        double3 xformOp:translate = (0, 18, 14)
+        float xformOp:rotateX = -55
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateX"]
+    }
+}
+
+def Scope "Render"
+{
+    def RenderSettings "settings"
+    {
+        int2 resolution = (320, 180)
+        int crust:samplesPerPixel = 4
+        int crust:maxDepth = 2
+        int crust:minSamplesPerPixel = 4
+        float crust:varianceThreshold = 0
+        int crust:frame = 0
+    }
+}
+"""
+    )
+    with open(out_path, "w") as f:
+        f.write("".join(parts))
+    n_refined = (GRID * GRID + 2 * INSTANCED_GRID * INSTANCED_GRID) * 4**LEVEL
+    print(
+        f"wrote {out_path}: {GRID * GRID} + 2x{INSTANCED_GRID * INSTANCED_GRID} cage quads "
+        f"at level {LEVEL} -> {n_refined} refined quads ({2 * n_refined} triangles)"
+    )
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "subdiv_stress.usda")


### PR DESCRIPTION
Integrate the pure-Rust opensubdiv-rs port of OpenSubdiv's Far/Sdc layers
(git tag 0.1.2 — zero dependencies, forbid(unsafe_code)) as the renderer's
subdivision method, applied at USD import.

A Mesh prim authoring crust:subdivisionLevel (int, default 0, clamped to 6)
is uniformly refined and snapped to the limit surface, with smooth
per-vertex shading normals flowing through every geometry path (committed
prototypes, deferred bakes via the inverse-transpose, and the
non-invertible-transform bake, which recomputes them post-transform).
Opt-in per prim rather than triggered by subdivisionScheme, since USD's
fallback scheme is catmullClark and honouring it alone would subdivide
virtually every authored mesh; the scheme still picks the algorithm
(catmullClark/bilinear/loop, none warns and keeps the cage). USD
creases (per-run or per-edge sharpness), corners and interpolateBoundary
are honoured; holes and faceVaryingLinearInterpolation are out of scope.

Ptex stays correct under refinement: FaceMap gains optional explicit
per-triangle corner UVs mapping refined triangles back into their base
cage face's unit square (via a synthetic face-varying channel refined with
linear-everywhere rules plus composed child->parent face maps), and
check_face_count now takes the authored cage's face count by signature.

Refinement happens in mesh_source before interning, so direct, deferred
and prototype paths all see it exactly once and MeshKey dedupes on the
refined arrays. Malformed cages and refiner errors warn and degrade to
the cage. CRUST_SUBDIV=0 forces level 0 everywhere (A/B kill switch).

samples/subdivision.usda shows cubes at levels 0-3 beside a fully
edge-creased cube whose limit surface is the cage itself. Every existing
sample renders bit-identical against pre-change goldens at 16 spp.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015Rz6Y7NCzAjsxadgfrHoxL