### PR TITLE
Amend the safe-Rust constraint with a scoped Hydra-delegate exception

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,14 @@ inspired by PBRT, *Ray Tracing in One Weekend*, and Autodesk Standard Surface / 
 Scenes are loaded exclusively from **USD** (`.usda` / `.usdc` / `.usdz`) via the pure-Rust
 [`openusd`](https://github.com/mxpv/openusd) crate — RON support was removed.
 
+The safe-Rust rule is enforced (`forbid(unsafe_code)` in every crate root, test-only
+carve-outs excepted) and carries exactly **one sanctioned exception**: the planned
+**Hydra render delegate boundary** — a future `crust-capi` C-ABI crate plus the
+`hdCrust` C++ `HdRenderDelegate` plugin — may use `unsafe`/FFI, because Hydra's plugin
+ABI is C++ and cannot be reached otherwise. No engine crate may ever depend on those
+boundary crates, so the exception cannot leak inward. Rationale, scope and the phased
+roadmap live in `docs/hydra_delegate.md`.
+
 ## Commands
 
 ```bash
@@ -21,7 +29,11 @@ cargo run --release -- --bucket -i samples/cornellbox.usda   # tiled/bucket rend
 # CLI flags: -i/--input, -o/--output (default output.exr), -l/--level (log level),
 # -b/--bucket, -s/--samples (override spp), --strategy (power|balance|light|bsdf),
 # --filter (box|triangle|gaussian|blackman|mitchell) + --filter-radius (pixels),
-# --stats (per-phase profile + scene statistics)
+# --stats (per-phase profile + scene statistics),
+# --progressive <spp> (chunked render; run to completion it is bit-identical to
+# one-shot) + --preview <n> (snapshot PNG every n chunks), --time-limit <secs>
+# (stop and write the coherent partial image), --aovs (EXR sidecars: primary-hit
+# depth/normal/alpha + [geom_id, prim_id] as u32 channels in out.id.exr)
 
 # Where did the time and memory actually go? (parse vs build vs render vs output)
 cargo run --release -- -i samples/curves.usda --stats
@@ -186,6 +198,23 @@ material types, `simple_scene`, `get_settings`). Prefer importing from `crust_co
 2. **`Renderer`** (`tracer.rs`) drives sampling. Two entry points, both Rayon-parallel:
    - `render()` — parallel over pixels within each scanline row.
    - `render_with_tiles()` — parallel over 16×16 tiles (the `--bucket` path).
+   Both resolve a **`Film`** (one persisted `PixelAccum` — Σwᵢ·Lᵢ, Σwᵢ, luminance
+   moments, `taken`, adaptive-stop latch — per pixel) that `advance_film` drives to a
+   target spp; because the sampler is a pure function of the sample index and the
+   adaptive predicate a pure function of those accumulators, `begin_progressive()`
+   (chunked `step`/`snapshot`/`finish`, for hosts like a Hydra delegate) is
+   **bit-identical to batch when run to completion** — pinned by
+   `progressive_equals_batch_bitwise`. `render_with_control(tiled, progress, stop)`
+   adds cancellation via `StopToken` (checked per row/tile, never per sample; a stopped
+   render is a coherent partial image). Guided training passes never chunk (their
+   sample order feeds the order-sensitive SD-tree update); only the final pass does.
+   The ΔEff guided/unguided decision compares wall-clock costs, so guided renders are
+   deterministic only per-decision — the guided bitwise test pins one training
+   iteration for exactly that reason.
+   `render_aovs(AovRequest)` (`aov.rs`) fills depth/normal/`[geom_id, prim_id]`/alpha
+   planes from one primary-hit probe per pixel — point-sampled at pixel centers
+   through the lens center (never filtered: ids don't average), `MASK_CAMERA` so AOVs
+   agree with what the beauty sees.
    Pixel reconstruction (`filter.rs`, `crust:pixelFilter` / `--filter`) is **filter
    importance sampling**, not splatting: each pixel warps its jitter through the
    filter's distribution and weights radiance by `f/p`, keeping every per-pixel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,11 @@ cargo run --release -p crust-render --example xform_probe -- stage.usda /prim   
 # codegen: runs the suite with AVX/AVX2/AVX-512 off, with AVX2+FMA, and native.
 scripts/test_simd_matrix.sh -p crust-rt
 
+# The C-side ABI guard for crust-capi (the Hydra delegate boundary): compiles
+# include/crust.h from real C with -Werror, links the release cdylib, runs
+# tests/smoke.c. The Rust-side twin is `cargo test -p crust-capi`.
+scripts/test_capi_c.sh
+
 # --- The optimization loop (see "Measuring a change" below) --------------
 scripts/bench_scenes.sh                        # min-of-N Render seconds + Mray/s per scene
 scripts/check_images.sh record <dir>           # golden EXRs at 16 spp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,9 +142,16 @@ Five crates under `crates/` (plus the C++ plugin under `hydra/`):
 
 - **`crust-capi`** — the C ABI over crust-core for the Hydra delegate; the one
   sanctioned `unsafe` crate (see the safe-Rust rule above). The C contract is
-  the hand-written `include/crust.h`, guarded from drift by `tests/abi.rs`
-  (Rust side) and `tests/smoke.c` via `scripts/test_capi_c.sh` (C side).
-  Depends only on crust-core + glam; nothing depends on it.
+  the hand-written `include/crust.h` (API v2), guarded from drift by
+  `tests/abi.rs` (Rust side) and `tests/smoke.c` via `scripts/test_capi_c.sh`
+  (C side). What makes Hydra edits cheap lives here: `CrustGeoCache` keeps each
+  mesh's committed inner `rt::Scene` alive across scene rebuilds (placements are
+  kernel `Instance`s, so a rebuild pays only the top-level BVH over instance
+  boxes), and `crust_renderer_update_camera`/`update_settings` restart sampling
+  in place with no world work at all. Depends on crust-core + glam, plus
+  `exr`/`image` for `crust_scene_add_dome_light_file` (the capi plays the
+  `AssetLoader` role for the delegate that the CLI plays for batch renders);
+  nothing depends on it.
 - **`hydra/hdCrust/`** (not a crate) — the C++ `HdRenderDelegate` plugin over
   crust-capi: synchronous stepping per Hydra `Execute`, rebuild-on-any-edit,
   displayColor shading, color/depth/primId AOVs. Builds against an OpenUSD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,21 @@ rather than plateauing.
 
 ## Workspace layout
 
-Five crates under `crates/`:
+Five crates under `crates/` (plus the C++ plugin under `hydra/`):
+
+- **`crust-capi`** — the C ABI over crust-core for the Hydra delegate; the one
+  sanctioned `unsafe` crate (see the safe-Rust rule above). The C contract is
+  the hand-written `include/crust.h`, guarded from drift by `tests/abi.rs`
+  (Rust side) and `tests/smoke.c` via `scripts/test_capi_c.sh` (C side).
+  Depends only on crust-core + glam; nothing depends on it.
+- **`hydra/hdCrust/`** (not a crate) — the C++ `HdRenderDelegate` plugin over
+  crust-capi: synchronous stepping per Hydra `Execute`, rebuild-on-any-edit,
+  displayColor shading, color/depth/primId AOVs. Builds against an OpenUSD
+  C++ install (imaging on, GL not needed); `tests/testHdCrust.cpp` is a
+  headless registry→render harness. See `hydra/hdCrust/README.md` and
+  `docs/hydra_delegate.md`.
+
+The engine crates:
 
 - **`crust-rt`** (lib name `crust_rt`) — the intersection kernel, factored out the way
   `openqmc-rs` was, behind a deliberately **Embree-shaped API**: `Geometry` values
@@ -175,7 +189,9 @@ Five crates under `crates/`:
   the tone-mapped PNG. `main.rs` is the only file.
 - **`utils`** — math/RNG helpers (`random*`, `random_cosine_direction`, `align_to_normal`,
   `balance_heuristic`, `power_heuristic`, `clamp`, `Lerp`). Depended on by `crust-core`.
-- **`openqmc-rs`** (crate/lib name `openqmc`) — a self-contained, from-scratch Rust port
+- **`openqmc-rs`** (crate/lib name `openqmc`; no longer under `crates/` — pulled from
+  crates.io as an ordinary dependency, having graduated out of the workspace) — a
+  self-contained, from-scratch Rust port
   of [AcademySoftwareFoundation/openqmc](https://github.com/AcademySoftwareFoundation/openqmc)
   (Apache-2.0), the quasi-Monte Carlo sampling library. Modules map one-to-one to the
   upstream `oqmc/*.h` headers (`pcg`, `reverse`, `rotate`, `permute`, `encode`, `float`,

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 A toy, high-quality path tracer written in safe, modern Rust — inspired by PBRT, `Ray Tracing in One Weekend`, and Autodesk Standard Surface.
 Completely in a vibe coding mood.
 
+Every crate is `forbid(unsafe_code)` safe Rust, with one sanctioned exception on the
+roadmap: the USD **Hydra render delegate boundary** (a `crust-capi` C-ABI crate + the
+`hdCrust` C++ plugin) may use `unsafe`/FFI, since Hydra's plugin ABI is C++ — see
+[`docs/hydra_delegate.md`](docs/hydra_delegate.md).
+
 ## 📸 Preview
 
 ![preview](./images/rgb.png)

--- a/crates/crust-capi/Cargo.toml
+++ b/crates/crust-capi/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "crust-capi"
+version = { workspace = true }
+edition = { workspace = true }
+license-file = { workspace = true }
+
+# The C ABI boundary for the hdCrust Hydra render delegate — the one
+# sanctioned exception to the workspace's safe-Rust rule (see
+# docs/hydra_delegate.md). No engine crate depends on this crate.
+#
+# `cdylib` + `staticlib` are what a C++ host links; `rlib` keeps
+# `tests/abi.rs` linking normally under the test profile (where Cargo forces
+# `panic = "unwind"` back on, so the workspace's release `panic = "abort"`
+# does not affect the tests).
+[lib]
+name = "crust_capi"
+crate-type = ["cdylib", "staticlib", "rlib"]
+
+[dependencies]
+crust-core = { path = "../crust-core" }
+# Same workspace glam as crust-core (one crate instance), for the types
+# crust-core does not re-export (Mat3A, Affine3A).
+glam.workspace = true

--- a/crates/crust-capi/Cargo.toml
+++ b/crates/crust-capi/Cargo.toml
@@ -21,3 +21,9 @@ crust-core = { path = "../crust-core" }
 # Same workspace glam as crust-core (one crate instance), for the types
 # crust-core does not re-export (Mat3A, Affine3A).
 glam.workspace = true
+# Dome-light texture decoding (crust_scene_add_dome_light_file): the capi
+# is the delegate's host, so it owns the AssetLoader role the CLI plays for
+# batch renders — same decoders, same feature set, same linearization
+# semantics as crust-render/src/main.rs's CliAssets.
+exr.workspace = true
+image = { version = "0.25.6", default-features = false, features = ["png", "hdr"] }

--- a/crates/crust-capi/include/crust.h
+++ b/crates/crust-capi/include/crust.h
@@ -40,8 +40,11 @@ extern "C" {
 
 /* ---- version ---------------------------------------------------------- */
 
-/* Bumped on any ABI-incompatible change to this header. */
-#define CRUST_API_VERSION 1u
+/* Bumped on any ABI-incompatible change to this header.
+ * v2: CrustMaterial gained coat_weight/coat_roughness (sizeof 56 -> 64);
+ *     added CrustGeoCache, crust_scene_add_instance, the in-place
+ *     renderer edits, and crust_scene_add_dome_light_file. */
+#define CRUST_API_VERSION 2u
 
 /* The API version the library was built against; check == CRUST_API_VERSION
  * at startup. */
@@ -113,14 +116,16 @@ typedef struct CrustMaterial {
   float opacity;            /* geometric presence, 0..1                    */
   float emission_color[3];
   float emission_luminance; /* nits; 0 = not emissive                      */
+  float coat_weight;        /* clearcoat layer weight, 0..1                */
+  float coat_roughness;     /* clearcoat roughness, 0..1                   */
   int32_t thin_walled;      /* nonzero: thin sheet, no interior            */
   int32_t reserved_;        /* keep zeroed                                 */
 } CrustMaterial;
 
 #if !defined(__cplusplus)
-_Static_assert(sizeof(CrustMaterial) == 56, "CrustMaterial ABI drift");
+_Static_assert(sizeof(CrustMaterial) == 64, "CrustMaterial ABI drift");
 #else
-static_assert(sizeof(CrustMaterial) == 56, "CrustMaterial ABI drift");
+static_assert(sizeof(CrustMaterial) == 64, "CrustMaterial ABI drift");
 #endif
 
 /* Fill with defaults (grey diffuse: the OpenPBR default surface). */
@@ -238,6 +243,16 @@ CrustStatus crust_scene_add_dome_light(CrustScene* scene,
                                        uint32_t tex_width, uint32_t tex_height,
                                        const float* pixels_or_null,
                                        const float rotation[9]);
+
+/* As crust_scene_add_dome_light, but decoding the equirect texture from a
+ * file (NUL-terminated UTF-8 path): .exr and .hdr load linearly, LDR
+ * formats (e.g. .png) are converted from sRGB to linear — the same
+ * semantics as crust's CLI. Unreadable/undecodable path ->
+ * CRUST_ERROR_INVALID_ARGUMENT (fall back to the uniform-color variant). */
+CrustStatus crust_scene_add_dome_light_file(CrustScene* scene,
+                                            const float tint[3],
+                                            const char* path,
+                                            const float rotation[9]);
 
 /* view: world-to-view. proj: any perspective projection (GL [-1,1] z,
  * DirectX [0,1] z, reverse-Z, off-axis all accepted; orthographic is

--- a/crates/crust-capi/include/crust.h
+++ b/crates/crust-capi/include/crust.h
@@ -72,6 +72,7 @@ const char* crust_status_string(CrustStatus status);
 typedef struct CrustScene CrustScene;         /* scene builder              */
 typedef struct CrustRenderer CrustRenderer;   /* committed, steppable render */
 typedef struct CrustStopToken CrustStopToken; /* cross-thread cancellation  */
+typedef struct CrustGeoCache CrustGeoCache;   /* cross-rebuild prototype cache */
 
 /* ---- stop token --------------------------------------------------------- */
 
@@ -81,6 +82,23 @@ CrustStopToken* crust_stop_token_create(void);
 void crust_stop_token_stop(CrustStopToken* token);
 bool crust_stop_token_is_stopped(const CrustStopToken* token);
 void crust_stop_token_destroy(CrustStopToken* token);
+
+/* ---- geometry cache -------------------------------------------------------
+ * What makes edits cheap: a mesh's triangles (and their acceleration
+ * structure) are committed once and cached across scene rebuilds, keyed by
+ * an opaque caller-chosen key (e.g. a prim path hash) plus a content
+ * version the caller bumps when the geometry itself changes. A rebuild
+ * whose meshes all hit the cache pays only the top-level build over
+ * instance bounds. Thread-safe (internally synchronized), like the stop
+ * token; prototypes still referenced by live renderers survive removal. */
+
+CrustGeoCache* crust_geo_cache_create(void);
+bool crust_geo_cache_contains(const CrustGeoCache* cache, uint64_t key,
+                              uint32_t version);
+/* Call when a prim is deleted so its prototype can be reclaimed. */
+void crust_geo_cache_remove(CrustGeoCache* cache, uint64_t key);
+void crust_geo_cache_clear(CrustGeoCache* cache);
+void crust_geo_cache_destroy(CrustGeoCache* cache);
 
 /* ---- material ----------------------------------------------------------- */
 
@@ -158,6 +176,29 @@ CrustStatus crust_scene_add_sphere(CrustScene* scene,
                                    const float center[3], float radius,
                                    const CrustMaterial* material,
                                    uint32_t* out_geom_id);
+
+/* An OBJECT-SPACE mesh placed by xform (column-major doubles, same
+ * convention as the camera matrices — a GfMatrix4d passes untransposed),
+ * with its triangles cached in `cache` under (key, version):
+ *  - on a cache HIT the vertex arrays are never read and may be NULL —
+ *    check crust_geo_cache_contains first to skip marshalling entirely;
+ *  - on a MISS the arrays are required (as in crust_scene_add_mesh, but
+ *    object space; normals transform correctly through the placement) and
+ *    the committed prototype is stored for every later rebuild.
+ * The placement must be invertible: a singular xform (e.g. zero scale, the
+ * common "hide this" idiom) returns CRUST_ERROR_INVALID_ARGUMENT and the
+ * caller skips the placement. Each call adds one placement and returns its
+ * geom_id; N placements of one prototype share the cached triangles. */
+CrustStatus crust_scene_add_instance(CrustScene* scene, CrustGeoCache* cache,
+                                     uint64_t key, uint32_t version,
+                                     const float* positions_or_null,
+                                     size_t vertex_count,
+                                     const uint32_t* tri_indices_or_null,
+                                     size_t triangle_count,
+                                     const float* normals_or_null,
+                                     const double xform[16],
+                                     const CrustMaterial* material,
+                                     uint32_t* out_geom_id);
 
 /* Lights. Geometry-backed lights (sphere, rect) follow crust's engine
  * convention internally: their emissive geometry is hidden from camera
@@ -272,6 +313,24 @@ CrustStatus crust_renderer_read_aov_id(CrustRenderer* renderer,
 /* 1 float per pixel: 1.0 hit / 0.0 miss. */
 CrustStatus crust_renderer_read_aov_alpha(CrustRenderer* renderer,
                                           float* alpha, size_t capacity_px);
+
+/* ---- in-place edits --------------------------------------------------------
+ * Both restart sampling from zero (a film cannot survive a camera or
+ * resolution change) WITHOUT touching the world or its acceleration
+ * structure — this is the cheap path for viewport orbits. Reads made after
+ * an edit see the restarted render. A stopped token is permanent, so pass
+ * a fresh token to keep the restarted render cancellable; NULL keeps the
+ * current one (stopped or not). */
+
+CrustStatus crust_renderer_update_camera(CrustRenderer* renderer,
+                                         const double view[16],
+                                         const double proj[16],
+                                         float aperture, float focus_distance,
+                                         const CrustStopToken* token_or_null);
+
+CrustStatus crust_renderer_update_settings(CrustRenderer* renderer,
+                                           const CrustRenderSettings* settings,
+                                           const CrustStopToken* token_or_null);
 
 void crust_renderer_destroy(CrustRenderer* renderer);
 

--- a/crates/crust-capi/include/crust.h
+++ b/crates/crust-capi/include/crust.h
@@ -1,0 +1,282 @@
+/* crust.h — the C ABI of Crust Render, for render-delegate hosts (hdCrust).
+ *
+ * Hand-written and kept in lockstep with crates/crust-capi/src/ by three
+ * guards: the C smoke test compiles this header with -Wall -Wextra -Werror
+ * and exercises every exported symbol; POD struct sizes are pinned by
+ * paired static_asserts here and in Rust; and every extern "C" function in
+ * Rust carries its C declaration in the doc comment directly above it.
+ *
+ * Conventions, once:
+ *  - Every fallible function returns CrustStatus; out-parameters come last.
+ *  - Framebuffer and AOV reads are BOTTOM-UP: row 0 is the BOTTOM scanline
+ *    (OpenGL / Hydra render-buffer convention, and crust's native layout),
+ *    indexed y*width + x. Flip yourself if you want display order.
+ *  - Dome-light textures are the one asymmetric exception: equirect
+ *    lat-long pixels with row 0 at the TOP (+Y pole), the texture-space
+ *    convention environment maps are authored in.
+ *  - Matrices are column-major, column-vector (OpenGL) convention. A USD
+ *    GfMatrix4d (row-major, row-vector) passes element-for-element with NO
+ *    transpose: transposing the storage and transposing the convention
+ *    cancel out.
+ *  - Thread safety: CrustScene and CrustRenderer are externally
+ *    synchronized — at most one thread inside any function on a given
+ *    handle at a time; distinct handles are independent. CrustStopToken is
+ *    the ONE cross-thread type: its functions may be called from any thread
+ *    at any time, including while a step on a renderer holding a clone of
+ *    the token is in flight — that is its purpose. crust_renderer_step
+ *    blocks and parallelizes internally.
+ *  - All *_destroy functions accept NULL as a no-op.
+ */
+#ifndef CRUST_H
+#define CRUST_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ---- version ---------------------------------------------------------- */
+
+/* Bumped on any ABI-incompatible change to this header. */
+#define CRUST_API_VERSION 1u
+
+/* The API version the library was built against; check == CRUST_API_VERSION
+ * at startup. */
+uint32_t crust_api_version(void);
+
+/* The crust-render release (semver) behind the library. */
+void crust_library_version(uint32_t* major, uint32_t* minor, uint32_t* patch);
+
+/* ---- status ------------------------------------------------------------ */
+
+typedef enum CrustStatus {
+  CRUST_OK = 0,
+  CRUST_ERROR_NULL_ARGUMENT = 1,    /* a required pointer was NULL          */
+  CRUST_ERROR_INVALID_ARGUMENT = 2, /* zero/oversized count, non-finite
+                                     * float, malformed enum or texture     */
+  CRUST_ERROR_INVALID_CAMERA = 3,   /* non-invertible matrices, orthographic
+                                     * projection, bad focus distance       */
+  CRUST_ERROR_BAD_STATE = 4,        /* builder used after commit, or commit
+                                     * without camera/settings              */
+  CRUST_ERROR_BUFFER_TOO_SMALL = 5, /* read capacity < width*height pixels  */
+} CrustStatus;
+
+/* Static string for logging; never NULL. Thread-safe. */
+const char* crust_status_string(CrustStatus status);
+
+/* ---- opaque handles ----------------------------------------------------- */
+
+typedef struct CrustScene CrustScene;         /* scene builder              */
+typedef struct CrustRenderer CrustRenderer;   /* committed, steppable render */
+typedef struct CrustStopToken CrustStopToken; /* cross-thread cancellation  */
+
+/* ---- stop token --------------------------------------------------------- */
+
+CrustStopToken* crust_stop_token_create(void);
+/* Idempotent; a stopped token is PERMANENT (there is no un-stop). Create a
+ * fresh token per committed scene. */
+void crust_stop_token_stop(CrustStopToken* token);
+bool crust_stop_token_is_stopped(const CrustStopToken* token);
+void crust_stop_token_destroy(CrustStopToken* token);
+
+/* ---- material ----------------------------------------------------------- */
+
+/* A portable subset of the OpenPBR übershader (crust's single surface
+ * shader). Unset lobes keep OpenPBR defaults. All colors linear RGB. */
+typedef struct CrustMaterial {
+  float base_color[3];
+  float metalness;          /* 0 dielectric .. 1 metal                     */
+  float roughness;          /* specular/microfacet roughness, 0..1         */
+  float ior;                /* dielectric IOR (default 1.5)                */
+  float transmission;       /* 0 opaque .. 1 fully transmissive (glass)    */
+  float opacity;            /* geometric presence, 0..1                    */
+  float emission_color[3];
+  float emission_luminance; /* nits; 0 = not emissive                      */
+  int32_t thin_walled;      /* nonzero: thin sheet, no interior            */
+  int32_t reserved_;        /* keep zeroed                                 */
+} CrustMaterial;
+
+#if !defined(__cplusplus)
+_Static_assert(sizeof(CrustMaterial) == 56, "CrustMaterial ABI drift");
+#else
+static_assert(sizeof(CrustMaterial) == 56, "CrustMaterial ABI drift");
+#endif
+
+/* Fill with defaults (grey diffuse: the OpenPBR default surface). */
+void crust_material_default(CrustMaterial* out);
+
+/* ---- render settings ----------------------------------------------------- */
+
+typedef struct CrustRenderSettings {
+  uint32_t width, height;         /* pixels; 1..=65536 each                */
+  uint32_t samples_per_pixel;     /* full budget; >= 1                     */
+  uint32_t max_depth;             /* path length bound; >= 1               */
+  uint32_t min_samples_per_pixel; /* adaptive-stop floor                   */
+  float variance_threshold;       /* relative std-error target; 0 disables
+                                   * adaptive early stop                   */
+  uint32_t frame;                 /* seeds the sampler (animation frame)   */
+} CrustRenderSettings;
+
+#if !defined(__cplusplus)
+_Static_assert(sizeof(CrustRenderSettings) == 28, "CrustRenderSettings ABI drift");
+#else
+static_assert(sizeof(CrustRenderSettings) == 28, "CrustRenderSettings ABI drift");
+#endif
+
+/* 640x360, 64 spp, depth 8, adaptive off. */
+void crust_render_settings_default(CrustRenderSettings* out);
+
+/* ---- scene builder -------------------------------------------------------
+ * Single-threaded. After a successful commit the builder is SPENT: further
+ * add/set calls return CRUST_ERROR_BAD_STATE; the handle itself must still
+ * be destroyed. Rebuilds (any scene edit) mean: destroy the renderer,
+ * build a fresh scene, commit again — crust has no incremental edits yet. */
+
+CrustScene* crust_scene_create(void);
+void crust_scene_destroy(CrustScene* scene);
+
+/* Triangles only — Hydra hosts triangulate with HdMeshUtil, which also
+ * yields the triangle->authored-face mapping picking wants.
+ *   positions:  3 floats per vertex, world space.
+ *   tri_indices: 3 uint32 per triangle. Out-of-range indices are skipped
+ *                by the kernel (they cannot crash it), but are a modeling
+ *                error.
+ *   normals_or_null: optional per-vertex shading normals, 3 floats per
+ *                vertex, exactly vertex_count of them.
+ * out_geom_id receives the id the id-AOV reports for this mesh. */
+CrustStatus crust_scene_add_mesh(CrustScene* scene,
+                                 const float* positions, size_t vertex_count,
+                                 const uint32_t* tri_indices, size_t triangle_count,
+                                 const float* normals_or_null,
+                                 const CrustMaterial* material,
+                                 uint32_t* out_geom_id);
+
+CrustStatus crust_scene_add_sphere(CrustScene* scene,
+                                   const float center[3], float radius,
+                                   const CrustMaterial* material,
+                                   uint32_t* out_geom_id);
+
+/* Lights. Geometry-backed lights (sphere, rect) follow crust's engine
+ * convention internally: their emissive geometry is hidden from camera
+ * rays (a light in frame does not show its source) but visible to shadow
+ * and indirect rays. radiance is linear RGB, W·sr⁻¹·m⁻². */
+CrustStatus crust_scene_add_sphere_light(CrustScene* scene,
+                                         const float center[3], float radius,
+                                         const float radiance[3]);
+
+/* Rect area light spanning origin -> origin+edge_u -> origin+edge_u+edge_v
+ * -> origin+edge_v, emitting along normalize(edge_u x edge_v) only. */
+CrustStatus crust_scene_add_rect_light(CrustScene* scene,
+                                       const float origin[3],
+                                       const float edge_u[3],
+                                       const float edge_v[3],
+                                       const float radiance[3]);
+
+/* direction: from the light toward the scene (world space). irradiance:
+ * linear RGB W·m⁻² on a surface facing the light. angle_deg: the source's
+ * angular DIAMETER (0.53 = the sun); tiny angles are widened to a floor
+ * rather than made singular. */
+CrustStatus crust_scene_add_distant_light(CrustScene* scene,
+                                          const float direction[3],
+                                          const float irradiance[3],
+                                          float angle_deg);
+
+/* Infinite environment dome; replaces the built-in sky gradient.
+ *   tint: linear RGB multiplier (the whole radiance when untextured).
+ *   pixels_or_null: optional equirect lat-long RGB f32 texture,
+ *     tex_width*tex_height*3 floats, ROW 0 AT THE TOP (+Y pole) — the
+ *     texture convention, NOT the framebuffer one.
+ *   rotation: 3x3 column-major dome-to-world rotation ({1,0,0,0,1,0,0,0,1}
+ *     for identity). A dome is at infinity: translation/scale are
+ *     meaningless and not accepted. */
+CrustStatus crust_scene_add_dome_light(CrustScene* scene,
+                                       const float tint[3],
+                                       uint32_t tex_width, uint32_t tex_height,
+                                       const float* pixels_or_null,
+                                       const float rotation[9]);
+
+/* view: world-to-view. proj: any perspective projection (GL [-1,1] z,
+ * DirectX [0,1] z, reverse-Z, off-axis all accepted; orthographic is
+ * rejected with CRUST_ERROR_INVALID_CAMERA). Both column-major
+ * column-vector — pass GfMatrix4d::data() straight through, no transpose.
+ * aperture: lens diameter in world units, 0 = pinhole. focus_distance:
+ * distance to the focal plane, > 0. */
+CrustStatus crust_scene_set_camera(CrustScene* scene,
+                                   const double view[16], const double proj[16],
+                                   float aperture, float focus_distance);
+
+CrustStatus crust_scene_set_render_settings(CrustScene* scene,
+                                            const CrustRenderSettings* settings);
+
+/* Builds the acceleration structure and produces the steppable renderer.
+ * Camera and settings must have been set. token_or_null is CLONED — the
+ * caller keeps ownership and may stop/destroy it independently; NULL means
+ * this render cannot be cancelled mid-step. On success the builder is
+ * spent (see above). */
+CrustStatus crust_scene_commit(CrustScene* scene,
+                               const CrustStopToken* token_or_null,
+                               CrustRenderer** out_renderer);
+
+/* ---- renderer ------------------------------------------------------------ */
+
+typedef enum CrustStepStatus {
+  CRUST_STEP_IN_PROGRESS = 0, /* chunk done, budget remains               */
+  CRUST_STEP_STOPPED = 1,     /* token fired mid-chunk; image coherent;
+                               * stepping later resumes exactly there      */
+  CRUST_STEP_COMPLETE = 2,    /* full budget rendered; step is a no-op    */
+} CrustStepStatus;
+
+/* Advance the render by (up to) spp more samples per pixel. Blocking;
+ * honors the commit-time stop token at row/tile granularity. Driving this
+ * once per Hydra Execute call yields progressive refinement: read the
+ * framebuffer after each step. A render stepped to completion is
+ * bit-identical to the same scene rendered in one shot, whatever the chunk
+ * sizes. */
+CrustStatus crust_renderer_step(CrustRenderer* renderer, uint32_t spp,
+                                CrustStepStatus* out_status,
+                                uint32_t* out_spp_done);
+
+bool crust_renderer_is_converged(const CrustRenderer* renderer);
+uint32_t crust_renderer_spp_done(const CrustRenderer* renderer);
+void crust_renderer_get_dimensions(const CrustRenderer* renderer,
+                                   uint32_t* width, uint32_t* height);
+
+/* All reads: bottom-up rows (see header comment), capacity in PIXELS,
+ * capacity >= width*height or CRUST_ERROR_BUFFER_TOO_SMALL. Valid at any
+ * time: black before the first step, the coherent partial image after a
+ * stopped one. The first AOV read (any of the four) runs one primary-hit
+ * probe pass and caches all four planes; later reads are copies. */
+
+/* 4 floats per pixel, linear RGBA. Alpha is primary-hit coverage (1 hit /
+ * 0 miss), point-sampled, not filtered. */
+CrustStatus crust_renderer_read_color(CrustRenderer* renderer,
+                                      float* rgba, size_t capacity_px);
+
+/* 1 float per pixel: camera-forward hit distance; +INFINITY on miss.
+ * Convert to your own depth convention with your projection matrix. */
+CrustStatus crust_renderer_read_aov_depth(CrustRenderer* renderer,
+                                          float* depth, size_t capacity_px);
+
+/* 3 floats per pixel: outward world-space normal; (0,0,0) on miss. */
+CrustStatus crust_renderer_read_aov_normal(CrustRenderer* renderer,
+                                           float* xyz, size_t capacity_px);
+
+/* 2 uint32 per pixel: [geom_id, prim_id] of the primary hit; UINT32_MAX on
+ * miss. geom_id matches the ids returned at scene build time. */
+CrustStatus crust_renderer_read_aov_id(CrustRenderer* renderer,
+                                       uint32_t* geom_prim, size_t capacity_px);
+
+/* 1 float per pixel: 1.0 hit / 0.0 miss. */
+CrustStatus crust_renderer_read_aov_alpha(CrustRenderer* renderer,
+                                          float* alpha, size_t capacity_px);
+
+void crust_renderer_destroy(CrustRenderer* renderer);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* CRUST_H */

--- a/crates/crust-capi/src/dome.rs
+++ b/crates/crust-capi/src/dome.rs
@@ -1,0 +1,82 @@
+//! File-based dome-light textures.
+//!
+//! The capi plays the `AssetLoader` role for the Hydra delegate that the
+//! CLI plays for batch renders, so the decode semantics here mirror
+//! `crust-render/src/main.rs`'s `CliAssets` exactly: `.exr` via the `exr`
+//! crate (values already linear), `.hdr` via the `image` crate
+//! (passthrough), any other `image`-supported format decoded then pushed
+//! through the piecewise sRGB EOTF so an LDR sky lights the scene in
+//! linear light. Row order is file order — row 0 at the top (+Y pole),
+//! `EnvironmentMap`'s convention.
+
+use crust_core::{EnvironmentMap, Vec3A};
+use exr::prelude::read_first_rgba_layer_from_file;
+use std::path::Path;
+
+pub(crate) fn load_environment(path: &Path) -> Option<EnvironmentMap> {
+    match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("exr") => load_exr(path),
+        _ => load_image(path),
+    }
+}
+
+fn load_exr(path: &Path) -> Option<EnvironmentMap> {
+    let image = read_first_rgba_layer_from_file(
+        path,
+        |resolution, _| {
+            let (w, h) = (resolution.width(), resolution.height());
+            (w, h, vec![Vec3A::ZERO; w * h])
+        },
+        |(w, _h, pixels): &mut (usize, usize, Vec<Vec3A>),
+         pos,
+         (r, g, b, _a): (f32, f32, f32, f32)| {
+            pixels[pos.y() * *w + pos.x()] = Vec3A::new(r, g, b);
+        },
+    )
+    .ok()?;
+    let (w, h, pixels) = image.layer_data.channel_data.pixels;
+    EnvironmentMap::new(w, h, pixels)
+}
+
+fn load_image(path: &Path) -> Option<EnvironmentMap> {
+    // The default 512 MiB decode-allocation limit is well below a
+    // production panorama (a 16k HDRI); this is a trusted, locally-authored
+    // asset, so lift it — same reasoning as the CLI.
+    let mut reader = image::ImageReader::open(path)
+        .ok()?
+        .with_guessed_format()
+        .ok()?;
+    reader.no_limits();
+    let decoded = reader.decode().ok()?;
+    let rgb = decoded.to_rgb32f();
+    let (w, h) = (rgb.width() as usize, rgb.height() as usize);
+    // `to_rgb32f` keeps HDR values as authored but rescales integer formats
+    // to 0..1 *without* removing their sRGB transfer curve — undo it for
+    // those.
+    let is_hdr = matches!(
+        path.extension()
+            .and_then(|e| e.to_str())
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("hdr")
+    );
+    let to_linear = |c: f32| {
+        if is_hdr {
+            c
+        } else if c <= 0.04045 {
+            c / 12.92
+        } else {
+            ((c + 0.055) / 1.055).powf(2.4)
+        }
+    };
+    let pixels = rgb
+        .pixels()
+        .map(|p| Vec3A::new(to_linear(p[0]), to_linear(p[1]), to_linear(p[2])))
+        .collect();
+    EnvironmentMap::new(w, h, pixels)
+}

--- a/crates/crust-capi/src/geo_cache.rs
+++ b/crates/crust-capi/src/geo_cache.rs
@@ -1,0 +1,102 @@
+//! The prototype geometry cache — what makes Hydra edits cheap.
+//!
+//! A committed inner `rt::Scene` (the triangles and their BVH) is immutable
+//! and shareable, so it can outlive any number of top-level scene rebuilds:
+//! the host keys each mesh by an opaque `u64` (hdCrust uses the prim path's
+//! hash) plus a content version it bumps when the geometry itself changes.
+//! A rebuild whose meshes all hit the cache pays only the top-level BVH
+//! over instance boxes — never a triangle re-upload or an inner build.
+
+use crust_core::rt;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+struct CachedProto {
+    version: u32,
+    scene: Arc<rt::Scene>,
+}
+
+/// The C `CrustGeoCache`. Mutex-guarded (like the stop token's atomic): the
+/// cache outlives individual scene builds and may be shared, so unlike the
+/// builder/renderer handles it is safe to touch from any thread.
+pub struct GeoCacheHandle {
+    entries: Mutex<HashMap<u64, CachedProto>>,
+}
+
+impl GeoCacheHandle {
+    fn new() -> Self {
+        GeoCacheHandle {
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn lookup(&self, key: u64, version: u32) -> Option<Arc<rt::Scene>> {
+        let entries = self.entries.lock().expect("geo cache poisoned");
+        entries
+            .get(&key)
+            .filter(|c| c.version == version)
+            .map(|c| c.scene.clone())
+    }
+
+    /// Inserts (or replaces — a stale version is dead weight) an entry.
+    pub(crate) fn insert(&self, key: u64, version: u32, scene: Arc<rt::Scene>) {
+        let mut entries = self.entries.lock().expect("geo cache poisoned");
+        entries.insert(key, CachedProto { version, scene });
+    }
+}
+
+/// `CrustGeoCache* crust_geo_cache_create(void);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_geo_cache_create() -> *mut GeoCacheHandle {
+    Box::into_raw(Box::new(GeoCacheHandle::new()))
+}
+
+/// `bool crust_geo_cache_contains(const CrustGeoCache*, uint64_t key,
+///     uint32_t version);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_geo_cache_contains(
+    cache: *const GeoCacheHandle,
+    key: u64,
+    version: u32,
+) -> bool {
+    // SAFETY: non-null checked; validity until destroy is the header
+    // contract, and the cache is internally synchronized.
+    unsafe { cache.as_ref() }.is_some_and(|c| c.lookup(key, version).is_some())
+}
+
+/// `void crust_geo_cache_remove(CrustGeoCache*, uint64_t key);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_geo_cache_remove(cache: *mut GeoCacheHandle, key: u64) {
+    // SAFETY: as `crust_geo_cache_contains`.
+    if let Some(cache) = unsafe { cache.as_ref() } {
+        cache
+            .entries
+            .lock()
+            .expect("geo cache poisoned")
+            .remove(&key);
+    }
+}
+
+/// `void crust_geo_cache_clear(CrustGeoCache*);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_geo_cache_clear(cache: *mut GeoCacheHandle) {
+    // SAFETY: as `crust_geo_cache_contains`.
+    if let Some(cache) = unsafe { cache.as_ref() } {
+        cache
+            .entries
+            .lock()
+            .expect("geo cache poisoned")
+            .clear();
+    }
+}
+
+/// `void crust_geo_cache_destroy(CrustGeoCache*);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_geo_cache_destroy(cache: *mut GeoCacheHandle) {
+    if !cache.is_null() {
+        // SAFETY: created by `crust_geo_cache_create`; use after destroy is
+        // forbidden by the header contract. Prototypes still referenced by
+        // live renderers survive — they are `Arc`s.
+        drop(unsafe { Box::from_raw(cache) });
+    }
+}

--- a/crates/crust-capi/src/geo_cache.rs
+++ b/crates/crust-capi/src/geo_cache.rs
@@ -53,8 +53,15 @@ pub extern "C" fn crust_geo_cache_create() -> *mut GeoCacheHandle {
 
 /// `bool crust_geo_cache_contains(const CrustGeoCache*, uint64_t key,
 ///     uint32_t version);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_geo_cache_contains(
+pub unsafe extern "C" fn crust_geo_cache_contains(
     cache: *const GeoCacheHandle,
     key: u64,
     version: u32,
@@ -65,8 +72,15 @@ pub extern "C" fn crust_geo_cache_contains(
 }
 
 /// `void crust_geo_cache_remove(CrustGeoCache*, uint64_t key);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_geo_cache_remove(cache: *mut GeoCacheHandle, key: u64) {
+pub unsafe extern "C" fn crust_geo_cache_remove(cache: *mut GeoCacheHandle, key: u64) {
     // SAFETY: as `crust_geo_cache_contains`.
     if let Some(cache) = unsafe { cache.as_ref() } {
         cache
@@ -78,8 +92,15 @@ pub extern "C" fn crust_geo_cache_remove(cache: *mut GeoCacheHandle, key: u64) {
 }
 
 /// `void crust_geo_cache_clear(CrustGeoCache*);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_geo_cache_clear(cache: *mut GeoCacheHandle) {
+pub unsafe extern "C" fn crust_geo_cache_clear(cache: *mut GeoCacheHandle) {
     // SAFETY: as `crust_geo_cache_contains`.
     if let Some(cache) = unsafe { cache.as_ref() } {
         cache
@@ -91,8 +112,15 @@ pub extern "C" fn crust_geo_cache_clear(cache: *mut GeoCacheHandle) {
 }
 
 /// `void crust_geo_cache_destroy(CrustGeoCache*);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_geo_cache_destroy(cache: *mut GeoCacheHandle) {
+pub unsafe extern "C" fn crust_geo_cache_destroy(cache: *mut GeoCacheHandle) {
     if !cache.is_null() {
         // SAFETY: created by `crust_geo_cache_create`; use after destroy is
         // forbidden by the header contract. Prototypes still referenced by

--- a/crates/crust-capi/src/handles.rs
+++ b/crates/crust-capi/src/handles.rs
@@ -1,0 +1,216 @@
+//! The opaque handle types behind the C pointers — including the one piece
+//! of genuinely delicate `unsafe` in this crate, `RendererHandle`'s pinned
+//! self-reference.
+
+use crate::status::{CrustStatus, CrustStepStatus};
+use crate::validate::CResult;
+use crust_core::{
+    AovBuffers, AovRequest, Buffer, Camera, LightList, ProgressiveRender, RenderSettings,
+    Renderer, StepStatus, StopToken, WorldBuilder,
+};
+use std::mem::ManuallyDrop;
+use std::ptr::NonNull;
+
+/// The C `CrustStopToken`: a boxed clone-able engine token. The one type
+/// whose functions are callable from any thread — `StopToken` is an
+/// `Arc<AtomicBool>` underneath, which is exactly what makes that sound.
+pub struct TokenHandle(pub(crate) StopToken);
+
+/// The C `CrustScene`: everything accumulated before commit. `builder`
+/// turning `None` is the "spent" state the header describes — every
+/// add/set call answers `CRUST_ERROR_BAD_STATE` from then on.
+pub struct SceneHandle {
+    pub(crate) builder: Option<WorldBuilder>,
+    pub(crate) lights: LightList,
+    pub(crate) camera: Option<Camera>,
+    pub(crate) settings: Option<RenderSettings>,
+}
+
+impl SceneHandle {
+    pub(crate) fn new() -> Self {
+        SceneHandle {
+            builder: Some(WorldBuilder::new()),
+            lights: LightList::new(),
+            camera: None,
+            settings: None,
+        }
+    }
+
+    /// The builder, or `BadState` once the scene has been committed.
+    pub(crate) fn builder_mut(&mut self) -> CResult<&mut WorldBuilder> {
+        self.builder.as_mut().ok_or(CrustStatus::BadState)
+    }
+
+    /// Spent check for the non-geometry setters (camera/settings/lights).
+    pub(crate) fn ensure_live(&self) -> CResult<()> {
+        if self.builder.is_some() {
+            Ok(())
+        } else {
+            Err(CrustStatus::BadState)
+        }
+    }
+}
+
+/// The C `CrustRenderer`: a committed render — the `Renderer` and the
+/// `ProgressiveRender` session advancing it — behind one opaque pointer.
+///
+/// `ProgressiveRender<'a>` borrows `&'a Renderer`, which C's "one handle"
+/// shape cannot express safely, so this struct is self-referential.
+///
+/// SAFETY ARGUMENT (the whole of it):
+/// - The `Renderer` lives at a stable heap address: it is boxed once in
+///   [`RendererHandle::new`] and freed only in `Drop`. The session's
+///   `&'static Renderer` is a lie about *lifetime*, never about *address*.
+/// - No `&mut Renderer` is ever created while the session exists: this
+///   crate's C surface exposes no post-commit mutation (rebuild-everything
+///   semantics — an edit means a new scene handle and a new commit), and
+///   internally only shared `renderer()` references are taken.
+///   `ProgressiveRender::step` mutates the *session*, not the renderer.
+/// - `renderer` is a raw `NonNull`, not a `Box` field: materializing
+///   `&mut RendererHandle` from the C pointer at every call would retag a
+///   `Box`'s unique pointer and invalidate the session's outstanding
+///   borrow under Stacked Borrows; raw pointers are never retagged.
+/// - Drop order is explicit: `Drop::drop` first drops the session (which
+///   merely releases its film — dropping a `&Renderer` field dereferences
+///   nothing), then frees the `Renderer`. `ManuallyDrop` makes that
+///   ordering independent of field order, and nothing can observe the
+///   handle between the two.
+pub struct RendererHandle {
+    session: ManuallyDrop<ProgressiveRender<'static>>,
+    renderer: NonNull<Renderer>,
+    stop: StopToken,
+    /// Reused `snapshot_into` target so per-step color reads do not
+    /// allocate a frame each time.
+    color_scratch: Buffer,
+    /// The four AOV planes, probed lazily on the first read (the committed
+    /// scene is immutable, so once is enough) and cached.
+    aovs: Option<AovBuffers>,
+}
+
+impl RendererHandle {
+    pub(crate) fn new(renderer: Renderer, stop: StopToken) -> Box<RendererHandle> {
+        let (width, height) = renderer.settings.get_dimensions();
+        let renderer = NonNull::from(Box::leak(Box::new(renderer)));
+        // SAFETY: see the struct-level argument — stable address (freed
+        // only in Drop, after the session), and no exclusive reference to
+        // the Renderer is ever created while the session lives.
+        let session: ProgressiveRender<'static> =
+            unsafe { renderer.as_ref() }.begin_progressive(true);
+        Box::new(RendererHandle {
+            session: ManuallyDrop::new(session),
+            renderer,
+            stop,
+            color_scratch: Buffer::new(width, height),
+            aovs: None,
+        })
+    }
+
+    fn renderer(&self) -> &Renderer {
+        // SAFETY: the pointee is alive for the whole life of the handle
+        // (freed only in Drop) and only ever shared-borrowed.
+        unsafe { self.renderer.as_ref() }
+    }
+
+    pub(crate) fn dimensions(&self) -> (u32, u32) {
+        let (w, h) = self.renderer().settings.get_dimensions();
+        (w as u32, h as u32)
+    }
+
+    pub(crate) fn pixel_count(&self) -> usize {
+        let (w, h) = self.renderer().settings.get_dimensions();
+        w * h
+    }
+
+    pub(crate) fn step(&mut self, spp: u32) -> (CrustStepStatus, u32) {
+        match self.session.step(spp, None, Some(&self.stop)) {
+            StepStatus::InProgress { spp_done } => (CrustStepStatus::InProgress, spp_done),
+            StepStatus::Stopped { spp_done } => (CrustStepStatus::Stopped, spp_done),
+            StepStatus::Complete { spp_done } => (CrustStepStatus::Complete, spp_done),
+        }
+    }
+
+    pub(crate) fn is_converged(&self) -> bool {
+        self.session.is_complete()
+    }
+
+    pub(crate) fn spp_done(&self) -> u32 {
+        self.session.spp_done()
+    }
+
+    fn ensure_aovs(&mut self) -> &AovBuffers {
+        if self.aovs.is_none() {
+            self.aovs = Some(self.renderer().render_aovs(AovRequest {
+                depth: true,
+                normal: true,
+                prim_id: true,
+                alpha: true,
+            }));
+        }
+        self.aovs.as_ref().expect("just filled")
+    }
+
+    /// Linear RGBA into `out` (4 floats per pixel, bottom-up rows). Alpha
+    /// comes from the primary-hit coverage plane. Per-pixel copies on
+    /// purpose: `Vec3A` is 16 bytes with an undefined fourth lane, so the
+    /// accumulators must never be memcpy'd as float data.
+    pub(crate) fn read_color(&mut self, out: &mut [f32]) {
+        self.ensure_aovs();
+        self.session.snapshot_into(&mut self.color_scratch);
+        let alpha = self
+            .aovs
+            .as_ref()
+            .and_then(|a| a.alpha.as_deref())
+            .expect("alpha requested at probe time");
+        for (i, (px, a)) in self
+            .color_scratch
+            .as_slice()
+            .iter()
+            .zip(alpha)
+            .enumerate()
+        {
+            out[4 * i] = px.x;
+            out[4 * i + 1] = px.y;
+            out[4 * i + 2] = px.z;
+            out[4 * i + 3] = *a;
+        }
+    }
+
+    pub(crate) fn read_depth(&mut self, out: &mut [f32]) {
+        let depth = self.ensure_aovs().depth.as_deref().expect("requested");
+        out.copy_from_slice(depth);
+    }
+
+    pub(crate) fn read_normal(&mut self, out: &mut [f32]) {
+        let normals = self.ensure_aovs().normal.as_deref().expect("requested");
+        for (i, n) in normals.iter().enumerate() {
+            out[3 * i] = n.x;
+            out[3 * i + 1] = n.y;
+            out[3 * i + 2] = n.z;
+        }
+    }
+
+    pub(crate) fn read_id(&mut self, out: &mut [u32]) {
+        let ids = self.ensure_aovs().prim_id.as_deref().expect("requested");
+        for (i, [geom, prim]) in ids.iter().enumerate() {
+            out[2 * i] = *geom;
+            out[2 * i + 1] = *prim;
+        }
+    }
+
+    pub(crate) fn read_alpha(&mut self, out: &mut [f32]) {
+        let alpha = self.ensure_aovs().alpha.as_deref().expect("requested");
+        out.copy_from_slice(alpha);
+    }
+}
+
+impl Drop for RendererHandle {
+    fn drop(&mut self) {
+        // SAFETY: the session (which borrows the renderer) is dropped
+        // strictly before the renderer's box is reclaimed, and neither is
+        // touched again — `self` is being destroyed.
+        unsafe {
+            ManuallyDrop::drop(&mut self.session);
+            drop(Box::from_raw(self.renderer.as_ptr()));
+        }
+    }
+}

--- a/crates/crust-capi/src/handles.rs
+++ b/crates/crust-capi/src/handles.rs
@@ -8,7 +8,6 @@ use crust_core::{
     AovBuffers, AovRequest, Buffer, Camera, LightList, ProgressiveRender, RenderSettings,
     Renderer, StepStatus, StopToken, WorldBuilder,
 };
-use std::mem::ManuallyDrop;
 use std::ptr::NonNull;
 
 /// The C `CrustStopToken`: a boxed clone-able engine token. The one type
@@ -61,29 +60,33 @@ impl SceneHandle {
 /// - The `Renderer` lives at a stable heap address: it is boxed once in
 ///   [`RendererHandle::new`] and freed only in `Drop`. The session's
 ///   `&'static Renderer` is a lie about *lifetime*, never about *address*.
-/// - No `&mut Renderer` is ever created while the session exists: this
-///   crate's C surface exposes no post-commit mutation (rebuild-everything
-///   semantics — an edit means a new scene handle and a new commit), and
-///   internally only shared `renderer()` references are taken.
-///   `ProgressiveRender::step` mutates the *session*, not the renderer.
+/// - No `&mut Renderer` is ever created **while a session exists**. The
+///   session and the renderer alternate: rendering holds a live session and
+///   takes only shared `renderer()` references (`ProgressiveRender::step`
+///   mutates the *session*, not the renderer); an in-place edit
+///   ([`RendererHandle::edit`]) first drops the session — ending its
+///   borrow — then forms the one `&mut Renderer`, then begins a fresh
+///   session before returning. Nothing can observe the handle mid-edit
+///   (handles are externally synchronized per the header contract).
 /// - `renderer` is a raw `NonNull`, not a `Box` field: materializing
 ///   `&mut RendererHandle` from the C pointer at every call would retag a
 ///   `Box`'s unique pointer and invalidate the session's outstanding
 ///   borrow under Stacked Borrows; raw pointers are never retagged.
-/// - Drop order is explicit: `Drop::drop` first drops the session (which
-///   merely releases its film — dropping a `&Renderer` field dereferences
-///   nothing), then frees the `Renderer`. `ManuallyDrop` makes that
-///   ordering independent of field order, and nothing can observe the
-///   handle between the two.
+/// - `session` is an `Option` dropped via `take()` in both `edit` and
+///   `Drop`, so the session is destroyed strictly before any `&mut
+///   Renderer` (edit) or the `Renderer`'s deallocation (drop), and a panic
+///   unwinding out of an edit (test builds only) can at worst leave the
+///   session `None` — never double-drop it.
 pub struct RendererHandle {
-    session: ManuallyDrop<ProgressiveRender<'static>>,
+    session: Option<ProgressiveRender<'static>>,
     renderer: NonNull<Renderer>,
     stop: StopToken,
     /// Reused `snapshot_into` target so per-step color reads do not
     /// allocate a frame each time.
     color_scratch: Buffer,
-    /// The four AOV planes, probed lazily on the first read (the committed
-    /// scene is immutable, so once is enough) and cached.
+    /// The four AOV planes, probed lazily on the first read and cached
+    /// until an edit invalidates them (they depend on the camera, the
+    /// resolution and the world alike).
     aovs: Option<AovBuffers>,
 }
 
@@ -97,7 +100,7 @@ impl RendererHandle {
         let session: ProgressiveRender<'static> =
             unsafe { renderer.as_ref() }.begin_progressive(true);
         Box::new(RendererHandle {
-            session: ManuallyDrop::new(session),
+            session: Some(session),
             renderer,
             stop,
             color_scratch: Buffer::new(width, height),
@@ -107,8 +110,38 @@ impl RendererHandle {
 
     fn renderer(&self) -> &Renderer {
         // SAFETY: the pointee is alive for the whole life of the handle
-        // (freed only in Drop) and only ever shared-borrowed.
+        // (freed only in Drop) and only ever shared-borrowed while a
+        // session exists (see the struct-level argument).
         unsafe { self.renderer.as_ref() }
+    }
+
+    fn session(&self) -> &ProgressiveRender<'static> {
+        self.session.as_ref().expect("session alive outside edit()")
+    }
+
+    /// The one place a `&mut Renderer` is ever formed. Tears the session
+    /// down (ending its borrow), applies the mutation, restarts sampling
+    /// from zero with a fresh session, and invalidates everything the old
+    /// scene/camera state had derived (AOV cache, scratch size). A stopped
+    /// token stays stopped, so callers may hand in a fresh one.
+    pub(crate) fn edit(&mut self, new_token: Option<StopToken>, apply: impl FnOnce(&mut Renderer)) {
+        drop(self.session.take());
+        // SAFETY: the session — the only borrower of the renderer — was
+        // just dropped, so this exclusive reference is unique. It ends
+        // before `begin_progressive` takes a new shared borrow below.
+        apply(unsafe { self.renderer.as_mut() });
+        if let Some(token) = new_token {
+            self.stop = token;
+        }
+        let (width, height) = self.renderer().settings.get_dimensions();
+        if (self.color_scratch.width(), self.color_scratch.height()) != (width, height) {
+            self.color_scratch = Buffer::new(width, height);
+        }
+        self.aovs = None;
+        // SAFETY: same as in `new` — the unbounded lifetime from
+        // `NonNull::as_ref` is what lets the session be stored as
+        // `'static`; the struct-level argument covers why that is sound.
+        self.session = Some(unsafe { self.renderer.as_ref() }.begin_progressive(true));
     }
 
     pub(crate) fn dimensions(&self) -> (u32, u32) {
@@ -122,7 +155,10 @@ impl RendererHandle {
     }
 
     pub(crate) fn step(&mut self, spp: u32) -> (CrustStepStatus, u32) {
-        match self.session.step(spp, None, Some(&self.stop)) {
+        // Field-precise borrows: the session advances while the (atomic)
+        // stop token is observed from the sibling field.
+        let session = self.session.as_mut().expect("session alive outside edit()");
+        match session.step(spp, None, Some(&self.stop)) {
             StepStatus::InProgress { spp_done } => (CrustStepStatus::InProgress, spp_done),
             StepStatus::Stopped { spp_done } => (CrustStepStatus::Stopped, spp_done),
             StepStatus::Complete { spp_done } => (CrustStepStatus::Complete, spp_done),
@@ -130,11 +166,11 @@ impl RendererHandle {
     }
 
     pub(crate) fn is_converged(&self) -> bool {
-        self.session.is_complete()
+        self.session().is_complete()
     }
 
     pub(crate) fn spp_done(&self) -> u32 {
-        self.session.spp_done()
+        self.session().spp_done()
     }
 
     fn ensure_aovs(&mut self) -> &AovBuffers {
@@ -155,7 +191,7 @@ impl RendererHandle {
     /// accumulators must never be memcpy'd as float data.
     pub(crate) fn read_color(&mut self, out: &mut [f32]) {
         self.ensure_aovs();
-        self.session.snapshot_into(&mut self.color_scratch);
+        self.session.as_ref().expect("session alive outside edit()").snapshot_into(&mut self.color_scratch);
         let alpha = self
             .aovs
             .as_ref()
@@ -205,11 +241,13 @@ impl RendererHandle {
 
 impl Drop for RendererHandle {
     fn drop(&mut self) {
-        // SAFETY: the session (which borrows the renderer) is dropped
-        // strictly before the renderer's box is reclaimed, and neither is
-        // touched again — `self` is being destroyed.
+        // The session (which borrows the renderer) is dropped strictly
+        // before the renderer's box is reclaimed, and neither is touched
+        // again — `self` is being destroyed.
+        drop(self.session.take());
+        // SAFETY: allocated by `Box::new` in `RendererHandle::new`, freed
+        // exactly once here, with no outstanding borrows (see above).
         unsafe {
-            ManuallyDrop::drop(&mut self.session);
             drop(Box::from_raw(self.renderer.as_ptr()));
         }
     }

--- a/crates/crust-capi/src/lib.rs
+++ b/crates/crust-capi/src/lib.rs
@@ -25,6 +25,7 @@
 //!   owning both. `handles::RendererHandle` documents how that
 //!   self-reference is kept sound.
 
+mod dome;
 mod geo_cache;
 mod handles;
 mod material;

--- a/crates/crust-capi/src/lib.rs
+++ b/crates/crust-capi/src/lib.rs
@@ -25,6 +25,7 @@
 //!   owning both. `handles::RendererHandle` documents how that
 //!   self-reference is kept sound.
 
+mod geo_cache;
 mod handles;
 mod material;
 mod render;
@@ -33,6 +34,7 @@ mod status;
 mod token;
 mod validate;
 
+pub use geo_cache::*;
 pub use handles::{RendererHandle, SceneHandle, TokenHandle};
 pub use material::*;
 pub use render::*;

--- a/crates/crust-capi/src/lib.rs
+++ b/crates/crust-capi/src/lib.rs
@@ -1,0 +1,41 @@
+//! crust-capi — the C ABI boundary for the hdCrust Hydra render delegate.
+//!
+//! This crate is the **one sanctioned exception** to the workspace's
+//! safe-Rust rule (see `docs/hydra_delegate.md`): `unsafe` here is confined
+//! to the `extern "C"` surface (raw-pointer arguments become checked
+//! references and slices), and to the pinned self-reference inside
+//! [`handles::RendererHandle`]. No engine crate depends on this crate, so
+//! the exception cannot leak inward.
+//!
+//! The C contract is `include/crust.h` — hand-written, and every
+//! `extern "C"` function below carries its C declaration in the doc comment
+//! directly above it. The C smoke test (`tests/smoke.c`, run by
+//! `scripts/test_capi_c.sh`) compiles that header with `-Wall -Wextra
+//! -Werror` and exercises every exported symbol; POD struct sizes are
+//! pinned by paired static asserts on both sides.
+//!
+//! Two facts shape the implementation:
+//!
+//! - The workspace builds release with `panic = "abort"`, so
+//!   `catch_unwind` cannot protect the boundary — **validation is the
+//!   safety net**. Every argument is checked before any engine call, and
+//!   the engine entry points used here are non-panicking on bad geometry
+//!   (the kernel skips out-of-range indices at commit).
+//! - `ProgressiveRender` borrows its `Renderer`; C wants one opaque handle
+//!   owning both. `handles::RendererHandle` documents how that
+//!   self-reference is kept sound.
+
+mod handles;
+mod material;
+mod render;
+mod scene;
+mod status;
+mod token;
+mod validate;
+
+pub use handles::{RendererHandle, SceneHandle, TokenHandle};
+pub use material::*;
+pub use render::*;
+pub use scene::*;
+pub use status::*;
+pub use token::*;

--- a/crates/crust-capi/src/lib.rs
+++ b/crates/crust-capi/src/lib.rs
@@ -7,6 +7,14 @@
 //! [`handles::RendererHandle`]. No engine crate depends on this crate, so
 //! the exception cannot leak inward.
 //!
+//! Every export that takes a raw pointer is `pub unsafe extern "C" fn`,
+//! with its preconditions in a `# Safety` section: validation here checks
+//! what CAN be checked (null, counts, finiteness), but validity, alignment,
+//! liveness and exclusivity are promises only the caller can make — a safe
+//! signature would let safe Rust cause UB with a dangling pointer. The
+//! `unsafe` marker is Rust-side only: symbol names and the C ABI are
+//! unchanged.
+//!
 //! The C contract is `include/crust.h` — hand-written, and every
 //! `extern "C"` function below carries its C declaration in the doc comment
 //! directly above it. The C smoke test (`tests/smoke.c`, run by

--- a/crates/crust-capi/src/material.rs
+++ b/crates/crust-capi/src/material.rs
@@ -17,11 +17,13 @@ pub struct CrustMaterial {
     pub opacity: f32,
     pub emission_color: [f32; 3],
     pub emission_luminance: f32,
+    pub coat_weight: f32,
+    pub coat_roughness: f32,
     pub thin_walled: i32,
     pub reserved: i32,
 }
 
-const _: () = assert!(size_of::<CrustMaterial>() == 56, "CrustMaterial ABI drift");
+const _: () = assert!(size_of::<CrustMaterial>() == 64, "CrustMaterial ABI drift");
 
 impl CrustMaterial {
     /// The header's default: the OpenPBR default surface (grey diffuse).
@@ -36,6 +38,8 @@ impl CrustMaterial {
             opacity: pbr.geometry_opacity,
             emission_color: pbr.emission_color.to_array(),
             emission_luminance: pbr.emission_luminance,
+            coat_weight: pbr.coat_weight,
+            coat_roughness: pbr.coat_roughness,
             thin_walled: pbr.geometry_thin_walled as i32,
             reserved: 0,
         }
@@ -55,6 +59,8 @@ impl CrustMaterial {
             self.emission_color[1],
             self.emission_color[2],
             self.emission_luminance,
+            self.coat_weight,
+            self.coat_roughness,
         ];
         if !all.iter().all(|v| v.is_finite()) {
             return Err(CrustStatus::InvalidArgument);
@@ -68,6 +74,8 @@ impl CrustMaterial {
         pbr.geometry_opacity = self.opacity.clamp(0.0, 1.0);
         pbr.emission_color = Vec3A::from_array(self.emission_color);
         pbr.emission_luminance = self.emission_luminance.max(0.0);
+        pbr.coat_weight = self.coat_weight.clamp(0.0, 1.0);
+        pbr.coat_roughness = self.coat_roughness.clamp(0.0, 1.0);
         pbr.geometry_thin_walled = self.thin_walled != 0;
         Ok(pbr)
     }

--- a/crates/crust-capi/src/material.rs
+++ b/crates/crust-capi/src/material.rs
@@ -83,9 +83,17 @@ impl CrustMaterial {
 }
 
 /// `void crust_material_default(CrustMaterial* out);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_material_default(out: *mut CrustMaterial) {
-    crate::validate::write_out(out, CrustMaterial::defaults());
+pub unsafe extern "C" fn crust_material_default(out: *mut CrustMaterial) {
+    // SAFETY: out-param per this export's `# Safety` contract.
+    unsafe { crate::validate::write_out(out, CrustMaterial::defaults()) };
 }
 
 /// Mirrors `CrustRenderSettings` in `crust.h`.
@@ -132,9 +140,18 @@ impl CrustRenderSettings {
 }
 
 /// `void crust_render_settings_default(CrustRenderSettings* out);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_render_settings_default(out: *mut CrustRenderSettings) {
-    crate::validate::write_out(
+pub unsafe extern "C" fn crust_render_settings_default(out: *mut CrustRenderSettings) {
+    // SAFETY: out-param per this export's `# Safety` contract.
+    unsafe {
+        crate::validate::write_out(
         out,
         CrustRenderSettings {
             width: 640,
@@ -145,5 +162,6 @@ pub extern "C" fn crust_render_settings_default(out: *mut CrustRenderSettings) {
             variance_threshold: 0.0,
             frame: 0,
         },
-    );
+    )
+    };
 }

--- a/crates/crust-capi/src/material.rs
+++ b/crates/crust-capi/src/material.rs
@@ -3,6 +3,7 @@
 use crate::status::CrustStatus;
 use crate::validate::{CResult, MAX_DIM};
 use crust_core::{OpenPBR, RenderSettings, Vec3A};
+use std::mem::size_of;
 
 /// Mirrors `CrustMaterial` in `crust.h`: a portable subset of the OpenPBR
 /// übershader. Field-for-field POD; size pinned on both sides.

--- a/crates/crust-capi/src/material.rs
+++ b/crates/crust-capi/src/material.rs
@@ -1,0 +1,140 @@
+//! The POD structs of the C contract and their mapping onto engine types.
+
+use crate::status::CrustStatus;
+use crate::validate::{CResult, MAX_DIM};
+use crust_core::{OpenPBR, RenderSettings, Vec3A};
+
+/// Mirrors `CrustMaterial` in `crust.h`: a portable subset of the OpenPBR
+/// übershader. Field-for-field POD; size pinned on both sides.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CrustMaterial {
+    pub base_color: [f32; 3],
+    pub metalness: f32,
+    pub roughness: f32,
+    pub ior: f32,
+    pub transmission: f32,
+    pub opacity: f32,
+    pub emission_color: [f32; 3],
+    pub emission_luminance: f32,
+    pub thin_walled: i32,
+    pub reserved: i32,
+}
+
+const _: () = assert!(size_of::<CrustMaterial>() == 56, "CrustMaterial ABI drift");
+
+impl CrustMaterial {
+    /// The header's default: the OpenPBR default surface (grey diffuse).
+    fn defaults() -> Self {
+        let pbr = OpenPBR::default();
+        CrustMaterial {
+            base_color: pbr.base_color.to_array(),
+            metalness: pbr.base_metalness,
+            roughness: pbr.specular_roughness,
+            ior: pbr.specular_ior,
+            transmission: pbr.transmission_weight,
+            opacity: pbr.geometry_opacity,
+            emission_color: pbr.emission_color.to_array(),
+            emission_luminance: pbr.emission_luminance,
+            thin_walled: pbr.geometry_thin_walled as i32,
+            reserved: 0,
+        }
+    }
+
+    pub(crate) fn to_openpbr(self) -> CResult<OpenPBR> {
+        let all = [
+            self.base_color[0],
+            self.base_color[1],
+            self.base_color[2],
+            self.metalness,
+            self.roughness,
+            self.ior,
+            self.transmission,
+            self.opacity,
+            self.emission_color[0],
+            self.emission_color[1],
+            self.emission_color[2],
+            self.emission_luminance,
+        ];
+        if !all.iter().all(|v| v.is_finite()) {
+            return Err(CrustStatus::InvalidArgument);
+        }
+        let mut pbr = OpenPBR::default();
+        pbr.base_color = Vec3A::from_array(self.base_color);
+        pbr.base_metalness = self.metalness.clamp(0.0, 1.0);
+        pbr.specular_roughness = self.roughness.clamp(0.0, 1.0);
+        pbr.specular_ior = self.ior.max(1.0);
+        pbr.transmission_weight = self.transmission.clamp(0.0, 1.0);
+        pbr.geometry_opacity = self.opacity.clamp(0.0, 1.0);
+        pbr.emission_color = Vec3A::from_array(self.emission_color);
+        pbr.emission_luminance = self.emission_luminance.max(0.0);
+        pbr.geometry_thin_walled = self.thin_walled != 0;
+        Ok(pbr)
+    }
+}
+
+/// `void crust_material_default(CrustMaterial* out);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_material_default(out: *mut CrustMaterial) {
+    crate::validate::write_out(out, CrustMaterial::defaults());
+}
+
+/// Mirrors `CrustRenderSettings` in `crust.h`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CrustRenderSettings {
+    pub width: u32,
+    pub height: u32,
+    pub samples_per_pixel: u32,
+    pub max_depth: u32,
+    pub min_samples_per_pixel: u32,
+    pub variance_threshold: f32,
+    pub frame: u32,
+}
+
+const _: () = assert!(
+    size_of::<CrustRenderSettings>() == 28,
+    "CrustRenderSettings ABI drift"
+);
+
+impl CrustRenderSettings {
+    pub(crate) fn to_settings(self) -> CResult<RenderSettings> {
+        if self.width == 0
+            || self.height == 0
+            || self.width > MAX_DIM
+            || self.height > MAX_DIM
+            || self.samples_per_pixel == 0
+            || self.max_depth == 0
+            || !self.variance_threshold.is_finite()
+            || self.variance_threshold < 0.0
+        {
+            return Err(CrustStatus::InvalidArgument);
+        }
+        Ok(RenderSettings::new(
+            self.samples_per_pixel,
+            self.max_depth,
+            self.width as usize,
+            self.height as usize,
+            self.min_samples_per_pixel,
+            self.variance_threshold,
+            self.frame as isize,
+        ))
+    }
+}
+
+/// `void crust_render_settings_default(CrustRenderSettings* out);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_render_settings_default(out: *mut CrustRenderSettings) {
+    crate::validate::write_out(
+        out,
+        CrustRenderSettings {
+            width: 640,
+            height: 360,
+            samples_per_pixel: 64,
+            max_depth: 8,
+            min_samples_per_pixel: 0,
+            variance_threshold: 0.0,
+            frame: 0,
+        },
+    );
+}

--- a/crates/crust-capi/src/render.rs
+++ b/crates/crust-capi/src/render.rs
@@ -1,8 +1,11 @@
-//! The renderer entry points: stepping and framebuffer/AOV reads.
+//! The renderer entry points: stepping, framebuffer/AOV reads, and the
+//! in-place edits that restart sampling without touching the world.
 
-use crate::handles::RendererHandle;
+use crate::handles::{RendererHandle, TokenHandle};
+use crate::material::CrustRenderSettings;
 use crate::status::{CrustStatus, CrustStepStatus};
-use crate::validate::{CResult, require, require_mut, slice_mut, write_out};
+use crate::validate::{CResult, require, require_mut, slice, slice_mut, write_out};
+use crust_core::{Camera, Mat4};
 
 /// `CrustStatus crust_renderer_step(CrustRenderer*, uint32_t spp,
 ///     CrustStepStatus* out_status, uint32_t* out_spp_done);`
@@ -149,6 +152,74 @@ pub extern "C" fn crust_renderer_read_aov_alpha(
     capacity_px: usize,
 ) -> CrustStatus {
     read_into(renderer, alpha, capacity_px, 1, RendererHandle::read_alpha)
+}
+
+fn read_mat4(ptr: *const f64) -> CResult<Mat4> {
+    let m = slice(ptr, 16)?;
+    let mut cols = [0.0f32; 16];
+    for (dst, src) in cols.iter_mut().zip(m) {
+        if !src.is_finite() {
+            return Err(CrustStatus::InvalidArgument);
+        }
+        *dst = *src as f32;
+    }
+    Ok(Mat4::from_cols_array(&cols))
+}
+
+/// `CrustStatus crust_renderer_update_camera(CrustRenderer*,
+///     const double view[16], const double proj[16], float aperture,
+///     float focus_distance, const CrustStopToken* token_or_null);`
+///
+/// Restarts sampling from zero with the new camera — no world/BVH work at
+/// all, which is what makes a viewport orbit cheap. The film cannot survive
+/// a camera change, so progress resets; a stopped token stays stopped, so
+/// pass a fresh one to make the restarted render cancellable.
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_renderer_update_camera(
+    renderer: *mut RendererHandle,
+    view: *const f64,
+    proj: *const f64,
+    aperture: f32,
+    focus_distance: f32,
+    token_or_null: *const TokenHandle,
+) -> CrustStatus {
+    let result = (|| -> CResult<()> {
+        let handle = require_mut(renderer)?;
+        let view = read_mat4(view)?;
+        let proj = read_mat4(proj)?;
+        if !(aperture.is_finite() && aperture >= 0.0) {
+            return Err(CrustStatus::InvalidArgument);
+        }
+        let camera = Camera::from_view_projection(view, proj, aperture, focus_distance)
+            .map_err(|_| CrustStatus::InvalidCamera)?;
+        // SAFETY: read-only access to a caller-owned token, per the header.
+        let token = unsafe { token_or_null.as_ref() }.map(|t| t.0.clone());
+        handle.edit(token, |r| r.camera = camera);
+        Ok(())
+    })();
+    result.err().unwrap_or(CrustStatus::Ok)
+}
+
+/// `CrustStatus crust_renderer_update_settings(CrustRenderer*,
+///     const CrustRenderSettings*, const CrustStopToken* token_or_null);`
+///
+/// As `crust_renderer_update_camera`, for the render settings (resolution,
+/// budget, depth, adaptive stop). Sampling restarts from zero.
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_renderer_update_settings(
+    renderer: *mut RendererHandle,
+    settings: *const CrustRenderSettings,
+    token_or_null: *const TokenHandle,
+) -> CrustStatus {
+    let result = (|| -> CResult<()> {
+        let handle = require_mut(renderer)?;
+        let settings = require(settings)?.to_settings()?;
+        // SAFETY: read-only access to a caller-owned token, per the header.
+        let token = unsafe { token_or_null.as_ref() }.map(|t| t.0.clone());
+        handle.edit(token, |r| r.settings = settings);
+        Ok(())
+    })();
+    result.err().unwrap_or(CrustStatus::Ok)
 }
 
 /// `void crust_renderer_destroy(CrustRenderer*);`

--- a/crates/crust-capi/src/render.rs
+++ b/crates/crust-capi/src/render.rs
@@ -9,15 +9,22 @@ use crust_core::{Camera, Mat4};
 
 /// `CrustStatus crust_renderer_step(CrustRenderer*, uint32_t spp,
 ///     CrustStepStatus* out_status, uint32_t* out_spp_done);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_renderer_step(
+pub unsafe extern "C" fn crust_renderer_step(
     renderer: *mut RendererHandle,
     spp: u32,
     out_status: *mut CrustStepStatus,
     out_spp_done: *mut u32,
 ) -> CrustStatus {
     let result = (|| -> CResult<(CrustStepStatus, u32)> {
-        let handle = require_mut(renderer)?;
+        let handle = unsafe { require_mut(renderer) }?;
         if spp == 0 {
             return Err(CrustStatus::InvalidArgument);
         }
@@ -25,8 +32,8 @@ pub extern "C" fn crust_renderer_step(
     })();
     match result {
         Ok((status, spp_done)) => {
-            write_out(out_status, status);
-            write_out(out_spp_done, spp_done);
+            unsafe { write_out(out_status, status) };
+            unsafe { write_out(out_spp_done, spp_done) };
             CrustStatus::Ok
         }
         Err(status) => status,
@@ -34,33 +41,59 @@ pub extern "C" fn crust_renderer_step(
 }
 
 /// `bool crust_renderer_is_converged(const CrustRenderer*);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_renderer_is_converged(renderer: *const RendererHandle) -> bool {
-    require(renderer).map(|h| h.is_converged()).unwrap_or(false)
+pub unsafe extern "C" fn crust_renderer_is_converged(renderer: *const RendererHandle) -> bool {
+    unsafe { require(renderer) }.map(|h| h.is_converged()).unwrap_or(false)
 }
 
 /// `uint32_t crust_renderer_spp_done(const CrustRenderer*);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_renderer_spp_done(renderer: *const RendererHandle) -> u32 {
-    require(renderer).map(|h| h.spp_done()).unwrap_or(0)
+pub unsafe extern "C" fn crust_renderer_spp_done(renderer: *const RendererHandle) -> u32 {
+    unsafe { require(renderer) }.map(|h| h.spp_done()).unwrap_or(0)
 }
 
 /// `void crust_renderer_get_dimensions(const CrustRenderer*,
 ///     uint32_t* width, uint32_t* height);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_renderer_get_dimensions(
+pub unsafe extern "C" fn crust_renderer_get_dimensions(
     renderer: *const RendererHandle,
     width: *mut u32,
     height: *mut u32,
 ) {
-    let (w, h) = require(renderer).map(|r| r.dimensions()).unwrap_or((0, 0));
-    write_out(width, w);
-    write_out(height, h);
+    let (w, h) = unsafe { require(renderer) }.map(|r| r.dimensions()).unwrap_or((0, 0));
+    unsafe { write_out(width, w) };
+    unsafe { write_out(height, h) };
 }
 
 /// Shared shape of the read entry points: capacity check, then a bounded
 /// output slice of `stride` elements per pixel.
-fn read_into<F>(
+///
+/// # Safety
+/// Carries [`crate::validate::require_mut`]'s contract for `renderer` and
+/// [`crate::validate::slice_mut`]'s for `out` with `capacity_px * stride`
+/// elements.
+unsafe fn read_into<F>(
     renderer: *mut RendererHandle,
     out: *mut f32,
     capacity_px: usize,
@@ -71,7 +104,7 @@ where
     F: FnOnce(&mut RendererHandle, &mut [f32]),
 {
     let result = (|| -> CResult<()> {
-        let handle = require_mut(renderer)?;
+        let handle = unsafe { require_mut(renderer) }?;
         let pixels = handle.pixel_count();
         if capacity_px < pixels {
             return Err(CrustStatus::BufferTooSmall);
@@ -79,7 +112,7 @@ where
         let len = pixels
             .checked_mul(stride)
             .ok_or(CrustStatus::InvalidArgument)?;
-        let out = slice_mut(out, len)?;
+        let out = unsafe { slice_mut(out, len) }?;
         fill(handle, out);
         Ok(())
     })();
@@ -88,47 +121,78 @@ where
 
 /// `CrustStatus crust_renderer_read_color(CrustRenderer*, float* rgba,
 ///     size_t capacity_px);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_renderer_read_color(
+pub unsafe extern "C" fn crust_renderer_read_color(
     renderer: *mut RendererHandle,
     rgba: *mut f32,
     capacity_px: usize,
 ) -> CrustStatus {
-    read_into(renderer, rgba, capacity_px, 4, RendererHandle::read_color)
+    // SAFETY: forwarded from this export's `# Safety` contract.
+    unsafe { read_into(renderer, rgba, capacity_px, 4, RendererHandle::read_color) }
 }
 
 /// `CrustStatus crust_renderer_read_aov_depth(CrustRenderer*, float* depth,
 ///     size_t capacity_px);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_renderer_read_aov_depth(
+pub unsafe extern "C" fn crust_renderer_read_aov_depth(
     renderer: *mut RendererHandle,
     depth: *mut f32,
     capacity_px: usize,
 ) -> CrustStatus {
-    read_into(renderer, depth, capacity_px, 1, RendererHandle::read_depth)
+    // SAFETY: forwarded from this export's `# Safety` contract.
+    unsafe { read_into(renderer, depth, capacity_px, 1, RendererHandle::read_depth) }
 }
 
 /// `CrustStatus crust_renderer_read_aov_normal(CrustRenderer*, float* xyz,
 ///     size_t capacity_px);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_renderer_read_aov_normal(
+pub unsafe extern "C" fn crust_renderer_read_aov_normal(
     renderer: *mut RendererHandle,
     xyz: *mut f32,
     capacity_px: usize,
 ) -> CrustStatus {
-    read_into(renderer, xyz, capacity_px, 3, RendererHandle::read_normal)
+    // SAFETY: forwarded from this export's `# Safety` contract.
+    unsafe { read_into(renderer, xyz, capacity_px, 3, RendererHandle::read_normal) }
 }
 
 /// `CrustStatus crust_renderer_read_aov_id(CrustRenderer*, uint32_t* geom_prim,
 ///     size_t capacity_px);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_renderer_read_aov_id(
+pub unsafe extern "C" fn crust_renderer_read_aov_id(
     renderer: *mut RendererHandle,
     geom_prim: *mut u32,
     capacity_px: usize,
 ) -> CrustStatus {
     let result = (|| -> CResult<()> {
-        let handle = require_mut(renderer)?;
+        let handle = unsafe { require_mut(renderer) }?;
         let pixels = handle.pixel_count();
         if capacity_px < pixels {
             return Err(CrustStatus::BufferTooSmall);
@@ -136,7 +200,7 @@ pub extern "C" fn crust_renderer_read_aov_id(
         let len = pixels
             .checked_mul(2)
             .ok_or(CrustStatus::InvalidArgument)?;
-        let out = slice_mut(geom_prim, len)?;
+        let out = unsafe { slice_mut(geom_prim, len) }?;
         handle.read_id(out);
         Ok(())
     })();
@@ -145,17 +209,27 @@ pub extern "C" fn crust_renderer_read_aov_id(
 
 /// `CrustStatus crust_renderer_read_aov_alpha(CrustRenderer*, float* alpha,
 ///     size_t capacity_px);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_renderer_read_aov_alpha(
+pub unsafe extern "C" fn crust_renderer_read_aov_alpha(
     renderer: *mut RendererHandle,
     alpha: *mut f32,
     capacity_px: usize,
 ) -> CrustStatus {
-    read_into(renderer, alpha, capacity_px, 1, RendererHandle::read_alpha)
+    // SAFETY: forwarded from this export's `# Safety` contract.
+    unsafe { read_into(renderer, alpha, capacity_px, 1, RendererHandle::read_alpha) }
 }
 
-fn read_mat4(ptr: *const f64) -> CResult<Mat4> {
-    let m = slice(ptr, 16)?;
+/// # Safety
+/// Carries [`crate::validate::slice`]'s contract for 16 doubles.
+unsafe fn read_mat4(ptr: *const f64) -> CResult<Mat4> {
+    let m = unsafe { slice(ptr, 16) }?;
     let mut cols = [0.0f32; 16];
     for (dst, src) in cols.iter_mut().zip(m) {
         if !src.is_finite() {
@@ -174,8 +248,15 @@ fn read_mat4(ptr: *const f64) -> CResult<Mat4> {
 /// all, which is what makes a viewport orbit cheap. The film cannot survive
 /// a camera change, so progress resets; a stopped token stays stopped, so
 /// pass a fresh one to make the restarted render cancellable.
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_renderer_update_camera(
+pub unsafe extern "C" fn crust_renderer_update_camera(
     renderer: *mut RendererHandle,
     view: *const f64,
     proj: *const f64,
@@ -184,9 +265,9 @@ pub extern "C" fn crust_renderer_update_camera(
     token_or_null: *const TokenHandle,
 ) -> CrustStatus {
     let result = (|| -> CResult<()> {
-        let handle = require_mut(renderer)?;
-        let view = read_mat4(view)?;
-        let proj = read_mat4(proj)?;
+        let handle = unsafe { require_mut(renderer) }?;
+        let view = unsafe { read_mat4(view) }?;
+        let proj = unsafe { read_mat4(proj) }?;
         if !(aperture.is_finite() && aperture >= 0.0) {
             return Err(CrustStatus::InvalidArgument);
         }
@@ -205,15 +286,22 @@ pub extern "C" fn crust_renderer_update_camera(
 ///
 /// As `crust_renderer_update_camera`, for the render settings (resolution,
 /// budget, depth, adaptive stop). Sampling restarts from zero.
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_renderer_update_settings(
+pub unsafe extern "C" fn crust_renderer_update_settings(
     renderer: *mut RendererHandle,
     settings: *const CrustRenderSettings,
     token_or_null: *const TokenHandle,
 ) -> CrustStatus {
     let result = (|| -> CResult<()> {
-        let handle = require_mut(renderer)?;
-        let settings = require(settings)?.to_settings()?;
+        let handle = unsafe { require_mut(renderer) }?;
+        let settings = unsafe { require(settings) }?.to_settings()?;
         // SAFETY: read-only access to a caller-owned token, per the header.
         let token = unsafe { token_or_null.as_ref() }.map(|t| t.0.clone());
         handle.edit(token, |r| r.settings = settings);
@@ -223,8 +311,15 @@ pub extern "C" fn crust_renderer_update_settings(
 }
 
 /// `void crust_renderer_destroy(CrustRenderer*);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_renderer_destroy(renderer: *mut RendererHandle) {
+pub unsafe extern "C" fn crust_renderer_destroy(renderer: *mut RendererHandle) {
     if !renderer.is_null() {
         // SAFETY: created by `crust_scene_commit`; use after destroy is
         // forbidden by the header contract. RendererHandle's Drop releases

--- a/crates/crust-capi/src/render.rs
+++ b/crates/crust-capi/src/render.rs
@@ -1,0 +1,163 @@
+//! The renderer entry points: stepping and framebuffer/AOV reads.
+
+use crate::handles::RendererHandle;
+use crate::status::{CrustStatus, CrustStepStatus};
+use crate::validate::{CResult, require, require_mut, slice_mut, write_out};
+
+/// `CrustStatus crust_renderer_step(CrustRenderer*, uint32_t spp,
+///     CrustStepStatus* out_status, uint32_t* out_spp_done);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_renderer_step(
+    renderer: *mut RendererHandle,
+    spp: u32,
+    out_status: *mut CrustStepStatus,
+    out_spp_done: *mut u32,
+) -> CrustStatus {
+    let result = (|| -> CResult<(CrustStepStatus, u32)> {
+        let handle = require_mut(renderer)?;
+        if spp == 0 {
+            return Err(CrustStatus::InvalidArgument);
+        }
+        Ok(handle.step(spp))
+    })();
+    match result {
+        Ok((status, spp_done)) => {
+            write_out(out_status, status);
+            write_out(out_spp_done, spp_done);
+            CrustStatus::Ok
+        }
+        Err(status) => status,
+    }
+}
+
+/// `bool crust_renderer_is_converged(const CrustRenderer*);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_renderer_is_converged(renderer: *const RendererHandle) -> bool {
+    require(renderer).map(|h| h.is_converged()).unwrap_or(false)
+}
+
+/// `uint32_t crust_renderer_spp_done(const CrustRenderer*);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_renderer_spp_done(renderer: *const RendererHandle) -> u32 {
+    require(renderer).map(|h| h.spp_done()).unwrap_or(0)
+}
+
+/// `void crust_renderer_get_dimensions(const CrustRenderer*,
+///     uint32_t* width, uint32_t* height);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_renderer_get_dimensions(
+    renderer: *const RendererHandle,
+    width: *mut u32,
+    height: *mut u32,
+) {
+    let (w, h) = require(renderer).map(|r| r.dimensions()).unwrap_or((0, 0));
+    write_out(width, w);
+    write_out(height, h);
+}
+
+/// Shared shape of the read entry points: capacity check, then a bounded
+/// output slice of `stride` elements per pixel.
+fn read_into<F>(
+    renderer: *mut RendererHandle,
+    out: *mut f32,
+    capacity_px: usize,
+    stride: usize,
+    fill: F,
+) -> CrustStatus
+where
+    F: FnOnce(&mut RendererHandle, &mut [f32]),
+{
+    let result = (|| -> CResult<()> {
+        let handle = require_mut(renderer)?;
+        let pixels = handle.pixel_count();
+        if capacity_px < pixels {
+            return Err(CrustStatus::BufferTooSmall);
+        }
+        let len = pixels
+            .checked_mul(stride)
+            .ok_or(CrustStatus::InvalidArgument)?;
+        let out = slice_mut(out, len)?;
+        fill(handle, out);
+        Ok(())
+    })();
+    result.err().unwrap_or(CrustStatus::Ok)
+}
+
+/// `CrustStatus crust_renderer_read_color(CrustRenderer*, float* rgba,
+///     size_t capacity_px);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_renderer_read_color(
+    renderer: *mut RendererHandle,
+    rgba: *mut f32,
+    capacity_px: usize,
+) -> CrustStatus {
+    read_into(renderer, rgba, capacity_px, 4, RendererHandle::read_color)
+}
+
+/// `CrustStatus crust_renderer_read_aov_depth(CrustRenderer*, float* depth,
+///     size_t capacity_px);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_renderer_read_aov_depth(
+    renderer: *mut RendererHandle,
+    depth: *mut f32,
+    capacity_px: usize,
+) -> CrustStatus {
+    read_into(renderer, depth, capacity_px, 1, RendererHandle::read_depth)
+}
+
+/// `CrustStatus crust_renderer_read_aov_normal(CrustRenderer*, float* xyz,
+///     size_t capacity_px);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_renderer_read_aov_normal(
+    renderer: *mut RendererHandle,
+    xyz: *mut f32,
+    capacity_px: usize,
+) -> CrustStatus {
+    read_into(renderer, xyz, capacity_px, 3, RendererHandle::read_normal)
+}
+
+/// `CrustStatus crust_renderer_read_aov_id(CrustRenderer*, uint32_t* geom_prim,
+///     size_t capacity_px);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_renderer_read_aov_id(
+    renderer: *mut RendererHandle,
+    geom_prim: *mut u32,
+    capacity_px: usize,
+) -> CrustStatus {
+    let result = (|| -> CResult<()> {
+        let handle = require_mut(renderer)?;
+        let pixels = handle.pixel_count();
+        if capacity_px < pixels {
+            return Err(CrustStatus::BufferTooSmall);
+        }
+        let len = pixels
+            .checked_mul(2)
+            .ok_or(CrustStatus::InvalidArgument)?;
+        let out = slice_mut(geom_prim, len)?;
+        handle.read_id(out);
+        Ok(())
+    })();
+    result.err().unwrap_or(CrustStatus::Ok)
+}
+
+/// `CrustStatus crust_renderer_read_aov_alpha(CrustRenderer*, float* alpha,
+///     size_t capacity_px);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_renderer_read_aov_alpha(
+    renderer: *mut RendererHandle,
+    alpha: *mut f32,
+    capacity_px: usize,
+) -> CrustStatus {
+    read_into(renderer, alpha, capacity_px, 1, RendererHandle::read_alpha)
+}
+
+/// `void crust_renderer_destroy(CrustRenderer*);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_renderer_destroy(renderer: *mut RendererHandle) {
+    if !renderer.is_null() {
+        // SAFETY: created by `crust_scene_commit`; use after destroy is
+        // forbidden by the header contract. RendererHandle's Drop releases
+        // the session before the Renderer (see handles.rs).
+        drop(unsafe { Box::from_raw(renderer) });
+    }
+}

--- a/crates/crust-capi/src/scene.rs
+++ b/crates/crust-capi/src/scene.rs
@@ -43,6 +43,39 @@ fn read_vec3s(ptr: *const f32, count: usize) -> CResult<Vec<Vec3A>> {
         .collect())
 }
 
+/// Validates and reads a triangle mesh's arrays into kernel form — the
+/// shared front half of `crust_scene_add_mesh` and
+/// `crust_scene_add_instance`.
+fn read_mesh_geometry(
+    positions: *const f32,
+    vertex_count: usize,
+    tri_indices: *const u32,
+    triangle_count: usize,
+    normals_or_null: *const f32,
+) -> CResult<Geometry> {
+    if vertex_count > u32::MAX as usize {
+        return Err(CrustStatus::InvalidArgument);
+    }
+    let vertices = read_vec3s(positions, vertex_count)?;
+    let index_len = triangle_count
+        .checked_mul(3)
+        .ok_or(CrustStatus::InvalidArgument)?;
+    let indices: Vec<[u32; 3]> = slice(tri_indices, index_len)?
+        .chunks_exact(3)
+        .map(|c| [c[0], c[1], c[2]])
+        .collect();
+    let normals = if normals_or_null.is_null() {
+        None
+    } else {
+        Some(read_vec3s(normals_or_null, vertex_count)?)
+    };
+    Ok(Geometry::TriangleMesh {
+        vertices,
+        indices,
+        normals,
+    })
+}
+
 /// `CrustStatus crust_scene_add_mesh(CrustScene*, const float* positions,
 ///     size_t vertex_count, const uint32_t* tri_indices,
 ///     size_t triangle_count, const float* normals_or_null,
@@ -61,28 +94,94 @@ pub extern "C" fn crust_scene_add_mesh(
     let result = (|| -> CResult<u32> {
         let handle = require_mut(scene)?;
         let pbr = require(material)?.to_openpbr()?;
-        if vertex_count > u32::MAX as usize {
+        let geometry = read_mesh_geometry(
+            positions,
+            vertex_count,
+            tri_indices,
+            triangle_count,
+            normals_or_null,
+        )?;
+        let builder = handle.builder_mut()?;
+        Ok(builder.attach(geometry, Arc::new(pbr)))
+    })();
+    match result {
+        Ok(id) => {
+            write_out(out_geom_id, id);
+            CrustStatus::Ok
+        }
+        Err(status) => status,
+    }
+}
+
+/// `CrustStatus crust_scene_add_instance(CrustScene*, CrustGeoCache*,
+///     uint64_t key, uint32_t version,
+///     const float* positions_or_null, size_t vertex_count,
+///     const uint32_t* tri_indices_or_null, size_t triangle_count,
+///     const float* normals_or_null, const double xform[16],
+///     const CrustMaterial*, uint32_t* out_geom_id);`
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn crust_scene_add_instance(
+    scene: *mut SceneHandle,
+    cache: *mut crate::geo_cache::GeoCacheHandle,
+    key: u64,
+    version: u32,
+    positions_or_null: *const f32,
+    vertex_count: usize,
+    tri_indices_or_null: *const u32,
+    triangle_count: usize,
+    normals_or_null: *const f32,
+    xform: *const f64,
+    material: *const CrustMaterial,
+    out_geom_id: *mut u32,
+) -> CrustStatus {
+    let result = (|| -> CResult<u32> {
+        let handle = require_mut(scene)?;
+        let cache = require(cache.cast_const())?;
+        let pbr = require(material)?.to_openpbr()?;
+
+        // The placement, validated before any geometry work: the kernel's
+        // instance path requires an invertible transform (a zero scale is
+        // the common "hide this" idiom — the caller skips those).
+        let m = slice(xform, 16)?;
+        if !m.iter().all(|v| v.is_finite()) {
             return Err(CrustStatus::InvalidArgument);
         }
-        let vertices = read_vec3s(positions, vertex_count)?;
-        let index_len = triangle_count
-            .checked_mul(3)
-            .ok_or(CrustStatus::InvalidArgument)?;
-        let indices: Vec<[u32; 3]> = slice(tri_indices, index_len)?
-            .chunks_exact(3)
-            .map(|c| [c[0], c[1], c[2]])
-            .collect();
-        let normals = if normals_or_null.is_null() {
-            None
-        } else {
-            Some(read_vec3s(normals_or_null, vertex_count)?)
+        let mut cols = [0.0f64; 16];
+        cols.copy_from_slice(m);
+        let placement64 = glam::DMat4::from_cols_array(&cols);
+        if placement64.determinant().abs() < 1e-12 {
+            return Err(CrustStatus::InvalidArgument);
+        }
+        let placement = glam::Affine3A::from_mat4(placement64.as_mat4());
+
+        // The prototype: cached committed scene, or built from the arrays
+        // on a miss. On a hit the arrays are never read (they may be NULL —
+        // that is the whole point of `crust_geo_cache_contains`).
+        let proto = match cache.lookup(key, version) {
+            Some(scene) => scene,
+            None => {
+                let geometry = read_mesh_geometry(
+                    positions_or_null,
+                    vertex_count,
+                    tri_indices_or_null,
+                    triangle_count,
+                    normals_or_null,
+                )?;
+                let mut inner = crust_core::rt::SceneBuilder::new();
+                inner.attach(geometry);
+                let scene = Arc::new(inner.commit());
+                cache.insert(key, version, scene.clone());
+                scene
+            }
         };
+
         let builder = handle.builder_mut()?;
         Ok(builder.attach(
-            Geometry::TriangleMesh {
-                vertices,
-                indices,
-                normals,
+            crust_core::rt::Geometry::Instance {
+                scene: proto,
+                transform: placement,
+                transform_end: None,
             },
             Arc::new(pbr),
         ))

--- a/crates/crust-capi/src/scene.rs
+++ b/crates/crust-capi/src/scene.rs
@@ -19,8 +19,15 @@ pub extern "C" fn crust_scene_create() -> *mut SceneHandle {
 }
 
 /// `void crust_scene_destroy(CrustScene* scene);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_scene_destroy(scene: *mut SceneHandle) {
+pub unsafe extern "C" fn crust_scene_destroy(scene: *mut SceneHandle) {
     if !scene.is_null() {
         // SAFETY: created by `crust_scene_create`; use after destroy is
         // forbidden by the header contract.
@@ -29,11 +36,15 @@ pub extern "C" fn crust_scene_destroy(scene: *mut SceneHandle) {
 }
 
 /// Reads a required point/vector array (`3 * count` floats, all finite).
-fn read_vec3s(ptr: *const f32, count: usize) -> CResult<Vec<Vec3A>> {
+///
+/// # Safety
+/// Carries [`crate::validate::slice`]'s contract for `ptr` with
+/// `3 * count` elements.
+unsafe fn read_vec3s(ptr: *const f32, count: usize) -> CResult<Vec<Vec3A>> {
     let len = count
         .checked_mul(3)
         .ok_or(CrustStatus::InvalidArgument)?;
-    let flat = slice(ptr, len)?;
+    let flat = unsafe { slice(ptr, len) }?;
     if !flat.iter().all(|v| v.is_finite()) {
         return Err(CrustStatus::InvalidArgument);
     }
@@ -46,7 +57,12 @@ fn read_vec3s(ptr: *const f32, count: usize) -> CResult<Vec<Vec3A>> {
 /// Validates and reads a triangle mesh's arrays into kernel form — the
 /// shared front half of `crust_scene_add_mesh` and
 /// `crust_scene_add_instance`.
-fn read_mesh_geometry(
+///
+/// # Safety
+/// Carries [`crate::validate::slice`]'s contract for each array:
+/// `3 * vertex_count` floats, `3 * triangle_count` indices, and (when
+/// non-NULL) `3 * vertex_count` normal floats.
+unsafe fn read_mesh_geometry(
     positions: *const f32,
     vertex_count: usize,
     tri_indices: *const u32,
@@ -56,18 +72,18 @@ fn read_mesh_geometry(
     if vertex_count > u32::MAX as usize {
         return Err(CrustStatus::InvalidArgument);
     }
-    let vertices = read_vec3s(positions, vertex_count)?;
+    let vertices = unsafe { read_vec3s(positions, vertex_count) }?;
     let index_len = triangle_count
         .checked_mul(3)
         .ok_or(CrustStatus::InvalidArgument)?;
-    let indices: Vec<[u32; 3]> = slice(tri_indices, index_len)?
+    let indices: Vec<[u32; 3]> = unsafe { slice(tri_indices, index_len) }?
         .chunks_exact(3)
         .map(|c| [c[0], c[1], c[2]])
         .collect();
     let normals = if normals_or_null.is_null() {
         None
     } else {
-        Some(read_vec3s(normals_or_null, vertex_count)?)
+        Some(unsafe { read_vec3s(normals_or_null, vertex_count) }?)
     };
     Ok(Geometry::TriangleMesh {
         vertices,
@@ -80,8 +96,15 @@ fn read_mesh_geometry(
 ///     size_t vertex_count, const uint32_t* tri_indices,
 ///     size_t triangle_count, const float* normals_or_null,
 ///     const CrustMaterial*, uint32_t* out_geom_id);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_scene_add_mesh(
+pub unsafe extern "C" fn crust_scene_add_mesh(
     scene: *mut SceneHandle,
     positions: *const f32,
     vertex_count: usize,
@@ -92,21 +115,24 @@ pub extern "C" fn crust_scene_add_mesh(
     out_geom_id: *mut u32,
 ) -> CrustStatus {
     let result = (|| -> CResult<u32> {
-        let handle = require_mut(scene)?;
-        let pbr = require(material)?.to_openpbr()?;
-        let geometry = read_mesh_geometry(
-            positions,
-            vertex_count,
-            tri_indices,
-            triangle_count,
-            normals_or_null,
-        )?;
+        let handle = unsafe { require_mut(scene) }?;
+        let pbr = unsafe { require(material) }?.to_openpbr()?;
+        // SAFETY: forwarded from this export's `# Safety` contract.
+        let geometry = unsafe {
+            read_mesh_geometry(
+                positions,
+                vertex_count,
+                tri_indices,
+                triangle_count,
+                normals_or_null,
+            )
+        }?;
         let builder = handle.builder_mut()?;
         Ok(builder.attach(geometry, Arc::new(pbr)))
     })();
     match result {
         Ok(id) => {
-            write_out(out_geom_id, id);
+            unsafe { write_out(out_geom_id, id) };
             CrustStatus::Ok
         }
         Err(status) => status,
@@ -119,9 +145,16 @@ pub extern "C" fn crust_scene_add_mesh(
 ///     const uint32_t* tri_indices_or_null, size_t triangle_count,
 ///     const float* normals_or_null, const double xform[16],
 ///     const CrustMaterial*, uint32_t* out_geom_id);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
 #[allow(clippy::too_many_arguments)]
-pub extern "C" fn crust_scene_add_instance(
+pub unsafe extern "C" fn crust_scene_add_instance(
     scene: *mut SceneHandle,
     cache: *mut crate::geo_cache::GeoCacheHandle,
     key: u64,
@@ -136,14 +169,14 @@ pub extern "C" fn crust_scene_add_instance(
     out_geom_id: *mut u32,
 ) -> CrustStatus {
     let result = (|| -> CResult<u32> {
-        let handle = require_mut(scene)?;
-        let cache = require(cache.cast_const())?;
-        let pbr = require(material)?.to_openpbr()?;
+        let handle = unsafe { require_mut(scene) }?;
+        let cache = unsafe { require(cache.cast_const()) }?;
+        let pbr = unsafe { require(material) }?.to_openpbr()?;
 
         // The placement, validated before any geometry work: the kernel's
         // instance path requires an invertible transform (a zero scale is
         // the common "hide this" idiom — the caller skips those).
-        let m = slice(xform, 16)?;
+        let m = unsafe { slice(xform, 16) }?;
         if !m.iter().all(|v| v.is_finite()) {
             return Err(CrustStatus::InvalidArgument);
         }
@@ -161,13 +194,17 @@ pub extern "C" fn crust_scene_add_instance(
         let proto = match cache.lookup(key, version) {
             Some(scene) => scene,
             None => {
-                let geometry = read_mesh_geometry(
-                    positions_or_null,
-                    vertex_count,
-                    tri_indices_or_null,
-                    triangle_count,
-                    normals_or_null,
-                )?;
+                // SAFETY: forwarded from this export's `# Safety` contract
+                // (on a cache miss the arrays are required and valid).
+                let geometry = unsafe {
+                    read_mesh_geometry(
+                        positions_or_null,
+                        vertex_count,
+                        tri_indices_or_null,
+                        triangle_count,
+                        normals_or_null,
+                    )
+                }?;
                 let mut inner = crust_core::rt::SceneBuilder::new();
                 inner.attach(geometry);
                 let scene = Arc::new(inner.commit());
@@ -188,7 +225,7 @@ pub extern "C" fn crust_scene_add_instance(
     })();
     match result {
         Ok(id) => {
-            write_out(out_geom_id, id);
+            unsafe { write_out(out_geom_id, id) };
             CrustStatus::Ok
         }
         Err(status) => status,
@@ -197,8 +234,15 @@ pub extern "C" fn crust_scene_add_instance(
 
 /// `CrustStatus crust_scene_add_sphere(CrustScene*, const float center[3],
 ///     float radius, const CrustMaterial*, uint32_t* out_geom_id);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_scene_add_sphere(
+pub unsafe extern "C" fn crust_scene_add_sphere(
     scene: *mut SceneHandle,
     center: *const f32,
     radius: f32,
@@ -206,9 +250,9 @@ pub extern "C" fn crust_scene_add_sphere(
     out_geom_id: *mut u32,
 ) -> CrustStatus {
     let result = (|| -> CResult<u32> {
-        let handle = require_mut(scene)?;
-        let pbr = require(material)?.to_openpbr()?;
-        let center = validate::finite3(center)?;
+        let handle = unsafe { require_mut(scene) }?;
+        let pbr = unsafe { require(material) }?.to_openpbr()?;
+        let center = unsafe { validate::finite3(center) }?;
         if !(radius.is_finite() && radius > 0.0) {
             return Err(CrustStatus::InvalidArgument);
         }
@@ -217,7 +261,7 @@ pub extern "C" fn crust_scene_add_sphere(
     })();
     match result {
         Ok(id) => {
-            write_out(out_geom_id, id);
+            unsafe { write_out(out_geom_id, id) };
             CrustStatus::Ok
         }
         Err(status) => status,
@@ -231,17 +275,24 @@ const LIGHT_MASK: u32 = MASK_SHADOW | MASK_INDIRECT;
 
 /// `CrustStatus crust_scene_add_sphere_light(CrustScene*,
 ///     const float center[3], float radius, const float radiance[3]);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_scene_add_sphere_light(
+pub unsafe extern "C" fn crust_scene_add_sphere_light(
     scene: *mut SceneHandle,
     center: *const f32,
     radius: f32,
     radiance: *const f32,
 ) -> CrustStatus {
     let result = (|| -> CResult<()> {
-        let handle = require_mut(scene)?;
-        let center = validate::finite3(center)?;
-        let radiance = validate::finite3(radiance)?;
+        let handle = unsafe { require_mut(scene) }?;
+        let center = unsafe { validate::finite3(center) }?;
+        let radiance = unsafe { validate::finite3(radiance) }?;
         if !(radius.is_finite() && radius > 0.0) {
             return Err(CrustStatus::InvalidArgument);
         }
@@ -264,8 +315,15 @@ pub extern "C" fn crust_scene_add_sphere_light(
 
 /// `CrustStatus crust_scene_add_rect_light(CrustScene*, const float origin[3],
 ///     const float edge_u[3], const float edge_v[3], const float radiance[3]);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_scene_add_rect_light(
+pub unsafe extern "C" fn crust_scene_add_rect_light(
     scene: *mut SceneHandle,
     origin: *const f32,
     edge_u: *const f32,
@@ -273,11 +331,11 @@ pub extern "C" fn crust_scene_add_rect_light(
     radiance: *const f32,
 ) -> CrustStatus {
     let result = (|| -> CResult<()> {
-        let handle = require_mut(scene)?;
-        let origin = validate::finite3(origin)?;
-        let edge_u = validate::finite3(edge_u)?;
-        let edge_v = validate::finite3(edge_v)?;
-        let radiance = validate::finite3(radiance)?;
+        let handle = unsafe { require_mut(scene) }?;
+        let origin = unsafe { validate::finite3(origin) }?;
+        let edge_u = unsafe { validate::finite3(edge_u) }?;
+        let edge_v = unsafe { validate::finite3(edge_v) }?;
+        let radiance = unsafe { validate::finite3(radiance) }?;
         let normal = edge_u.cross(edge_v);
         if normal.length_squared() < 1e-20 {
             return Err(CrustStatus::InvalidArgument); // degenerate rectangle
@@ -314,18 +372,25 @@ pub extern "C" fn crust_scene_add_rect_light(
 
 /// `CrustStatus crust_scene_add_distant_light(CrustScene*,
 ///     const float direction[3], const float irradiance[3], float angle_deg);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_scene_add_distant_light(
+pub unsafe extern "C" fn crust_scene_add_distant_light(
     scene: *mut SceneHandle,
     direction: *const f32,
     irradiance: *const f32,
     angle_deg: f32,
 ) -> CrustStatus {
     let result = (|| -> CResult<()> {
-        let handle = require_mut(scene)?;
+        let handle = unsafe { require_mut(scene) }?;
         handle.ensure_live()?;
-        let direction = validate::finite3(direction)?;
-        let irradiance = validate::finite3(irradiance)?;
+        let direction = unsafe { validate::finite3(direction) }?;
+        let irradiance = unsafe { validate::finite3(irradiance) }?;
         if direction.length_squared() < 1e-20 || !(angle_deg.is_finite() && angle_deg >= 0.0) {
             return Err(CrustStatus::InvalidArgument);
         }
@@ -343,8 +408,11 @@ pub extern "C" fn crust_scene_add_distant_light(
 /// A dome is at infinity — only the rotation of its frame matters.
 /// Normalize the columns like the USD importer does, so a rotation with
 /// uniform scale folded in still orients correctly.
-fn read_dome_rotation(rotation: *const f32) -> CResult<Mat3A> {
-    let r = slice(rotation, 9)?;
+///
+/// # Safety
+/// Carries [`crate::validate::slice`]'s contract for 9 floats.
+unsafe fn read_dome_rotation(rotation: *const f32) -> CResult<Mat3A> {
+    let r = unsafe { slice(rotation, 9) }?;
     if !r.iter().all(|v| v.is_finite()) {
         return Err(CrustStatus::InvalidArgument);
     }
@@ -365,18 +433,25 @@ fn read_dome_rotation(rotation: *const f32) -> CResult<Mat3A> {
 
 /// `CrustStatus crust_scene_add_dome_light_file(CrustScene*,
 ///     const float tint[3], const char* path, const float rotation[9]);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_scene_add_dome_light_file(
+pub unsafe extern "C" fn crust_scene_add_dome_light_file(
     scene: *mut SceneHandle,
     tint: *const f32,
     path: *const std::ffi::c_char,
     rotation: *const f32,
 ) -> CrustStatus {
     let result = (|| -> CResult<()> {
-        let handle = require_mut(scene)?;
+        let handle = unsafe { require_mut(scene) }?;
         handle.ensure_live()?;
-        let tint = validate::finite3(tint)?;
-        let rotation = read_dome_rotation(rotation)?;
+        let tint = unsafe { validate::finite3(tint) }?;
+        let rotation = unsafe { read_dome_rotation(rotation) }?;
         if path.is_null() {
             return Err(CrustStatus::NullArgument);
         }
@@ -398,8 +473,15 @@ pub extern "C" fn crust_scene_add_dome_light_file(
 /// `CrustStatus crust_scene_add_dome_light(CrustScene*, const float tint[3],
 ///     uint32_t tex_width, uint32_t tex_height, const float* pixels_or_null,
 ///     const float rotation[9]);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_scene_add_dome_light(
+pub unsafe extern "C" fn crust_scene_add_dome_light(
     scene: *mut SceneHandle,
     tint: *const f32,
     tex_width: u32,
@@ -408,10 +490,10 @@ pub extern "C" fn crust_scene_add_dome_light(
     rotation: *const f32,
 ) -> CrustStatus {
     let result = (|| -> CResult<()> {
-        let handle = require_mut(scene)?;
+        let handle = unsafe { require_mut(scene) }?;
         handle.ensure_live()?;
-        let tint = validate::finite3(tint)?;
-        let rotation = read_dome_rotation(rotation)?;
+        let tint = unsafe { validate::finite3(tint) }?;
+        let rotation = unsafe { read_dome_rotation(rotation) }?;
         let map = if pixels_or_null.is_null() {
             None
         } else {
@@ -420,7 +502,7 @@ pub extern "C" fn crust_scene_add_dome_light(
                 .checked_mul(h)
                 .and_then(|px| px.checked_mul(3))
                 .ok_or(CrustStatus::InvalidArgument)?;
-            let flat = slice(pixels_or_null, count)?;
+            let flat = unsafe { slice(pixels_or_null, count) }?;
             let pixels: Vec<Vec3A> = flat
                 .chunks_exact(3)
                 .map(|c| Vec3A::new(c[0], c[1], c[2]))
@@ -442,8 +524,15 @@ pub extern "C" fn crust_scene_add_dome_light(
 
 /// `CrustStatus crust_scene_set_camera(CrustScene*, const double view[16],
 ///     const double proj[16], float aperture, float focus_distance);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_scene_set_camera(
+pub unsafe extern "C" fn crust_scene_set_camera(
     scene: *mut SceneHandle,
     view: *const f64,
     proj: *const f64,
@@ -451,10 +540,10 @@ pub extern "C" fn crust_scene_set_camera(
     focus_distance: f32,
 ) -> CrustStatus {
     let result = (|| -> CResult<()> {
-        let handle = require_mut(scene)?;
+        let handle = unsafe { require_mut(scene) }?;
         handle.ensure_live()?;
         let to_mat4 = |ptr: *const f64| -> CResult<Mat4> {
-            let m = slice(ptr, 16)?;
+            let m = unsafe { slice(ptr, 16) }?;
             let mut cols = [0.0f32; 16];
             for (dst, src) in cols.iter_mut().zip(m) {
                 if !src.is_finite() {
@@ -482,15 +571,22 @@ pub extern "C" fn crust_scene_set_camera(
 
 /// `CrustStatus crust_scene_set_render_settings(CrustScene*,
 ///     const CrustRenderSettings*);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_scene_set_render_settings(
+pub unsafe extern "C" fn crust_scene_set_render_settings(
     scene: *mut SceneHandle,
     settings: *const CrustRenderSettings,
 ) -> CrustStatus {
     let result = (|| -> CResult<()> {
-        let handle = require_mut(scene)?;
+        let handle = unsafe { require_mut(scene) }?;
         handle.ensure_live()?;
-        handle.settings = Some(require(settings)?.to_settings()?);
+        handle.settings = Some(unsafe { require(settings) }?.to_settings()?);
         Ok(())
     })();
     result.err().unwrap_or(CrustStatus::Ok)
@@ -498,14 +594,21 @@ pub extern "C" fn crust_scene_set_render_settings(
 
 /// `CrustStatus crust_scene_commit(CrustScene*,
 ///     const CrustStopToken* token_or_null, CrustRenderer** out_renderer);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_scene_commit(
+pub unsafe extern "C" fn crust_scene_commit(
     scene: *mut SceneHandle,
     token_or_null: *const TokenHandle,
     out_renderer: *mut *mut RendererHandle,
 ) -> CrustStatus {
     let result = (|| -> CResult<*mut RendererHandle> {
-        let handle = require_mut(scene)?;
+        let handle = unsafe { require_mut(scene) }?;
         if out_renderer.is_null() {
             return Err(CrustStatus::NullArgument);
         }
@@ -526,7 +629,7 @@ pub extern "C" fn crust_scene_commit(
     })();
     match result {
         Ok(ptr) => {
-            write_out(out_renderer, ptr);
+            unsafe { write_out(out_renderer, ptr) };
             CrustStatus::Ok
         }
         Err(status) => status,

--- a/crates/crust-capi/src/scene.rs
+++ b/crates/crust-capi/src/scene.rs
@@ -1,0 +1,395 @@
+//! The scene-builder entry points.
+
+use crate::handles::{RendererHandle, SceneHandle, TokenHandle};
+use crate::material::{CrustMaterial, CrustRenderSettings};
+use crate::status::CrustStatus;
+use crate::validate::{self, CResult, require, require_mut, slice, write_out};
+use crust_core::rt::Geometry;
+use crust_core::{
+    AreaLight, Camera, DistantLight, DomeLight, Emissive, EnvironmentMap, LightList,
+    MASK_INDIRECT, MASK_SHADOW, Mat4, RectShape, Renderer, SphereShape, StopToken, Vec3A,
+};
+use glam::Mat3A;
+use std::sync::Arc;
+
+/// `CrustScene* crust_scene_create(void);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_scene_create() -> *mut SceneHandle {
+    Box::into_raw(Box::new(SceneHandle::new()))
+}
+
+/// `void crust_scene_destroy(CrustScene* scene);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_scene_destroy(scene: *mut SceneHandle) {
+    if !scene.is_null() {
+        // SAFETY: created by `crust_scene_create`; use after destroy is
+        // forbidden by the header contract.
+        drop(unsafe { Box::from_raw(scene) });
+    }
+}
+
+/// Reads a required point/vector array (`3 * count` floats, all finite).
+fn read_vec3s(ptr: *const f32, count: usize) -> CResult<Vec<Vec3A>> {
+    let len = count
+        .checked_mul(3)
+        .ok_or(CrustStatus::InvalidArgument)?;
+    let flat = slice(ptr, len)?;
+    if !flat.iter().all(|v| v.is_finite()) {
+        return Err(CrustStatus::InvalidArgument);
+    }
+    Ok(flat
+        .chunks_exact(3)
+        .map(|c| Vec3A::new(c[0], c[1], c[2]))
+        .collect())
+}
+
+/// `CrustStatus crust_scene_add_mesh(CrustScene*, const float* positions,
+///     size_t vertex_count, const uint32_t* tri_indices,
+///     size_t triangle_count, const float* normals_or_null,
+///     const CrustMaterial*, uint32_t* out_geom_id);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_scene_add_mesh(
+    scene: *mut SceneHandle,
+    positions: *const f32,
+    vertex_count: usize,
+    tri_indices: *const u32,
+    triangle_count: usize,
+    normals_or_null: *const f32,
+    material: *const CrustMaterial,
+    out_geom_id: *mut u32,
+) -> CrustStatus {
+    let result = (|| -> CResult<u32> {
+        let handle = require_mut(scene)?;
+        let pbr = require(material)?.to_openpbr()?;
+        if vertex_count > u32::MAX as usize {
+            return Err(CrustStatus::InvalidArgument);
+        }
+        let vertices = read_vec3s(positions, vertex_count)?;
+        let index_len = triangle_count
+            .checked_mul(3)
+            .ok_or(CrustStatus::InvalidArgument)?;
+        let indices: Vec<[u32; 3]> = slice(tri_indices, index_len)?
+            .chunks_exact(3)
+            .map(|c| [c[0], c[1], c[2]])
+            .collect();
+        let normals = if normals_or_null.is_null() {
+            None
+        } else {
+            Some(read_vec3s(normals_or_null, vertex_count)?)
+        };
+        let builder = handle.builder_mut()?;
+        Ok(builder.attach(
+            Geometry::TriangleMesh {
+                vertices,
+                indices,
+                normals,
+            },
+            Arc::new(pbr),
+        ))
+    })();
+    match result {
+        Ok(id) => {
+            write_out(out_geom_id, id);
+            CrustStatus::Ok
+        }
+        Err(status) => status,
+    }
+}
+
+/// `CrustStatus crust_scene_add_sphere(CrustScene*, const float center[3],
+///     float radius, const CrustMaterial*, uint32_t* out_geom_id);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_scene_add_sphere(
+    scene: *mut SceneHandle,
+    center: *const f32,
+    radius: f32,
+    material: *const CrustMaterial,
+    out_geom_id: *mut u32,
+) -> CrustStatus {
+    let result = (|| -> CResult<u32> {
+        let handle = require_mut(scene)?;
+        let pbr = require(material)?.to_openpbr()?;
+        let center = validate::finite3(center)?;
+        if !(radius.is_finite() && radius > 0.0) {
+            return Err(CrustStatus::InvalidArgument);
+        }
+        let builder = handle.builder_mut()?;
+        Ok(builder.attach(Geometry::Sphere { center, radius }, Arc::new(pbr)))
+    })();
+    match result {
+        Ok(id) => {
+            write_out(out_geom_id, id);
+            CrustStatus::Ok
+        }
+        Err(status) => status,
+    }
+}
+
+/// Geometry-backed lights are hidden from camera rays (the industry
+/// convention crust's USD importer also follows): shadow and indirect rays
+/// see the source, the camera does not.
+const LIGHT_MASK: u32 = MASK_SHADOW | MASK_INDIRECT;
+
+/// `CrustStatus crust_scene_add_sphere_light(CrustScene*,
+///     const float center[3], float radius, const float radiance[3]);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_scene_add_sphere_light(
+    scene: *mut SceneHandle,
+    center: *const f32,
+    radius: f32,
+    radiance: *const f32,
+) -> CrustStatus {
+    let result = (|| -> CResult<()> {
+        let handle = require_mut(scene)?;
+        let center = validate::finite3(center)?;
+        let radiance = validate::finite3(radiance)?;
+        if !(radius.is_finite() && radius > 0.0) {
+            return Err(CrustStatus::InvalidArgument);
+        }
+        // The engine convention (usd_import's emit_sphere_light): one
+        // shared Emissive drives both the world geometry the rays hit and
+        // the light-list entry NEE samples, tied together by the geom_id.
+        let material = Arc::new(Emissive::new(radiance));
+        let builder = handle.builder_mut()?;
+        let geom_id =
+            builder.attach_masked(Geometry::Sphere { center, radius }, material.clone(), LIGHT_MASK);
+        handle.lights.add(Arc::new(AreaLight::new(
+            Box::new(SphereShape { center, radius }),
+            material,
+            geom_id,
+        )));
+        Ok(())
+    })();
+    result.err().unwrap_or(CrustStatus::Ok)
+}
+
+/// `CrustStatus crust_scene_add_rect_light(CrustScene*, const float origin[3],
+///     const float edge_u[3], const float edge_v[3], const float radiance[3]);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_scene_add_rect_light(
+    scene: *mut SceneHandle,
+    origin: *const f32,
+    edge_u: *const f32,
+    edge_v: *const f32,
+    radiance: *const f32,
+) -> CrustStatus {
+    let result = (|| -> CResult<()> {
+        let handle = require_mut(scene)?;
+        let origin = validate::finite3(origin)?;
+        let edge_u = validate::finite3(edge_u)?;
+        let edge_v = validate::finite3(edge_v)?;
+        let radiance = validate::finite3(radiance)?;
+        let normal = edge_u.cross(edge_v);
+        if normal.length_squared() < 1e-20 {
+            return Err(CrustStatus::InvalidArgument); // degenerate rectangle
+        }
+        let normal = normal.normalize();
+        // Same two-triangle emissive quad the USD importer builds for a
+        // UsdLux RectLight, shared-Emissive + geom_id wiring included.
+        let material = Arc::new(Emissive::new(radiance));
+        let (c00, c10, c11, c01) = (
+            origin,
+            origin + edge_u,
+            origin + edge_u + edge_v,
+            origin + edge_v,
+        );
+        let builder = handle.builder_mut()?;
+        let geom_id = builder.attach_masked(
+            Geometry::TriangleMesh {
+                vertices: vec![c00, c10, c11, c01],
+                indices: vec![[0, 1, 2], [0, 2, 3]],
+                normals: None,
+            },
+            material.clone(),
+            LIGHT_MASK,
+        );
+        handle.lights.add(Arc::new(AreaLight::new(
+            Box::new(RectShape::new(origin, edge_u, edge_v, normal)),
+            material,
+            geom_id,
+        )));
+        Ok(())
+    })();
+    result.err().unwrap_or(CrustStatus::Ok)
+}
+
+/// `CrustStatus crust_scene_add_distant_light(CrustScene*,
+///     const float direction[3], const float irradiance[3], float angle_deg);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_scene_add_distant_light(
+    scene: *mut SceneHandle,
+    direction: *const f32,
+    irradiance: *const f32,
+    angle_deg: f32,
+) -> CrustStatus {
+    let result = (|| -> CResult<()> {
+        let handle = require_mut(scene)?;
+        handle.ensure_live()?;
+        let direction = validate::finite3(direction)?;
+        let irradiance = validate::finite3(irradiance)?;
+        if direction.length_squared() < 1e-20 || !(angle_deg.is_finite() && angle_deg >= 0.0) {
+            return Err(CrustStatus::InvalidArgument);
+        }
+        // DistantLight widens tiny angles to its own floor internally.
+        handle.lights.add(Arc::new(DistantLight::new(
+            direction.normalize(),
+            irradiance,
+            angle_deg,
+        )));
+        Ok(())
+    })();
+    result.err().unwrap_or(CrustStatus::Ok)
+}
+
+/// `CrustStatus crust_scene_add_dome_light(CrustScene*, const float tint[3],
+///     uint32_t tex_width, uint32_t tex_height, const float* pixels_or_null,
+///     const float rotation[9]);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_scene_add_dome_light(
+    scene: *mut SceneHandle,
+    tint: *const f32,
+    tex_width: u32,
+    tex_height: u32,
+    pixels_or_null: *const f32,
+    rotation: *const f32,
+) -> CrustStatus {
+    let result = (|| -> CResult<()> {
+        let handle = require_mut(scene)?;
+        handle.ensure_live()?;
+        let tint = validate::finite3(tint)?;
+        let r = slice(rotation, 9)?;
+        if !r.iter().all(|v| v.is_finite()) {
+            return Err(CrustStatus::InvalidArgument);
+        }
+        // A dome is at infinity — only the rotation of its frame matters.
+        // Normalize the columns like the USD importer does, so a rotation
+        // with uniform scale folded in still orients correctly.
+        let mut rotation = Mat3A::from_cols_array(&[
+            r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8],
+        ]);
+        for col in [&mut rotation.x_axis, &mut rotation.y_axis, &mut rotation.z_axis] {
+            if col.length_squared() < 1e-20 {
+                return Err(CrustStatus::InvalidArgument);
+            }
+            *col = col.normalize();
+        }
+        let map = if pixels_or_null.is_null() {
+            None
+        } else {
+            let (w, h) = (tex_width as usize, tex_height as usize);
+            let count = w
+                .checked_mul(h)
+                .and_then(|px| px.checked_mul(3))
+                .ok_or(CrustStatus::InvalidArgument)?;
+            let flat = slice(pixels_or_null, count)?;
+            let pixels: Vec<Vec3A> = flat
+                .chunks_exact(3)
+                .map(|c| Vec3A::new(c[0], c[1], c[2]))
+                .collect();
+            if pixels.iter().any(|p| !p.is_finite()) {
+                return Err(CrustStatus::InvalidArgument);
+            }
+            Some(Arc::new(
+                EnvironmentMap::new(w, h, pixels).ok_or(CrustStatus::InvalidArgument)?,
+            ))
+        };
+        handle
+            .lights
+            .add(Arc::new(DomeLight::new(tint, map, rotation)));
+        Ok(())
+    })();
+    result.err().unwrap_or(CrustStatus::Ok)
+}
+
+/// `CrustStatus crust_scene_set_camera(CrustScene*, const double view[16],
+///     const double proj[16], float aperture, float focus_distance);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_scene_set_camera(
+    scene: *mut SceneHandle,
+    view: *const f64,
+    proj: *const f64,
+    aperture: f32,
+    focus_distance: f32,
+) -> CrustStatus {
+    let result = (|| -> CResult<()> {
+        let handle = require_mut(scene)?;
+        handle.ensure_live()?;
+        let to_mat4 = |ptr: *const f64| -> CResult<Mat4> {
+            let m = slice(ptr, 16)?;
+            let mut cols = [0.0f32; 16];
+            for (dst, src) in cols.iter_mut().zip(m) {
+                if !src.is_finite() {
+                    return Err(CrustStatus::InvalidArgument);
+                }
+                *dst = *src as f32;
+            }
+            Ok(Mat4::from_cols_array(&cols))
+        };
+        let view = to_mat4(view)?;
+        let proj = to_mat4(proj)?;
+        let aperture = validate::finite(aperture)?;
+        if aperture < 0.0 {
+            return Err(CrustStatus::InvalidArgument);
+        }
+        // `from_view_projection` validates the matrices and the focus
+        // distance itself (singular / orthographic / non-positive focus).
+        let camera = Camera::from_view_projection(view, proj, aperture, focus_distance)
+            .map_err(|_| CrustStatus::InvalidCamera)?;
+        handle.camera = Some(camera);
+        Ok(())
+    })();
+    result.err().unwrap_or(CrustStatus::Ok)
+}
+
+/// `CrustStatus crust_scene_set_render_settings(CrustScene*,
+///     const CrustRenderSettings*);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_scene_set_render_settings(
+    scene: *mut SceneHandle,
+    settings: *const CrustRenderSettings,
+) -> CrustStatus {
+    let result = (|| -> CResult<()> {
+        let handle = require_mut(scene)?;
+        handle.ensure_live()?;
+        handle.settings = Some(require(settings)?.to_settings()?);
+        Ok(())
+    })();
+    result.err().unwrap_or(CrustStatus::Ok)
+}
+
+/// `CrustStatus crust_scene_commit(CrustScene*,
+///     const CrustStopToken* token_or_null, CrustRenderer** out_renderer);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_scene_commit(
+    scene: *mut SceneHandle,
+    token_or_null: *const TokenHandle,
+    out_renderer: *mut *mut RendererHandle,
+) -> CrustStatus {
+    let result = (|| -> CResult<*mut RendererHandle> {
+        let handle = require_mut(scene)?;
+        if out_renderer.is_null() {
+            return Err(CrustStatus::NullArgument);
+        }
+        let camera = handle.camera.ok_or(CrustStatus::BadState)?;
+        let settings = handle.settings.ok_or(CrustStatus::BadState)?;
+        // Cloned, not moved: the caller keeps its token handle and may
+        // stop/destroy it independently of this renderer.
+        let stop = match unsafe { token_or_null.as_ref() } {
+            Some(token) => token.0.clone(),
+            None => StopToken::new(),
+        };
+        // Spends the builder: this is what flips every later add/set call
+        // on this handle to BAD_STATE.
+        let builder = handle.builder.take().ok_or(CrustStatus::BadState)?;
+        let lights = std::mem::replace(&mut handle.lights, LightList::new());
+        let renderer = Renderer::new(camera, builder.commit(), lights, settings);
+        Ok(Box::into_raw(RendererHandle::new(renderer, stop)))
+    })();
+    match result {
+        Ok(ptr) => {
+            write_out(out_renderer, ptr);
+            CrustStatus::Ok
+        }
+        Err(status) => status,
+    }
+}

--- a/crates/crust-capi/src/scene.rs
+++ b/crates/crust-capi/src/scene.rs
@@ -340,6 +340,61 @@ pub extern "C" fn crust_scene_add_distant_light(
     result.err().unwrap_or(CrustStatus::Ok)
 }
 
+/// A dome is at infinity — only the rotation of its frame matters.
+/// Normalize the columns like the USD importer does, so a rotation with
+/// uniform scale folded in still orients correctly.
+fn read_dome_rotation(rotation: *const f32) -> CResult<Mat3A> {
+    let r = slice(rotation, 9)?;
+    if !r.iter().all(|v| v.is_finite()) {
+        return Err(CrustStatus::InvalidArgument);
+    }
+    let mut rotation =
+        Mat3A::from_cols_array(&[r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8]]);
+    for col in [
+        &mut rotation.x_axis,
+        &mut rotation.y_axis,
+        &mut rotation.z_axis,
+    ] {
+        if col.length_squared() < 1e-20 {
+            return Err(CrustStatus::InvalidArgument);
+        }
+        *col = col.normalize();
+    }
+    Ok(rotation)
+}
+
+/// `CrustStatus crust_scene_add_dome_light_file(CrustScene*,
+///     const float tint[3], const char* path, const float rotation[9]);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_scene_add_dome_light_file(
+    scene: *mut SceneHandle,
+    tint: *const f32,
+    path: *const std::ffi::c_char,
+    rotation: *const f32,
+) -> CrustStatus {
+    let result = (|| -> CResult<()> {
+        let handle = require_mut(scene)?;
+        handle.ensure_live()?;
+        let tint = validate::finite3(tint)?;
+        let rotation = read_dome_rotation(rotation)?;
+        if path.is_null() {
+            return Err(CrustStatus::NullArgument);
+        }
+        // SAFETY: non-null checked; a NUL-terminated string is the caller's
+        // contract per the header.
+        let path = unsafe { std::ffi::CStr::from_ptr(path) }
+            .to_str()
+            .map_err(|_| CrustStatus::InvalidArgument)?;
+        let map = crate::dome::load_environment(std::path::Path::new(path))
+            .ok_or(CrustStatus::InvalidArgument)?;
+        handle
+            .lights
+            .add(Arc::new(DomeLight::new(tint, Some(Arc::new(map)), rotation)));
+        Ok(())
+    })();
+    result.err().unwrap_or(CrustStatus::Ok)
+}
+
 /// `CrustStatus crust_scene_add_dome_light(CrustScene*, const float tint[3],
 ///     uint32_t tex_width, uint32_t tex_height, const float* pixels_or_null,
 ///     const float rotation[9]);`
@@ -356,22 +411,7 @@ pub extern "C" fn crust_scene_add_dome_light(
         let handle = require_mut(scene)?;
         handle.ensure_live()?;
         let tint = validate::finite3(tint)?;
-        let r = slice(rotation, 9)?;
-        if !r.iter().all(|v| v.is_finite()) {
-            return Err(CrustStatus::InvalidArgument);
-        }
-        // A dome is at infinity — only the rotation of its frame matters.
-        // Normalize the columns like the USD importer does, so a rotation
-        // with uniform scale folded in still orients correctly.
-        let mut rotation = Mat3A::from_cols_array(&[
-            r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8],
-        ]);
-        for col in [&mut rotation.x_axis, &mut rotation.y_axis, &mut rotation.z_axis] {
-            if col.length_squared() < 1e-20 {
-                return Err(CrustStatus::InvalidArgument);
-            }
-            *col = col.normalize();
-        }
+        let rotation = read_dome_rotation(rotation)?;
         let map = if pixels_or_null.is_null() {
             None
         } else {

--- a/crates/crust-capi/src/status.rs
+++ b/crates/crust-capi/src/status.rs
@@ -1,0 +1,65 @@
+//! Status codes and version reporting — the error half of the C contract.
+
+use std::ffi::c_char;
+
+/// Result code of every fallible C entry point. Mirrors `CrustStatus` in
+/// `crust.h` — same names, same discriminants.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CrustStatus {
+    Ok = 0,
+    NullArgument = 1,
+    InvalidArgument = 2,
+    InvalidCamera = 3,
+    BadState = 4,
+    BufferTooSmall = 5,
+}
+
+/// Outcome of one `crust_renderer_step`. Mirrors `CrustStepStatus` in
+/// `crust.h`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CrustStepStatus {
+    InProgress = 0,
+    Stopped = 1,
+    Complete = 2,
+}
+
+/// `const char* crust_status_string(CrustStatus status);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_status_string(status: CrustStatus) -> *const c_char {
+    let s = match status {
+        CrustStatus::Ok => c"ok",
+        CrustStatus::NullArgument => c"a required pointer was NULL",
+        CrustStatus::InvalidArgument => c"invalid argument (count, non-finite float, or malformed data)",
+        CrustStatus::InvalidCamera => c"invalid camera matrices (singular, orthographic, or bad focus)",
+        CrustStatus::BadState => c"handle is in the wrong state for this call",
+        CrustStatus::BufferTooSmall => c"output buffer capacity is smaller than width*height",
+    };
+    s.as_ptr()
+}
+
+/// `uint32_t crust_api_version(void);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_api_version() -> u32 {
+    // Bump together with CRUST_API_VERSION in crust.h.
+    1
+}
+
+/// `void crust_library_version(uint32_t* major, uint32_t* minor, uint32_t* patch);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_library_version(major: *mut u32, minor: *mut u32, patch: *mut u32) {
+    let parts = [
+        env!("CARGO_PKG_VERSION_MAJOR"),
+        env!("CARGO_PKG_VERSION_MINOR"),
+        env!("CARGO_PKG_VERSION_PATCH"),
+    ]
+    .map(|s| s.parse::<u32>().unwrap_or(0));
+    for (out, value) in [major, minor, patch].into_iter().zip(parts) {
+        if !out.is_null() {
+            // SAFETY: non-null checked; the caller promises a valid u32 slot
+            // per the header contract.
+            unsafe { *out = value };
+        }
+    }
+}

--- a/crates/crust-capi/src/status.rs
+++ b/crates/crust-capi/src/status.rs
@@ -43,7 +43,10 @@ pub extern "C" fn crust_status_string(status: CrustStatus) -> *const c_char {
 #[unsafe(no_mangle)]
 pub extern "C" fn crust_api_version() -> u32 {
     // Bump together with CRUST_API_VERSION in crust.h.
-    1
+    // v2: CrustMaterial gained coat_weight/coat_roughness (sizeof 56 -> 64);
+    //     added the geometry cache, instanced placement, in-place edits and
+    //     file-based dome lights.
+    2
 }
 
 /// `void crust_library_version(uint32_t* major, uint32_t* minor, uint32_t* patch);`

--- a/crates/crust-capi/src/status.rs
+++ b/crates/crust-capi/src/status.rs
@@ -50,8 +50,15 @@ pub extern "C" fn crust_api_version() -> u32 {
 }
 
 /// `void crust_library_version(uint32_t* major, uint32_t* minor, uint32_t* patch);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_library_version(major: *mut u32, minor: *mut u32, patch: *mut u32) {
+pub unsafe extern "C" fn crust_library_version(major: *mut u32, minor: *mut u32, patch: *mut u32) {
     let parts = [
         env!("CARGO_PKG_VERSION_MAJOR"),
         env!("CARGO_PKG_VERSION_MINOR"),

--- a/crates/crust-capi/src/token.rs
+++ b/crates/crust-capi/src/token.rs
@@ -14,8 +14,15 @@ pub extern "C" fn crust_stop_token_create() -> *mut TokenHandle {
 /// Callable from any thread, including while a `crust_renderer_step`
 /// holding a clone of this token is in flight — `StopToken` is an atomic
 /// flag behind an `Arc`, which is the entire point of the type.
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_stop_token_stop(token: *mut TokenHandle) {
+pub unsafe extern "C" fn crust_stop_token_stop(token: *mut TokenHandle) {
     // SAFETY: non-null checked; the pointee is valid until its destroy call
     // per the header contract, and `StopToken::stop` is `&self` + atomic.
     if let Some(token) = unsafe { token.as_ref() } {
@@ -24,15 +31,29 @@ pub extern "C" fn crust_stop_token_stop(token: *mut TokenHandle) {
 }
 
 /// `bool crust_stop_token_is_stopped(const CrustStopToken* token);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_stop_token_is_stopped(token: *const TokenHandle) -> bool {
+pub unsafe extern "C" fn crust_stop_token_is_stopped(token: *const TokenHandle) -> bool {
     // SAFETY: as `crust_stop_token_stop`.
     unsafe { token.as_ref() }.is_some_and(|t| t.0.is_stopped())
 }
 
 /// `void crust_stop_token_destroy(CrustStopToken* token);`
+///
+/// # Safety
+/// Every pointer argument must satisfy the crust.h contract: NULL where the
+/// header allows it, otherwise valid, aligned and initialized for the whole
+/// call, with arrays holding at least the stated element counts, out-params
+/// exclusively accessible, and handle pointers live (not destroyed) and
+/// externally synchronized.
 #[unsafe(no_mangle)]
-pub extern "C" fn crust_stop_token_destroy(token: *mut TokenHandle) {
+pub unsafe extern "C" fn crust_stop_token_destroy(token: *mut TokenHandle) {
     if !token.is_null() {
         // SAFETY: created by `crust_stop_token_create`; the header forbids
         // use after destroy. Renderers hold their own clone, so dropping

--- a/crates/crust-capi/src/token.rs
+++ b/crates/crust-capi/src/token.rs
@@ -1,0 +1,42 @@
+//! The stop-token entry points — the only cross-thread part of the ABI.
+
+use crate::handles::TokenHandle;
+use crust_core::StopToken;
+
+/// `CrustStopToken* crust_stop_token_create(void);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_stop_token_create() -> *mut TokenHandle {
+    Box::into_raw(Box::new(TokenHandle(StopToken::new())))
+}
+
+/// `void crust_stop_token_stop(CrustStopToken* token);`
+///
+/// Callable from any thread, including while a `crust_renderer_step`
+/// holding a clone of this token is in flight — `StopToken` is an atomic
+/// flag behind an `Arc`, which is the entire point of the type.
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_stop_token_stop(token: *mut TokenHandle) {
+    // SAFETY: non-null checked; the pointee is valid until its destroy call
+    // per the header contract, and `StopToken::stop` is `&self` + atomic.
+    if let Some(token) = unsafe { token.as_ref() } {
+        token.0.stop();
+    }
+}
+
+/// `bool crust_stop_token_is_stopped(const CrustStopToken* token);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_stop_token_is_stopped(token: *const TokenHandle) -> bool {
+    // SAFETY: as `crust_stop_token_stop`.
+    unsafe { token.as_ref() }.is_some_and(|t| t.0.is_stopped())
+}
+
+/// `void crust_stop_token_destroy(CrustStopToken* token);`
+#[unsafe(no_mangle)]
+pub extern "C" fn crust_stop_token_destroy(token: *mut TokenHandle) {
+    if !token.is_null() {
+        // SAFETY: created by `crust_stop_token_create`; the header forbids
+        // use after destroy. Renderers hold their own clone, so dropping
+        // the handle never invalidates an in-flight render.
+        drop(unsafe { Box::from_raw(token) });
+    }
+}

--- a/crates/crust-capi/src/validate.rs
+++ b/crates/crust-capi/src/validate.rs
@@ -1,0 +1,80 @@
+//! Argument validation — the boundary's safety net.
+//!
+//! The workspace builds release with `panic = "abort"`, so nothing here may
+//! rely on unwinding: every raw pointer and count is checked *before* a
+//! slice or reference is materialized, and every float the engine assumes
+//! finite is checked on the way in.
+
+use crate::status::CrustStatus;
+use crust_core::Vec3A;
+
+pub(crate) type CResult<T> = Result<T, CrustStatus>;
+
+/// The engine's own dimension cap (see `crust.h`).
+pub(crate) const MAX_DIM: u32 = 65_536;
+
+/// A required shared reference.
+pub(crate) fn require<'a, T>(ptr: *const T) -> CResult<&'a T> {
+    // SAFETY: non-null checked; validity and aliasing are the caller's
+    // contract per the header ("externally synchronized" handles).
+    unsafe { ptr.as_ref() }.ok_or(CrustStatus::NullArgument)
+}
+
+/// A required exclusive reference.
+pub(crate) fn require_mut<'a, T>(ptr: *mut T) -> CResult<&'a mut T> {
+    // SAFETY: as `require`, plus the header's exclusivity contract.
+    unsafe { ptr.as_mut() }.ok_or(CrustStatus::NullArgument)
+}
+
+/// A required input array of exactly `len` elements (`len > 0`).
+pub(crate) fn slice<'a, T>(ptr: *const T, len: usize) -> CResult<&'a [T]> {
+    if ptr.is_null() {
+        return Err(CrustStatus::NullArgument);
+    }
+    if len == 0 || len > isize::MAX as usize / size_of::<T>().max(1) {
+        return Err(CrustStatus::InvalidArgument);
+    }
+    // SAFETY: non-null and byte size representable, checked above; contents
+    // and lifetime are the caller's contract.
+    Ok(unsafe { std::slice::from_raw_parts(ptr, len) })
+}
+
+/// A required output array of exactly `len` elements.
+pub(crate) fn slice_mut<'a, T>(ptr: *mut T, len: usize) -> CResult<&'a mut [T]> {
+    if ptr.is_null() {
+        return Err(CrustStatus::NullArgument);
+    }
+    if len == 0 || len > isize::MAX as usize / size_of::<T>().max(1) {
+        return Err(CrustStatus::InvalidArgument);
+    }
+    // SAFETY: as `slice`, plus the caller's exclusivity contract for the
+    // duration of the call.
+    Ok(unsafe { std::slice::from_raw_parts_mut(ptr, len) })
+}
+
+pub(crate) fn finite(v: f32) -> CResult<f32> {
+    if v.is_finite() {
+        Ok(v)
+    } else {
+        Err(CrustStatus::InvalidArgument)
+    }
+}
+
+/// A required, all-finite float triple, as the engine's vector type.
+pub(crate) fn finite3(ptr: *const f32) -> CResult<Vec3A> {
+    let v = slice(ptr, 3)?;
+    let v = Vec3A::new(v[0], v[1], v[2]);
+    if v.is_finite() {
+        Ok(v)
+    } else {
+        Err(CrustStatus::InvalidArgument)
+    }
+}
+
+/// Writes an out-parameter if the caller supplied one.
+pub(crate) fn write_out<T>(ptr: *mut T, value: T) {
+    if !ptr.is_null() {
+        // SAFETY: non-null checked; a valid slot is the caller's contract.
+        unsafe { *ptr = value };
+    }
+}

--- a/crates/crust-capi/src/validate.rs
+++ b/crates/crust-capi/src/validate.rs
@@ -7,6 +7,7 @@
 
 use crate::status::CrustStatus;
 use crust_core::Vec3A;
+use std::mem::size_of;
 
 pub(crate) type CResult<T> = Result<T, CrustStatus>;
 

--- a/crates/crust-capi/src/validate.rs
+++ b/crates/crust-capi/src/validate.rs
@@ -4,6 +4,11 @@
 //! rely on unwinding: every raw pointer and count is checked *before* a
 //! slice or reference is materialized, and every float the engine assumes
 //! finite is checked on the way in.
+//!
+//! Every helper that dereferences a caller pointer is an `unsafe fn`: what
+//! the checks here CANNOT establish — validity, alignment, initialization,
+//! liveness, exclusivity — is the caller's `# Safety` contract, threaded up
+//! through the `unsafe extern "C"` exports to crust.h.
 
 use crate::status::CrustStatus;
 use crust_core::Vec3A;
@@ -15,41 +20,56 @@ pub(crate) type CResult<T> = Result<T, CrustStatus>;
 pub(crate) const MAX_DIM: u32 = 65_536;
 
 /// A required shared reference.
-pub(crate) fn require<'a, T>(ptr: *const T) -> CResult<&'a T> {
-    // SAFETY: non-null checked; validity and aliasing are the caller's
-    // contract per the header ("externally synchronized" handles).
+///
+/// # Safety
+/// `ptr` must be NULL or valid, aligned, initialized and live for the
+/// duration of the call, with no concurrent mutation.
+pub(crate) unsafe fn require<'a, T>(ptr: *const T) -> CResult<&'a T> {
+    // SAFETY: non-null checked here; everything else is this fn's contract.
     unsafe { ptr.as_ref() }.ok_or(CrustStatus::NullArgument)
 }
 
 /// A required exclusive reference.
-pub(crate) fn require_mut<'a, T>(ptr: *mut T) -> CResult<&'a mut T> {
-    // SAFETY: as `require`, plus the header's exclusivity contract.
+///
+/// # Safety
+/// As [`require`], plus: nothing else may access the pointee for the
+/// duration of the call.
+pub(crate) unsafe fn require_mut<'a, T>(ptr: *mut T) -> CResult<&'a mut T> {
+    // SAFETY: non-null checked here; exclusivity is this fn's contract.
     unsafe { ptr.as_mut() }.ok_or(CrustStatus::NullArgument)
 }
 
 /// A required input array of exactly `len` elements (`len > 0`).
-pub(crate) fn slice<'a, T>(ptr: *const T, len: usize) -> CResult<&'a [T]> {
+///
+/// # Safety
+/// `ptr` must be NULL or point to at least `len` valid, aligned,
+/// initialized elements that stay live and unmutated for the call.
+pub(crate) unsafe fn slice<'a, T>(ptr: *const T, len: usize) -> CResult<&'a [T]> {
     if ptr.is_null() {
         return Err(CrustStatus::NullArgument);
     }
     if len == 0 || len > isize::MAX as usize / size_of::<T>().max(1) {
         return Err(CrustStatus::InvalidArgument);
     }
-    // SAFETY: non-null and byte size representable, checked above; contents
-    // and lifetime are the caller's contract.
+    // SAFETY: non-null and byte size representable, checked above; element
+    // validity is this fn's contract.
     Ok(unsafe { std::slice::from_raw_parts(ptr, len) })
 }
 
 /// A required output array of exactly `len` elements.
-pub(crate) fn slice_mut<'a, T>(ptr: *mut T, len: usize) -> CResult<&'a mut [T]> {
+///
+/// # Safety
+/// As [`slice`], plus: nothing else may access the elements for the
+/// duration of the call.
+pub(crate) unsafe fn slice_mut<'a, T>(ptr: *mut T, len: usize) -> CResult<&'a mut [T]> {
     if ptr.is_null() {
         return Err(CrustStatus::NullArgument);
     }
     if len == 0 || len > isize::MAX as usize / size_of::<T>().max(1) {
         return Err(CrustStatus::InvalidArgument);
     }
-    // SAFETY: as `slice`, plus the caller's exclusivity contract for the
-    // duration of the call.
+    // SAFETY: non-null and byte size representable, checked above;
+    // validity and exclusivity are this fn's contract.
     Ok(unsafe { std::slice::from_raw_parts_mut(ptr, len) })
 }
 
@@ -62,8 +82,13 @@ pub(crate) fn finite(v: f32) -> CResult<f32> {
 }
 
 /// A required, all-finite float triple, as the engine's vector type.
-pub(crate) fn finite3(ptr: *const f32) -> CResult<Vec3A> {
-    let v = slice(ptr, 3)?;
+///
+/// # Safety
+/// `ptr` must be NULL or point to at least 3 valid, initialized floats
+/// (see [`slice`]).
+pub(crate) unsafe fn finite3(ptr: *const f32) -> CResult<Vec3A> {
+    // SAFETY: forwarded — this fn carries `slice`'s contract.
+    let v = unsafe { slice(ptr, 3) }?;
     let v = Vec3A::new(v[0], v[1], v[2]);
     if v.is_finite() {
         Ok(v)
@@ -73,9 +98,13 @@ pub(crate) fn finite3(ptr: *const f32) -> CResult<Vec3A> {
 }
 
 /// Writes an out-parameter if the caller supplied one.
-pub(crate) fn write_out<T>(ptr: *mut T, value: T) {
+///
+/// # Safety
+/// `ptr` must be NULL or a valid, aligned, exclusively-accessible slot.
+pub(crate) unsafe fn write_out<T>(ptr: *mut T, value: T) {
     if !ptr.is_null() {
-        // SAFETY: non-null checked; a valid slot is the caller's contract.
+        // SAFETY: non-null checked here; slot validity and exclusivity are
+        // this fn's contract.
         unsafe { *ptr = value };
     }
 }

--- a/crates/crust-capi/tests/abi.rs
+++ b/crates/crust-capi/tests/abi.rs
@@ -543,6 +543,102 @@ fn in_place_edits_match_fresh_builds() {
     crust_scene_destroy(ts_ref.scene);
 }
 
+/// The file-based dome light decodes real image files with the CLI's
+/// semantics (LDR -> linear), errors cleanly on bad paths, and the v2
+/// material defaults carry the coat fields.
+#[test]
+fn dome_light_file_and_material_v2() {
+    let mut material = unsafe { std::mem::zeroed::<CrustMaterial>() };
+    crust_material_default(&mut material);
+    assert_eq!(material.coat_weight, 0.0);
+    assert_eq!(material.coat_roughness, 0.0);
+
+    // A 2x2 white PNG in the temp dir — sRGB 255 decodes to linear 1.0.
+    let png_path = std::env::temp_dir().join("crust_capi_dome_test.png");
+    image::RgbImage::from_pixel(2, 2, image::Rgb([255u8, 255, 255]))
+        .save(&png_path)
+        .expect("write test png");
+    let png_cstr = std::ffi::CString::new(png_path.to_str().unwrap()).unwrap();
+
+    let scene = crust_scene_create();
+    let identity9: [f32; 9] = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+    let tint = [0.5f32, 0.5, 0.5];
+    assert_eq!(
+        crust_scene_add_dome_light_file(
+            scene,
+            tint.as_ptr(),
+            png_cstr.as_ptr(),
+            identity9.as_ptr()
+        ),
+        CrustStatus::Ok
+    );
+    // Error paths: missing file, NULL path.
+    let missing = std::ffi::CString::new("/nonexistent/nowhere.exr").unwrap();
+    assert_eq!(
+        crust_scene_add_dome_light_file(
+            scene,
+            tint.as_ptr(),
+            missing.as_ptr(),
+            identity9.as_ptr()
+        ),
+        CrustStatus::InvalidArgument
+    );
+    assert_eq!(
+        crust_scene_add_dome_light_file(
+            scene,
+            tint.as_ptr(),
+            ptr::null(),
+            identity9.as_ptr()
+        ),
+        CrustStatus::NullArgument
+    );
+
+    // Coated sphere under the textured dome: renders finite and nonzero
+    // (the dome replaces the sky, so escaping rays return tint * texel).
+    material.coat_weight = 0.5;
+    material.coat_roughness = 0.1;
+    let mut id = 0u32;
+    assert_eq!(
+        crust_scene_add_sphere(scene, [0.0f32, 0.0, 0.0].as_ptr(), 1.0, &material, &mut id),
+        CrustStatus::Ok
+    );
+    assert_eq!(
+        crust_scene_set_camera(scene, VIEW.as_ptr(), perspective().as_ptr(), 0.0, 3.0),
+        CrustStatus::Ok
+    );
+    let mut settings = unsafe { std::mem::zeroed::<CrustRenderSettings>() };
+    crust_render_settings_default(&mut settings);
+    settings.width = 16;
+    settings.height = 16;
+    settings.samples_per_pixel = 4;
+    settings.max_depth = 4;
+    assert_eq!(
+        crust_scene_set_render_settings(scene, &settings),
+        CrustStatus::Ok
+    );
+    let renderer = commit(scene, ptr::null());
+    let mut status = CrustStepStatus::InProgress;
+    let mut done = 0u32;
+    while status != CrustStepStatus::Complete {
+        assert_eq!(
+            crust_renderer_step(renderer, 2, &mut status, &mut done),
+            CrustStatus::Ok
+        );
+    }
+    let mut rgba = vec![0.0f32; 16 * 16 * 4];
+    assert_eq!(
+        crust_renderer_read_color(renderer, rgba.as_mut_ptr(), 16 * 16),
+        CrustStatus::Ok
+    );
+    assert!(rgba.iter().all(|v| v.is_finite()));
+    // A corner pixel escapes to the dome: white texel * 0.5 tint = 0.5.
+    assert!((rgba[0] - 0.5).abs() < 1e-3, "corner = {}", rgba[0]);
+
+    crust_renderer_destroy(renderer);
+    crust_scene_destroy(scene);
+    let _ = std::fs::remove_file(&png_path);
+}
+
 #[test]
 fn error_paths_return_their_exact_status() {
     // Null handles.
@@ -626,7 +722,7 @@ fn error_paths_return_their_exact_status() {
     ] {
         assert!(!crust_status_string(status).is_null());
     }
-    assert_eq!(crust_api_version(), 1);
+    assert_eq!(crust_api_version(), 2);
     let (mut ma, mut mi, mut pa) = (0u32, 0u32, 0u32);
     crust_library_version(&mut ma, &mut mi, &mut pa);
     assert!(ma > 0 || mi > 0 || pa > 0);

--- a/crates/crust-capi/tests/abi.rs
+++ b/crates/crust-capi/tests/abi.rs
@@ -1,0 +1,354 @@
+//! Drives the extern "C" surface exactly as a C host would — real pointers,
+//! real status codes — and pins the boundary's contracts: error paths,
+//! progressive determinism through the ABI, AOV sentinels, stop/resume.
+//!
+//! Runs under the test profile, where Cargo forces `panic = "unwind"`, so
+//! the workspace's release `panic = "abort"` does not affect these tests.
+
+use crust_capi::*;
+use std::ptr;
+
+/// Column-major world-to-view: camera at (0,0,3) looking down -Z.
+const VIEW: [f64; 16] = [
+    1.0, 0.0, 0.0, 0.0, //
+    0.0, 1.0, 0.0, 0.0, //
+    0.0, 0.0, 1.0, 0.0, //
+    0.0, 0.0, -3.0, 1.0,
+];
+
+/// Column-major GL perspective, 45° vertical fov, square aspect.
+fn perspective() -> [f64; 16] {
+    let f = 1.0 / (45.0f64.to_radians() / 2.0).tan();
+    let (n, fa) = (0.1, 100.0);
+    [
+        f, 0.0, 0.0, 0.0, //
+        0.0, f, 0.0, 0.0, //
+        0.0, 0.0, -(fa + n) / (fa - n), -1.0, //
+        0.0, 0.0, -2.0 * fa * n / (fa - n), 0.0,
+    ]
+}
+
+/// A quad covering the view center, lit by a sphere light — enough for
+/// nonzero pixels, hit/miss AOV coverage, and a stable geom_id.
+struct TestScene {
+    scene: *mut SceneHandle,
+    quad_id: u32,
+}
+
+fn build_scene(spp: u32) -> TestScene {
+    let scene = crust_scene_create();
+    assert!(!scene.is_null());
+
+    let mut material = unsafe { std::mem::zeroed::<CrustMaterial>() };
+    crust_material_default(&mut material);
+    material.base_color = [0.8, 0.4, 0.2];
+
+    // Two triangles spanning [-0.6, 0.6]^2 at z = 0 (the 45° frustum at
+    // distance 3 spans ±1.24 there, so corners of the image miss).
+    let positions: [f32; 12] = [
+        -0.6, -0.6, 0.0, //
+        0.6, -0.6, 0.0, //
+        0.6, 0.6, 0.0, //
+        -0.6, 0.6, 0.0,
+    ];
+    let indices: [u32; 6] = [0, 1, 2, 0, 2, 3];
+    let mut quad_id = u32::MAX;
+    assert_eq!(
+        crust_scene_add_mesh(
+            scene,
+            positions.as_ptr(),
+            4,
+            indices.as_ptr(),
+            2,
+            ptr::null(),
+            &material,
+            &mut quad_id,
+        ),
+        CrustStatus::Ok
+    );
+    assert_eq!(quad_id, 0, "first geometry gets the first id");
+
+    let status = crust_scene_add_sphere_light(
+        scene,
+        [0.0f32, 0.0, 2.0].as_ptr(),
+        0.5,
+        [12.0f32, 12.0, 12.0].as_ptr(),
+    );
+    assert_eq!(status, CrustStatus::Ok);
+
+    assert_eq!(
+        crust_scene_set_camera(scene, VIEW.as_ptr(), perspective().as_ptr(), 0.0, 3.0),
+        CrustStatus::Ok
+    );
+
+    let mut settings = unsafe { std::mem::zeroed::<CrustRenderSettings>() };
+    crust_render_settings_default(&mut settings);
+    settings.width = 32;
+    settings.height = 32;
+    settings.samples_per_pixel = spp;
+    settings.max_depth = 4;
+    assert_eq!(
+        crust_scene_set_render_settings(scene, &settings),
+        CrustStatus::Ok
+    );
+
+    TestScene { scene, quad_id }
+}
+
+fn commit(scene: *mut SceneHandle, token: *const TokenHandle) -> *mut RendererHandle {
+    let mut renderer: *mut RendererHandle = ptr::null_mut();
+    assert_eq!(
+        crust_scene_commit(scene, token, &mut renderer),
+        CrustStatus::Ok
+    );
+    assert!(!renderer.is_null());
+    renderer
+}
+
+fn read_rgba(renderer: *mut RendererHandle) -> Vec<f32> {
+    let mut out = vec![0.0f32; 32 * 32 * 4];
+    assert_eq!(
+        crust_renderer_read_color(renderer, out.as_mut_ptr(), 32 * 32),
+        CrustStatus::Ok
+    );
+    out
+}
+
+#[test]
+fn renders_deterministically_through_the_abi() {
+    let run = || -> Vec<f32> {
+        let ts = build_scene(8);
+        let renderer = commit(ts.scene, ptr::null());
+        // Uneven chunks on purpose: chunking must not change the result.
+        let mut status = CrustStepStatus::InProgress;
+        let mut spp_done = 0u32;
+        for chunk in [3u32, 1, 4, 8] {
+            if status == CrustStepStatus::Complete {
+                break;
+            }
+            assert_eq!(
+                crust_renderer_step(renderer, chunk, &mut status, &mut spp_done),
+                CrustStatus::Ok
+            );
+        }
+        assert_eq!(status, CrustStepStatus::Complete);
+        assert_eq!(spp_done, 8);
+        assert!(crust_renderer_is_converged(renderer));
+        assert_eq!(crust_renderer_spp_done(renderer), 8);
+
+        let rgba = read_rgba(renderer);
+        crust_renderer_destroy(renderer);
+        crust_scene_destroy(ts.scene);
+        rgba
+    };
+
+    let a = run();
+    let b = run();
+    assert!(
+        a.iter().any(|v| *v > 0.0),
+        "image is all black — the light or camera wiring is broken"
+    );
+    assert!(a.iter().all(|v| v.is_finite()));
+    let bits = |v: &[f32]| v.iter().map(|f| f.to_bits()).collect::<Vec<_>>();
+    assert_eq!(bits(&a), bits(&b), "two identical runs must be bit-identical");
+}
+
+#[test]
+fn aov_planes_report_hits_and_misses() {
+    let ts = build_scene(2);
+    let renderer = commit(ts.scene, ptr::null());
+    let mut status = CrustStepStatus::InProgress;
+    let mut done = 0u32;
+    assert_eq!(
+        crust_renderer_step(renderer, 2, &mut status, &mut done),
+        CrustStatus::Ok
+    );
+
+    let mut width = 0u32;
+    let mut height = 0u32;
+    crust_renderer_get_dimensions(renderer, &mut width, &mut height);
+    assert_eq!((width, height), (32, 32));
+    let px = (width * height) as usize;
+    let center = (16 * 32 + 16) as usize;
+    let corner = 0usize;
+
+    let mut depth = vec![0.0f32; px];
+    let mut normal = vec![0.0f32; px * 3];
+    let mut ids = vec![0u32; px * 2];
+    let mut alpha = vec![0.0f32; px];
+    assert_eq!(
+        crust_renderer_read_aov_depth(renderer, depth.as_mut_ptr(), px),
+        CrustStatus::Ok
+    );
+    assert_eq!(
+        crust_renderer_read_aov_normal(renderer, normal.as_mut_ptr(), px),
+        CrustStatus::Ok
+    );
+    assert_eq!(
+        crust_renderer_read_aov_id(renderer, ids.as_mut_ptr(), px),
+        CrustStatus::Ok
+    );
+    assert_eq!(
+        crust_renderer_read_aov_alpha(renderer, alpha.as_mut_ptr(), px),
+        CrustStatus::Ok
+    );
+
+    assert_eq!(alpha[center], 1.0);
+    assert_eq!(alpha[corner], 0.0);
+    assert!(
+        (depth[center] - 3.0).abs() < 0.05,
+        "quad at z=0 seen from z=3: depth {} != 3",
+        depth[center]
+    );
+    assert_eq!(depth[corner], f32::INFINITY);
+    // The quad faces the camera: outward normal is +Z.
+    assert!((normal[center * 3 + 2] - 1.0).abs() < 0.05);
+    assert_eq!([ids[center * 2], ids[center * 2 + 1]], [ts.quad_id, 1]);
+    assert_eq!(
+        [ids[corner * 2], ids[corner * 2 + 1]],
+        [u32::MAX, u32::MAX]
+    );
+
+    // Color alpha channel mirrors the alpha AOV.
+    let rgba = read_rgba(renderer);
+    assert_eq!(rgba[center * 4 + 3], 1.0);
+    assert_eq!(rgba[corner * 4 + 3], 0.0);
+
+    crust_renderer_destroy(renderer);
+    crust_scene_destroy(ts.scene);
+}
+
+#[test]
+fn stop_token_interrupts_and_resumes() {
+    let ts = build_scene(8);
+    let token = crust_stop_token_create();
+    assert!(!crust_stop_token_is_stopped(token));
+    let renderer = commit(ts.scene, token);
+
+    // Fire before the first row: the step is cut short immediately.
+    crust_stop_token_stop(token);
+    assert!(crust_stop_token_is_stopped(token));
+    let mut status = CrustStepStatus::InProgress;
+    let mut done = 99u32;
+    assert_eq!(
+        crust_renderer_step(renderer, 8, &mut status, &mut done),
+        CrustStatus::Ok
+    );
+    assert_eq!(status, CrustStepStatus::Stopped);
+    assert_eq!(done, 0);
+    assert!(!crust_renderer_is_converged(renderer));
+    // The partial image is readable and coherent (all black here).
+    let rgba = read_rgba(renderer);
+    assert!(rgba.iter().all(|v| v.is_finite()));
+
+    // A stopped token is permanent — build the same scene with a fresh
+    // token and confirm it completes; also proves the reference render.
+    let ts2 = build_scene(8);
+    let token2 = crust_stop_token_create();
+    let renderer2 = commit(ts2.scene, token2);
+    let mut status2 = CrustStepStatus::InProgress;
+    let mut done2 = 0u32;
+    while status2 != CrustStepStatus::Complete {
+        assert_eq!(
+            crust_renderer_step(renderer2, 4, &mut status2, &mut done2),
+            CrustStatus::Ok
+        );
+    }
+    assert!(crust_renderer_is_converged(renderer2));
+
+    crust_renderer_destroy(renderer);
+    crust_renderer_destroy(renderer2);
+    crust_scene_destroy(ts.scene);
+    crust_scene_destroy(ts2.scene);
+    crust_stop_token_destroy(token);
+    crust_stop_token_destroy(token2);
+}
+
+#[test]
+fn error_paths_return_their_exact_status() {
+    // Null handles.
+    let mut out_id = 0u32;
+    let material = {
+        let mut m = unsafe { std::mem::zeroed::<CrustMaterial>() };
+        crust_material_default(&mut m);
+        m
+    };
+    let p = [0.0f32; 3];
+    assert_eq!(
+        crust_scene_add_sphere(ptr::null_mut(), p.as_ptr(), 1.0, &material, &mut out_id),
+        CrustStatus::NullArgument
+    );
+
+    let scene = crust_scene_create();
+    // Null required arrays.
+    assert_eq!(
+        crust_scene_add_mesh(scene, ptr::null(), 3, ptr::null(), 1, ptr::null(), &material, &mut out_id),
+        CrustStatus::NullArgument
+    );
+    // Invalid values.
+    assert_eq!(
+        crust_scene_add_sphere(scene, p.as_ptr(), -1.0, &material, &mut out_id),
+        CrustStatus::InvalidArgument
+    );
+    assert_eq!(
+        crust_scene_add_sphere(scene, [f32::NAN, 0.0, 0.0].as_ptr(), 1.0, &material, &mut out_id),
+        CrustStatus::InvalidArgument
+    );
+
+    // Commit without camera/settings.
+    let mut renderer: *mut RendererHandle = ptr::null_mut();
+    assert_eq!(
+        crust_scene_commit(scene, ptr::null(), &mut renderer),
+        CrustStatus::BadState
+    );
+
+    // Orthographic projection is rejected.
+    let ortho: [f64; 16] = [
+        1.0, 0.0, 0.0, 0.0, //
+        0.0, 1.0, 0.0, 0.0, //
+        0.0, 0.0, -0.02, 0.0, //
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    assert_eq!(
+        crust_scene_set_camera(scene, VIEW.as_ptr(), ortho.as_ptr(), 0.0, 3.0),
+        CrustStatus::InvalidCamera
+    );
+    crust_scene_destroy(scene);
+
+    // Use-after-commit and read-capacity checks on a real render.
+    let ts = build_scene(2);
+    let renderer = commit(ts.scene, ptr::null());
+    assert_eq!(
+        crust_scene_add_sphere(ts.scene, p.as_ptr(), 1.0, &material, &mut out_id),
+        CrustStatus::BadState,
+        "a committed scene is spent"
+    );
+    let mut rgba = vec![0.0f32; 8];
+    assert_eq!(
+        crust_renderer_read_color(renderer, rgba.as_mut_ptr(), 2),
+        CrustStatus::BufferTooSmall
+    );
+    let mut status = CrustStepStatus::InProgress;
+    assert_eq!(
+        crust_renderer_step(renderer, 0, &mut status, ptr::null_mut()),
+        CrustStatus::InvalidArgument
+    );
+    crust_renderer_destroy(renderer);
+    crust_scene_destroy(ts.scene);
+
+    // Status strings exist for every code.
+    for status in [
+        CrustStatus::Ok,
+        CrustStatus::NullArgument,
+        CrustStatus::InvalidArgument,
+        CrustStatus::InvalidCamera,
+        CrustStatus::BadState,
+        CrustStatus::BufferTooSmall,
+    ] {
+        assert!(!crust_status_string(status).is_null());
+    }
+    assert_eq!(crust_api_version(), 1);
+    let (mut ma, mut mi, mut pa) = (0u32, 0u32, 0u32);
+    crust_library_version(&mut ma, &mut mi, &mut pa);
+    assert!(ma > 0 || mi > 0 || pa > 0);
+}

--- a/crates/crust-capi/tests/abi.rs
+++ b/crates/crust-capi/tests/abi.rs
@@ -264,6 +264,285 @@ fn stop_token_interrupts_and_resumes() {
     crust_stop_token_destroy(token2);
 }
 
+/// Builds the standard test scene with the quad placed through the
+/// geometry cache as an instance. `arrays` controls whether the vertex
+/// data is supplied (a cache hit does not need it).
+fn build_instanced_scene(
+    cache: *mut GeoCacheHandle,
+    version: u32,
+    arrays: bool,
+    xform: &[f64; 16],
+) -> *mut SceneHandle {
+    let scene = crust_scene_create();
+    let mut material = unsafe { std::mem::zeroed::<CrustMaterial>() };
+    crust_material_default(&mut material);
+    material.base_color = [0.8, 0.4, 0.2];
+
+    let positions: [f32; 12] = [
+        -0.6, -0.6, 0.0, //
+        0.6, -0.6, 0.0, //
+        0.6, 0.6, 0.0, //
+        -0.6, 0.6, 0.0,
+    ];
+    let indices: [u32; 6] = [0, 1, 2, 0, 2, 3];
+    let mut id = u32::MAX;
+    let status = crust_scene_add_instance(
+        scene,
+        cache,
+        0xC0FFEE,
+        version,
+        if arrays { positions.as_ptr() } else { ptr::null() },
+        4,
+        if arrays { indices.as_ptr() } else { ptr::null() },
+        2,
+        ptr::null(),
+        xform.as_ptr(),
+        &material,
+        &mut id,
+    );
+    assert_eq!(status, CrustStatus::Ok);
+
+    assert_eq!(
+        crust_scene_add_sphere_light(
+            scene,
+            [0.0f32, 0.0, 2.0].as_ptr(),
+            0.5,
+            [12.0f32, 12.0, 12.0].as_ptr(),
+        ),
+        CrustStatus::Ok
+    );
+    assert_eq!(
+        crust_scene_set_camera(scene, VIEW.as_ptr(), perspective().as_ptr(), 0.0, 3.0),
+        CrustStatus::Ok
+    );
+    let mut settings = unsafe { std::mem::zeroed::<CrustRenderSettings>() };
+    crust_render_settings_default(&mut settings);
+    settings.width = 32;
+    settings.height = 32;
+    settings.samples_per_pixel = 8;
+    settings.max_depth = 4;
+    assert_eq!(
+        crust_scene_set_render_settings(scene, &settings),
+        CrustStatus::Ok
+    );
+    scene
+}
+
+fn render_to_completion(renderer: *mut RendererHandle) -> Vec<f32> {
+    let mut status = CrustStepStatus::InProgress;
+    let mut done = 0u32;
+    while status != CrustStepStatus::Complete {
+        assert_eq!(
+            crust_renderer_step(renderer, 4, &mut status, &mut done),
+            CrustStatus::Ok
+        );
+    }
+    read_rgba(renderer)
+}
+
+const IDENTITY: [f64; 16] = [
+    1.0, 0.0, 0.0, 0.0, //
+    0.0, 1.0, 0.0, 0.0, //
+    0.0, 0.0, 1.0, 0.0, //
+    0.0, 0.0, 0.0, 1.0,
+];
+
+/// The geometry cache must be invisible in the image: a cache-hit rebuild
+/// (NULL vertex arrays) renders bit-identically to the miss that populated
+/// it, and version bumps invalidate.
+#[test]
+fn geo_cache_hits_render_bit_identical() {
+    let cache = crust_geo_cache_create();
+    assert!(!crust_geo_cache_contains(cache, 0xC0FFEE, 1));
+
+    // Miss: arrays supplied, prototype committed and cached.
+    let scene_a = build_instanced_scene(cache, 1, true, &IDENTITY);
+    assert!(crust_geo_cache_contains(cache, 0xC0FFEE, 1));
+    assert!(!crust_geo_cache_contains(cache, 0xC0FFEE, 2));
+    let renderer_a = commit(scene_a, ptr::null());
+    let a = render_to_completion(renderer_a);
+
+    // Hit: NULL arrays, same key+version, same everything else.
+    let scene_b = build_instanced_scene(cache, 1, false, &IDENTITY);
+    let renderer_b = commit(scene_b, ptr::null());
+    let b = render_to_completion(renderer_b);
+
+    assert!(a.iter().any(|v| *v > 0.0));
+    let bits = |v: &[f32]| v.iter().map(|f| f.to_bits()).collect::<Vec<_>>();
+    assert_eq!(bits(&a), bits(&b), "cache hit must not change the image");
+
+    // A miss with NULL arrays is an error (version bumped, no data).
+    let scene_c = crust_scene_create();
+    let mut material = unsafe { std::mem::zeroed::<CrustMaterial>() };
+    crust_material_default(&mut material);
+    let mut id = 0u32;
+    assert_eq!(
+        crust_scene_add_instance(
+            scene_c,
+            cache,
+            0xC0FFEE,
+            2,
+            ptr::null(),
+            4,
+            ptr::null(),
+            2,
+            ptr::null(),
+            IDENTITY.as_ptr(),
+            &material,
+            &mut id,
+        ),
+        CrustStatus::NullArgument
+    );
+    // A singular placement is rejected.
+    let zero_scale: [f64; 16] = [0.0; 16];
+    let positions: [f32; 9] = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+    let indices: [u32; 3] = [0, 1, 2];
+    assert_eq!(
+        crust_scene_add_instance(
+            scene_c,
+            cache,
+            7,
+            1,
+            positions.as_ptr(),
+            3,
+            indices.as_ptr(),
+            1,
+            ptr::null(),
+            zero_scale.as_ptr(),
+            &material,
+            &mut id,
+        ),
+        CrustStatus::InvalidArgument
+    );
+    crust_scene_destroy(scene_c);
+
+    // Removal forgets the key; clear forgets everything.
+    crust_geo_cache_remove(cache, 0xC0FFEE);
+    assert!(!crust_geo_cache_contains(cache, 0xC0FFEE, 1));
+    crust_geo_cache_clear(cache);
+
+    // Renderers keep their prototypes alive through the Arc regardless.
+    let a2 = read_rgba(renderer_a);
+    assert_eq!(bits(&a), bits(&a2));
+
+    crust_renderer_destroy(renderer_a);
+    crust_renderer_destroy(renderer_b);
+    crust_scene_destroy(scene_a);
+    crust_scene_destroy(scene_b);
+    crust_geo_cache_destroy(cache);
+    crust_geo_cache_destroy(ptr::null_mut()); // NULL is a no-op
+}
+
+/// In-place camera and settings edits restart sampling without a rebuild
+/// and land on exactly the image a fresh build would produce.
+#[test]
+fn in_place_edits_match_fresh_builds() {
+    // Reference: fresh build with the SHIFTED camera.
+    let mut shifted_view = VIEW;
+    shifted_view[12] = -0.4; // translate x
+    let ts_ref = build_scene(8);
+    assert_eq!(
+        crust_scene_set_camera(
+            ts_ref.scene,
+            shifted_view.as_ptr(),
+            perspective().as_ptr(),
+            0.0,
+            3.0
+        ),
+        CrustStatus::Ok
+    );
+    let renderer_ref = commit(ts_ref.scene, ptr::null());
+    let reference = render_to_completion(renderer_ref);
+
+    // Edited: build with the ORIGINAL camera, render some, then update.
+    let ts = build_scene(8);
+    let renderer = commit(ts.scene, ptr::null());
+    let mut status = CrustStepStatus::InProgress;
+    let mut done = 0u32;
+    assert_eq!(
+        crust_renderer_step(renderer, 3, &mut status, &mut done),
+        CrustStatus::Ok
+    );
+    let token = crust_stop_token_create();
+    assert_eq!(
+        crust_renderer_update_camera(
+            renderer,
+            shifted_view.as_ptr(),
+            perspective().as_ptr(),
+            0.0,
+            3.0,
+            token,
+        ),
+        CrustStatus::Ok
+    );
+    // Progress restarted from zero.
+    assert_eq!(crust_renderer_spp_done(renderer), 0);
+    assert!(!crust_renderer_is_converged(renderer));
+    let edited = render_to_completion(renderer);
+
+    let bits = |v: &[f32]| v.iter().map(|f| f.to_bits()).collect::<Vec<_>>();
+    assert!(reference.iter().any(|v| *v > 0.0));
+    assert_eq!(
+        bits(&reference),
+        bits(&edited),
+        "update_camera must land on the fresh-build image"
+    );
+
+    // Settings edit: resolution change resizes the outputs.
+    let mut settings = unsafe { std::mem::zeroed::<CrustRenderSettings>() };
+    crust_render_settings_default(&mut settings);
+    settings.width = 16;
+    settings.height = 16;
+    settings.samples_per_pixel = 4;
+    settings.max_depth = 4;
+    assert_eq!(
+        crust_renderer_update_settings(renderer, &settings, ptr::null()),
+        CrustStatus::Ok
+    );
+    let mut w = 0u32;
+    let mut h = 0u32;
+    crust_renderer_get_dimensions(renderer, &mut w, &mut h);
+    assert_eq!((w, h), (16, 16));
+    let mut small = vec![0.0f32; 16 * 16 * 4];
+    let mut st = CrustStepStatus::InProgress;
+    while st != CrustStepStatus::Complete {
+        assert_eq!(
+            crust_renderer_step(renderer, 2, &mut st, &mut done),
+            CrustStatus::Ok
+        );
+    }
+    assert_eq!(
+        crust_renderer_read_color(renderer, small.as_mut_ptr(), 16 * 16),
+        CrustStatus::Ok
+    );
+    assert!(small.iter().all(|v| v.is_finite()));
+
+    // Error paths.
+    let ortho: [f64; 16] = [
+        1.0, 0.0, 0.0, 0.0, //
+        0.0, 1.0, 0.0, 0.0, //
+        0.0, 0.0, -0.02, 0.0, //
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    assert_eq!(
+        crust_renderer_update_camera(
+            renderer,
+            VIEW.as_ptr(),
+            ortho.as_ptr(),
+            0.0,
+            3.0,
+            ptr::null()
+        ),
+        CrustStatus::InvalidCamera
+    );
+
+    crust_stop_token_destroy(token);
+    crust_renderer_destroy(renderer);
+    crust_renderer_destroy(renderer_ref);
+    crust_scene_destroy(ts.scene);
+    crust_scene_destroy(ts_ref.scene);
+}
+
 #[test]
 fn error_paths_return_their_exact_status() {
     // Null handles.

--- a/crates/crust-capi/tests/abi.rs
+++ b/crates/crust-capi/tests/abi.rs
@@ -36,10 +36,14 @@ struct TestScene {
 }
 
 fn build_scene(spp: u32) -> TestScene {
+    // SAFETY: this test drives the C ABI with locally-owned, valid,
+    // exclusively-held pointers and correct array lengths - precisely
+    // the crust.h contract the exports' `# Safety` sections require.
+    unsafe {
     let scene = crust_scene_create();
     assert!(!scene.is_null());
 
-    let mut material = unsafe { std::mem::zeroed::<CrustMaterial>() };
+    let mut material = std::mem::zeroed::<CrustMaterial>();
     crust_material_default(&mut material);
     material.base_color = [0.8, 0.4, 0.2];
 
@@ -81,7 +85,7 @@ fn build_scene(spp: u32) -> TestScene {
         CrustStatus::Ok
     );
 
-    let mut settings = unsafe { std::mem::zeroed::<CrustRenderSettings>() };
+    let mut settings = std::mem::zeroed::<CrustRenderSettings>();
     crust_render_settings_default(&mut settings);
     settings.width = 32;
     settings.height = 32;
@@ -93,9 +97,14 @@ fn build_scene(spp: u32) -> TestScene {
     );
 
     TestScene { scene, quad_id }
+    }
 }
 
 fn commit(scene: *mut SceneHandle, token: *const TokenHandle) -> *mut RendererHandle {
+    // SAFETY: this test drives the C ABI with locally-owned, valid,
+    // exclusively-held pointers and correct array lengths - precisely
+    // the crust.h contract the exports' `# Safety` sections require.
+    unsafe {
     let mut renderer: *mut RendererHandle = ptr::null_mut();
     assert_eq!(
         crust_scene_commit(scene, token, &mut renderer),
@@ -103,19 +112,29 @@ fn commit(scene: *mut SceneHandle, token: *const TokenHandle) -> *mut RendererHa
     );
     assert!(!renderer.is_null());
     renderer
+    }
 }
 
 fn read_rgba(renderer: *mut RendererHandle) -> Vec<f32> {
+    // SAFETY: this test drives the C ABI with locally-owned, valid,
+    // exclusively-held pointers and correct array lengths - precisely
+    // the crust.h contract the exports' `# Safety` sections require.
+    unsafe {
     let mut out = vec![0.0f32; 32 * 32 * 4];
     assert_eq!(
         crust_renderer_read_color(renderer, out.as_mut_ptr(), 32 * 32),
         CrustStatus::Ok
     );
     out
+    }
 }
 
 #[test]
 fn renders_deterministically_through_the_abi() {
+    // SAFETY: this test drives the C ABI with locally-owned, valid,
+    // exclusively-held pointers and correct array lengths - precisely
+    // the crust.h contract the exports' `# Safety` sections require.
+    unsafe {
     let run = || -> Vec<f32> {
         let ts = build_scene(8);
         let renderer = commit(ts.scene, ptr::null());
@@ -151,10 +170,15 @@ fn renders_deterministically_through_the_abi() {
     assert!(a.iter().all(|v| v.is_finite()));
     let bits = |v: &[f32]| v.iter().map(|f| f.to_bits()).collect::<Vec<_>>();
     assert_eq!(bits(&a), bits(&b), "two identical runs must be bit-identical");
+    }
 }
 
 #[test]
 fn aov_planes_report_hits_and_misses() {
+    // SAFETY: this test drives the C ABI with locally-owned, valid,
+    // exclusively-held pointers and correct array lengths - precisely
+    // the crust.h contract the exports' `# Safety` sections require.
+    unsafe {
     let ts = build_scene(2);
     let renderer = commit(ts.scene, ptr::null());
     let mut status = CrustStepStatus::InProgress;
@@ -216,10 +240,15 @@ fn aov_planes_report_hits_and_misses() {
 
     crust_renderer_destroy(renderer);
     crust_scene_destroy(ts.scene);
+    }
 }
 
 #[test]
 fn stop_token_interrupts_and_resumes() {
+    // SAFETY: this test drives the C ABI with locally-owned, valid,
+    // exclusively-held pointers and correct array lengths - precisely
+    // the crust.h contract the exports' `# Safety` sections require.
+    unsafe {
     let ts = build_scene(8);
     let token = crust_stop_token_create();
     assert!(!crust_stop_token_is_stopped(token));
@@ -262,6 +291,7 @@ fn stop_token_interrupts_and_resumes() {
     crust_scene_destroy(ts2.scene);
     crust_stop_token_destroy(token);
     crust_stop_token_destroy(token2);
+    }
 }
 
 /// Builds the standard test scene with the quad placed through the
@@ -273,8 +303,12 @@ fn build_instanced_scene(
     arrays: bool,
     xform: &[f64; 16],
 ) -> *mut SceneHandle {
+    // SAFETY: this test drives the C ABI with locally-owned, valid,
+    // exclusively-held pointers and correct array lengths - precisely
+    // the crust.h contract the exports' `# Safety` sections require.
+    unsafe {
     let scene = crust_scene_create();
-    let mut material = unsafe { std::mem::zeroed::<CrustMaterial>() };
+    let mut material = std::mem::zeroed::<CrustMaterial>();
     crust_material_default(&mut material);
     material.base_color = [0.8, 0.4, 0.2];
 
@@ -315,7 +349,7 @@ fn build_instanced_scene(
         crust_scene_set_camera(scene, VIEW.as_ptr(), perspective().as_ptr(), 0.0, 3.0),
         CrustStatus::Ok
     );
-    let mut settings = unsafe { std::mem::zeroed::<CrustRenderSettings>() };
+    let mut settings = std::mem::zeroed::<CrustRenderSettings>();
     crust_render_settings_default(&mut settings);
     settings.width = 32;
     settings.height = 32;
@@ -326,9 +360,14 @@ fn build_instanced_scene(
         CrustStatus::Ok
     );
     scene
+    }
 }
 
 fn render_to_completion(renderer: *mut RendererHandle) -> Vec<f32> {
+    // SAFETY: this test drives the C ABI with locally-owned, valid,
+    // exclusively-held pointers and correct array lengths - precisely
+    // the crust.h contract the exports' `# Safety` sections require.
+    unsafe {
     let mut status = CrustStepStatus::InProgress;
     let mut done = 0u32;
     while status != CrustStepStatus::Complete {
@@ -338,6 +377,7 @@ fn render_to_completion(renderer: *mut RendererHandle) -> Vec<f32> {
         );
     }
     read_rgba(renderer)
+    }
 }
 
 const IDENTITY: [f64; 16] = [
@@ -352,6 +392,10 @@ const IDENTITY: [f64; 16] = [
 /// it, and version bumps invalidate.
 #[test]
 fn geo_cache_hits_render_bit_identical() {
+    // SAFETY: this test drives the C ABI with locally-owned, valid,
+    // exclusively-held pointers and correct array lengths - precisely
+    // the crust.h contract the exports' `# Safety` sections require.
+    unsafe {
     let cache = crust_geo_cache_create();
     assert!(!crust_geo_cache_contains(cache, 0xC0FFEE, 1));
 
@@ -373,7 +417,7 @@ fn geo_cache_hits_render_bit_identical() {
 
     // A miss with NULL arrays is an error (version bumped, no data).
     let scene_c = crust_scene_create();
-    let mut material = unsafe { std::mem::zeroed::<CrustMaterial>() };
+    let mut material = std::mem::zeroed::<CrustMaterial>();
     crust_material_default(&mut material);
     let mut id = 0u32;
     assert_eq!(
@@ -431,12 +475,17 @@ fn geo_cache_hits_render_bit_identical() {
     crust_scene_destroy(scene_b);
     crust_geo_cache_destroy(cache);
     crust_geo_cache_destroy(ptr::null_mut()); // NULL is a no-op
+    }
 }
 
 /// In-place camera and settings edits restart sampling without a rebuild
 /// and land on exactly the image a fresh build would produce.
 #[test]
 fn in_place_edits_match_fresh_builds() {
+    // SAFETY: this test drives the C ABI with locally-owned, valid,
+    // exclusively-held pointers and correct array lengths - precisely
+    // the crust.h contract the exports' `# Safety` sections require.
+    unsafe {
     // Reference: fresh build with the SHIFTED camera.
     let mut shifted_view = VIEW;
     shifted_view[12] = -0.4; // translate x
@@ -489,7 +538,7 @@ fn in_place_edits_match_fresh_builds() {
     );
 
     // Settings edit: resolution change resizes the outputs.
-    let mut settings = unsafe { std::mem::zeroed::<CrustRenderSettings>() };
+    let mut settings = std::mem::zeroed::<CrustRenderSettings>();
     crust_render_settings_default(&mut settings);
     settings.width = 16;
     settings.height = 16;
@@ -541,6 +590,7 @@ fn in_place_edits_match_fresh_builds() {
     crust_renderer_destroy(renderer_ref);
     crust_scene_destroy(ts.scene);
     crust_scene_destroy(ts_ref.scene);
+    }
 }
 
 /// The file-based dome light decodes real image files with the CLI's
@@ -548,7 +598,11 @@ fn in_place_edits_match_fresh_builds() {
 /// material defaults carry the coat fields.
 #[test]
 fn dome_light_file_and_material_v2() {
-    let mut material = unsafe { std::mem::zeroed::<CrustMaterial>() };
+    // SAFETY: this test drives the C ABI with locally-owned, valid,
+    // exclusively-held pointers and correct array lengths - precisely
+    // the crust.h contract the exports' `# Safety` sections require.
+    unsafe {
+    let mut material = std::mem::zeroed::<CrustMaterial>();
     crust_material_default(&mut material);
     assert_eq!(material.coat_weight, 0.0);
     assert_eq!(material.coat_roughness, 0.0);
@@ -606,7 +660,7 @@ fn dome_light_file_and_material_v2() {
         crust_scene_set_camera(scene, VIEW.as_ptr(), perspective().as_ptr(), 0.0, 3.0),
         CrustStatus::Ok
     );
-    let mut settings = unsafe { std::mem::zeroed::<CrustRenderSettings>() };
+    let mut settings = std::mem::zeroed::<CrustRenderSettings>();
     crust_render_settings_default(&mut settings);
     settings.width = 16;
     settings.height = 16;
@@ -637,14 +691,19 @@ fn dome_light_file_and_material_v2() {
     crust_renderer_destroy(renderer);
     crust_scene_destroy(scene);
     let _ = std::fs::remove_file(&png_path);
+    }
 }
 
 #[test]
 fn error_paths_return_their_exact_status() {
+    // SAFETY: this test drives the C ABI with locally-owned, valid,
+    // exclusively-held pointers and correct array lengths - precisely
+    // the crust.h contract the exports' `# Safety` sections require.
+    unsafe {
     // Null handles.
     let mut out_id = 0u32;
     let material = {
-        let mut m = unsafe { std::mem::zeroed::<CrustMaterial>() };
+        let mut m = std::mem::zeroed::<CrustMaterial>();
         crust_material_default(&mut m);
         m
     };
@@ -726,4 +785,5 @@ fn error_paths_return_their_exact_status() {
     let (mut ma, mut mi, mut pa) = (0u32, 0u32, 0u32);
     crust_library_version(&mut ma, &mut mi, &mut pa);
     assert!(ma > 0 || mi > 0 || pa > 0);
+    }
 }

--- a/crates/crust-capi/tests/smoke.c
+++ b/crates/crust-capi/tests/smoke.c
@@ -135,6 +135,96 @@ static void render_to_completion(CrustRenderer* renderer, float* rgba) {
   CHECK(crust_renderer_read_color(renderer, rgba, PX));
 }
 
+/* Phase 2 surface: geometry cache, instanced placement, in-place edits,
+ * file-based dome lights. */
+static void exercise_phase2(void) {
+  CrustGeoCache* cache = crust_geo_cache_create();
+  assert(cache != NULL);
+  assert(!crust_geo_cache_contains(cache, 42, 1));
+
+  CrustScene* scene = crust_scene_create();
+  CrustMaterial material;
+  crust_material_default(&material);
+  assert(material.coat_weight == 0.0f && material.coat_roughness == 0.0f);
+  material.base_color[0] = 0.9f;
+  material.coat_weight = 0.3f;
+
+  const float positions[9] = {-0.5f, -0.5f, 0.0f, 0.5f, -0.5f, 0.0f,
+                              0.0f,  0.5f,  0.0f};
+  const uint32_t indices[3] = {0, 1, 2};
+  const double identity[16] = {1, 0, 0, 0, 0, 1, 0, 0,
+                               0, 0, 1, 0, 0, 0, 0, 1};
+  uint32_t id_a = 0, id_b = 0;
+  /* Miss populates the cache; hit places the shared prototype with NULL
+   * arrays. */
+  CHECK(crust_scene_add_instance(scene, cache, 42, 1, positions, 3, indices,
+                                 1, NULL, identity, &material, &id_a));
+  assert(crust_geo_cache_contains(cache, 42, 1));
+  const double shifted[16] = {1, 0, 0, 0, 0, 1, 0, 0,
+                              0, 0, 1, 0, 1.5, 0, 0, 1};
+  CHECK(crust_scene_add_instance(scene, cache, 42, 1, NULL, 0, NULL, 0, NULL,
+                                 shifted, &material, &id_b));
+  assert(id_b == id_a + 1);
+
+  /* Dome-light file: a missing path is a clean error, not a crash. */
+  const float tint[3] = {0.2f, 0.2f, 0.2f};
+  const float identity9[9] = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+  assert(crust_scene_add_dome_light_file(scene, tint, "/no/such/file.exr",
+                                         identity9) ==
+         CRUST_ERROR_INVALID_ARGUMENT);
+  CHECK(crust_scene_add_dome_light(scene, tint, 0, 0, NULL, identity9));
+
+  double proj[16];
+  gl_perspective(proj);
+  CHECK(crust_scene_set_camera(scene, kView, proj, 0.0f, 3.0f));
+  CrustRenderSettings settings;
+  crust_render_settings_default(&settings);
+  settings.width = 16;
+  settings.height = 16;
+  settings.samples_per_pixel = 4;
+  settings.max_depth = 4;
+  CHECK(crust_scene_set_render_settings(scene, &settings));
+
+  CrustRenderer* renderer = NULL;
+  CHECK(crust_scene_commit(scene, NULL, &renderer));
+  crust_scene_destroy(scene);
+
+  CrustStepStatus status = CRUST_STEP_IN_PROGRESS;
+  uint32_t done = 0;
+  CHECK(crust_renderer_step(renderer, 2, &status, &done));
+
+  /* In-place edits: camera shift and a resolution change both restart
+   * sampling without a rebuild. */
+  double view2[16];
+  memcpy(view2, kView, sizeof(view2));
+  view2[12] = 0.25; /* translate x */
+  CrustStopToken* fresh = crust_stop_token_create();
+  CHECK(crust_renderer_update_camera(renderer, view2, proj, 0.0f, 3.0f, fresh));
+  assert(crust_renderer_spp_done(renderer) == 0);
+  settings.width = 8;
+  settings.height = 8;
+  CHECK(crust_renderer_update_settings(renderer, &settings, NULL));
+  uint32_t w = 0, h = 0;
+  crust_renderer_get_dimensions(renderer, &w, &h);
+  assert(w == 8 && h == 8);
+  status = CRUST_STEP_IN_PROGRESS;
+  while (status != CRUST_STEP_COMPLETE) {
+    CHECK(crust_renderer_step(renderer, 2, &status, &done));
+  }
+  static float small[8 * 8 * 4];
+  CHECK(crust_renderer_read_color(renderer, small, 8 * 8));
+  for (size_t i = 0; i < 8 * 8 * 4; i++) assert(!isnan(small[i]));
+
+  crust_stop_token_destroy(fresh);
+  crust_renderer_destroy(renderer);
+  crust_geo_cache_remove(cache, 42);
+  assert(!crust_geo_cache_contains(cache, 42, 1));
+  crust_geo_cache_clear(cache);
+  crust_geo_cache_destroy(cache);
+  crust_geo_cache_destroy(NULL); /* NULL is a no-op */
+  printf("smoke.c: phase 2 surface OK\n");
+}
+
 int main(void) {
   assert(crust_api_version() == CRUST_API_VERSION);
   uint32_t major = 0, minor = 0, patch = 0;
@@ -212,6 +302,8 @@ int main(void) {
   crust_stop_token_destroy(NULL); /* NULL is a no-op */
   crust_renderer_destroy(NULL);
   crust_scene_destroy(NULL);
+
+  exercise_phase2();
 
   printf("smoke.c: all checks passed (%d nonzero channel values)\n", nonzero);
   return 0;

--- a/crates/crust-capi/tests/smoke.c
+++ b/crates/crust-capi/tests/smoke.c
@@ -1,0 +1,218 @@
+/* The C half of the ABI guard: compiles the real crust.h with
+ * -Wall -Wextra -Werror, links the real cdylib, and exercises every
+ * exported symbol at least once. Mirrors tests/abi.rs: a lit quad,
+ * stepped to completion twice, asserting nonzero deterministic pixels.
+ * Run via scripts/test_capi_c.sh. */
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "crust.h"
+
+#define W 32u
+#define H 32u
+#define SPP 8u
+#define PX (W * H)
+
+#define CHECK(expr)                                                          \
+  do {                                                                       \
+    CrustStatus status_ = (expr);                                            \
+    if (status_ != CRUST_OK) {                                               \
+      fprintf(stderr, "%s:%d: %s -> %s\n", __FILE__, __LINE__, #expr,        \
+              crust_status_string(status_));                                 \
+      exit(1);                                                               \
+    }                                                                        \
+  } while (0)
+
+/* Camera at (0,0,3) looking down -Z; column-major world-to-view. */
+static const double kView[16] = {
+    1.0, 0.0, 0.0, 0.0,  /* col 0 */
+    0.0, 1.0, 0.0, 0.0,  /* col 1 */
+    0.0, 0.0, 1.0, 0.0,  /* col 2 */
+    0.0, 0.0, -3.0, 1.0, /* col 3 */
+};
+
+static void gl_perspective(double out[16]) {
+  const double pi = 3.14159265358979323846;
+  const double f = 1.0 / tan((45.0 * pi / 180.0) / 2.0);
+  const double n = 0.1, fa = 100.0;
+  memset(out, 0, 16 * sizeof(double));
+  out[0] = f;
+  out[5] = f;
+  out[10] = -(fa + n) / (fa - n);
+  out[11] = -1.0;
+  out[14] = -2.0 * fa * n / (fa - n);
+}
+
+static CrustRenderer* build_and_commit(const CrustStopToken* token,
+                                       uint32_t* out_quad_id) {
+  CrustScene* scene = crust_scene_create();
+  assert(scene != NULL);
+
+  CrustMaterial material;
+  crust_material_default(&material);
+  material.base_color[0] = 0.8f;
+  material.base_color[1] = 0.4f;
+  material.base_color[2] = 0.2f;
+
+  /* Two triangles spanning [-0.6, 0.6]^2 at z = 0. */
+  const float positions[12] = {
+      -0.6f, -0.6f, 0.0f, /**/ 0.6f, -0.6f, 0.0f,
+      0.6f,  0.6f,  0.0f, /**/ -0.6f, 0.6f, 0.0f,
+  };
+  const uint32_t indices[6] = {0, 1, 2, 0, 2, 3};
+  CHECK(crust_scene_add_mesh(scene, positions, 4, indices, 2, NULL, &material,
+                             out_quad_id));
+
+  const float center[3] = {0.0f, 0.0f, 2.0f};
+  const float radiance[3] = {12.0f, 12.0f, 12.0f};
+  CHECK(crust_scene_add_sphere_light(scene, center, 0.5f, radiance));
+
+  /* Touch the remaining light types (their math is pinned in Rust tests;
+   * here we prove the symbols and argument marshalling). */
+  const float dir[3] = {0.0f, -1.0f, -0.2f};
+  const float irradiance[3] = {0.05f, 0.05f, 0.05f};
+  CHECK(crust_scene_add_distant_light(scene, dir, irradiance, 0.53f));
+  const float rect_origin[3] = {-2.0f, 2.0f, 1.0f};
+  const float edge_u[3] = {0.5f, 0.0f, 0.0f};
+  const float edge_v[3] = {0.0f, 0.0f, -0.5f};
+  const float rect_radiance[3] = {0.5f, 0.5f, 0.5f};
+  CHECK(crust_scene_add_rect_light(scene, rect_origin, edge_u, edge_v,
+                                   rect_radiance));
+  const float tint[3] = {0.02f, 0.02f, 0.03f};
+  const float identity9[9] = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+  CHECK(crust_scene_add_dome_light(scene, tint, 0, 0, NULL, identity9));
+
+  /* One extra sphere so add_sphere is exercised too. */
+  CrustMaterial mirror;
+  crust_material_default(&mirror);
+  mirror.metalness = 1.0f;
+  mirror.roughness = 0.1f;
+  const float sphere_center[3] = {1.5f, 0.0f, 0.0f};
+  uint32_t sphere_id = 0;
+  CHECK(crust_scene_add_sphere(scene, sphere_center, 0.4f, &mirror, &sphere_id));
+
+  double proj[16];
+  gl_perspective(proj);
+  CHECK(crust_scene_set_camera(scene, kView, proj, 0.0f, 3.0f));
+
+  CrustRenderSettings settings;
+  crust_render_settings_default(&settings);
+  settings.width = W;
+  settings.height = H;
+  settings.samples_per_pixel = SPP;
+  settings.max_depth = 4;
+  CHECK(crust_scene_set_render_settings(scene, &settings));
+
+  CrustRenderer* renderer = NULL;
+  CHECK(crust_scene_commit(scene, token, &renderer));
+  assert(renderer != NULL);
+
+  /* A committed scene is spent. */
+  uint32_t dummy = 0;
+  CrustMaterial grey;
+  crust_material_default(&grey);
+  const float origin[3] = {0, 0, 0};
+  assert(crust_scene_add_sphere(scene, origin, 1.0f, &grey, &dummy) ==
+         CRUST_ERROR_BAD_STATE);
+  crust_scene_destroy(scene);
+  return renderer;
+}
+
+static void render_to_completion(CrustRenderer* renderer, float* rgba) {
+  CrustStepStatus status = CRUST_STEP_IN_PROGRESS;
+  uint32_t spp_done = 0;
+  while (status != CRUST_STEP_COMPLETE) {
+    CHECK(crust_renderer_step(renderer, 3, &status, &spp_done));
+    assert(status != CRUST_STEP_STOPPED);
+  }
+  assert(spp_done == SPP);
+  assert(crust_renderer_is_converged(renderer));
+  assert(crust_renderer_spp_done(renderer) == SPP);
+  CHECK(crust_renderer_read_color(renderer, rgba, PX));
+}
+
+int main(void) {
+  assert(crust_api_version() == CRUST_API_VERSION);
+  uint32_t major = 0, minor = 0, patch = 0;
+  crust_library_version(&major, &minor, &patch);
+  printf("crust-capi %u.%u.%u (api %u)\n", major, minor, patch,
+         crust_api_version());
+
+  CrustStopToken* token = crust_stop_token_create();
+  assert(token != NULL);
+  assert(!crust_stop_token_is_stopped(token));
+
+  uint32_t quad_id = 99;
+  CrustRenderer* renderer = build_and_commit(token, &quad_id);
+  assert(quad_id == 0);
+
+  uint32_t width = 0, height = 0;
+  crust_renderer_get_dimensions(renderer, &width, &height);
+  assert(width == W && height == H);
+
+  static float rgba_a[PX * 4], rgba_b[PX * 4];
+  render_to_completion(renderer, rgba_a);
+
+  /* AOVs: the quad covers the image center; the corner escapes. */
+  static float depth[PX], normal[PX * 3], alpha[PX];
+  static uint32_t ids[PX * 2];
+  CHECK(crust_renderer_read_aov_depth(renderer, depth, PX));
+  CHECK(crust_renderer_read_aov_normal(renderer, normal, PX));
+  CHECK(crust_renderer_read_aov_id(renderer, ids, PX));
+  CHECK(crust_renderer_read_aov_alpha(renderer, alpha, PX));
+  const size_t center = 16 * W + 16, corner = 0;
+  assert(alpha[center] == 1.0f && alpha[corner] == 0.0f);
+  assert(fabsf(depth[center] - 3.0f) < 0.05f);
+  assert(isinf(depth[corner]));
+  assert(fabsf(normal[center * 3 + 2] - 1.0f) < 0.05f);
+  assert(ids[center * 2] == quad_id);
+  assert(ids[corner * 2] == UINT32_MAX && ids[corner * 2 + 1] == UINT32_MAX);
+  assert(rgba_a[center * 4 + 3] == 1.0f && rgba_a[corner * 4 + 3] == 0.0f);
+
+  /* Error paths give exact statuses. */
+  assert(crust_renderer_read_color(renderer, rgba_b, 2) ==
+         CRUST_ERROR_BUFFER_TOO_SMALL);
+  CrustStepStatus step_status;
+  assert(crust_renderer_step(NULL, 1, &step_status, NULL) ==
+         CRUST_ERROR_NULL_ARGUMENT);
+  crust_renderer_destroy(renderer);
+
+  /* Determinism through the ABI: a second identical run is byte-equal. */
+  uint32_t quad_id2 = 99;
+  CrustRenderer* renderer2 = build_and_commit(NULL, &quad_id2);
+  render_to_completion(renderer2, rgba_b);
+  crust_renderer_destroy(renderer2);
+  assert(memcmp(rgba_a, rgba_b, sizeof(rgba_a)) == 0);
+
+  int nonzero = 0;
+  for (size_t i = 0; i < PX * 4; i++) {
+    if (rgba_a[i] > 0.0f) nonzero++;
+    assert(!isnan(rgba_a[i]));
+  }
+  assert(nonzero > 0);
+
+  /* Stop token: fired before stepping, the chunk is cut short; the token
+   * is permanent. */
+  crust_stop_token_stop(token);
+  assert(crust_stop_token_is_stopped(token));
+  uint32_t quad_id3 = 0;
+  CrustRenderer* renderer3 = build_and_commit(token, &quad_id3);
+  CrustStepStatus s3;
+  uint32_t done3 = 42;
+  CHECK(crust_renderer_step(renderer3, SPP, &s3, &done3));
+  assert(s3 == CRUST_STEP_STOPPED && done3 == 0);
+  assert(!crust_renderer_is_converged(renderer3));
+  crust_renderer_destroy(renderer3);
+
+  crust_stop_token_destroy(token);
+  crust_stop_token_destroy(NULL); /* NULL is a no-op */
+  crust_renderer_destroy(NULL);
+  crust_scene_destroy(NULL);
+
+  printf("smoke.c: all checks passed (%d nonzero channel values)\n", nonzero);
+  return 0;
+}

--- a/crates/crust-core/src/aov.rs
+++ b/crates/crust-core/src/aov.rs
@@ -1,0 +1,206 @@
+//! Arbitrary output variables (AOVs) for hosts that need more than beauty —
+//! a Hydra delegate binds depth for compositing and `[geom_id, prim_id]` for
+//! viewport picking.
+//!
+//! Deliberately a **dedicated primary-hit probe pass**, not instrumentation
+//! of the path tracer: one `World::intersect` per *pixel* through the pixel
+//! center with the lens sample pinned to the lens center (so depth-of-field
+//! cameras probe a pinhole view). That costs nothing in the integrator's hot
+//! loop, and it is also the correct semantics for id/depth AOVs: they must
+//! be point-sampled, never averaged across a reconstruction filter — half a
+//! `geom_id` is meaningless.
+
+use crate::tracer::Renderer;
+use glam::Vec3A;
+use rayon::prelude::*;
+
+/// Which AOVs [`Renderer::render_aovs`] should fill in. Unrequested channels
+/// stay `None` in [`AovBuffers`] and allocate nothing.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AovRequest {
+    /// Camera-forward hit distance (a host converts to its own depth
+    /// convention with its projection matrix).
+    pub depth: bool,
+    /// Outward world-space geometric normal.
+    pub normal: bool,
+    /// `[geom_id, prim_id]` of the primary hit — what a Hydra delegate maps
+    /// back to a prim path for picking.
+    pub prim_id: bool,
+    /// 1.0 where the probe hit geometry, 0.0 where it escaped.
+    pub alpha: bool,
+}
+
+/// Per-pixel AOV planes. Same storage convention as [`crate::Buffer`]:
+/// row-major with **row 0 at the bottom**, index `y * width + x`.
+pub struct AovBuffers {
+    pub width: usize,
+    pub height: usize,
+    /// `(hit_point − camera origin) · camera.forward()`; `+INFINITY` on miss.
+    pub depth: Option<Vec<f32>>,
+    /// Outward world normal (`front_face ? n : −n`); `Vec3A::ZERO` on miss.
+    pub normal: Option<Vec<Vec3A>>,
+    /// `[geom_id, prim_id]`; `[u32::MAX, u32::MAX]` on miss. Instanced hits
+    /// report the instance's top-level `geom_id` with the inner `prim_id`,
+    /// exactly as the kernel does.
+    pub prim_id: Option<Vec<[u32; 2]>>,
+    /// 1.0 hit / 0.0 miss.
+    pub alpha: Option<Vec<f32>>,
+}
+
+/// What one probe ray learned about its pixel.
+#[derive(Clone, Copy)]
+struct Probe {
+    depth: f32,
+    normal: Vec3A,
+    ids: [u32; 2],
+    alpha: f32,
+}
+
+const MISS: Probe = Probe {
+    depth: f32::INFINITY,
+    normal: Vec3A::ZERO,
+    ids: [u32::MAX, u32::MAX],
+    alpha: 0.0,
+};
+
+impl Renderer {
+    /// Renders the requested AOV planes with one primary-hit probe per
+    /// pixel. Independent of any beauty render — call it before, after, or
+    /// instead of `render()`.
+    ///
+    /// Probe rays go through the pixel center at shutter time 0 with the
+    /// camera's `MASK_CAMERA` visibility (so geometry hidden from camera
+    /// rays — light sources by default — is hidden here too, consistent with
+    /// the beauty image).
+    pub fn render_aovs(&self, req: AovRequest) -> AovBuffers {
+        let width = self.settings.width();
+        let height = self.settings.height();
+        let forward = self.camera.forward();
+
+        let probes: Vec<Probe> = (0..height)
+            .into_par_iter()
+            .flat_map_iter(|j| {
+                (0..width).map(move |i| {
+                    let u = (i as f32 + 0.5) / width as f32;
+                    let v = (j as f32 + 0.5) / height as f32;
+                    // [0.5, 0.5] maps to the center of the concentric lens
+                    // disk, so a nonzero aperture still probes a pinhole.
+                    let ray = self.camera.get_ray(u, v, [0.5, 0.5], 0.0);
+                    match self.world.intersect(&ray, 0.001, f32::INFINITY) {
+                        Some(hit) => {
+                            let n = if hit.rec.front_face {
+                                hit.rec.normal
+                            } else {
+                                -hit.rec.normal
+                            };
+                            Probe {
+                                depth: (hit.rec.p - ray.origin()).dot(forward),
+                                normal: n,
+                                ids: [hit.geom_id, hit.prim_id],
+                                alpha: 1.0,
+                            }
+                        }
+                        None => MISS,
+                    }
+                })
+            })
+            .collect();
+
+        AovBuffers {
+            width,
+            height,
+            depth: req
+                .depth
+                .then(|| probes.iter().map(|p| p.depth).collect()),
+            normal: req
+                .normal
+                .then(|| probes.iter().map(|p| p.normal).collect()),
+            prim_id: req
+                .prim_id
+                .then(|| probes.iter().map(|p| p.ids).collect()),
+            alpha: req
+                .alpha
+                .then(|| probes.iter().map(|p| p.alpha).collect()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::material::OpenPBR;
+    use crate::rt_world::WorldBuilder;
+    use crate::tracer::{RenderSettings, Renderer};
+    use crate::{Camera, LightList, rt};
+    use std::sync::Arc;
+
+    /// One sphere dead ahead: the center pixel must report the hit (id,
+    /// analytic depth, camera-facing normal), a corner pixel the miss
+    /// sentinels — and unrequested channels must stay unallocated.
+    #[test]
+    fn probe_reports_hits_and_misses() {
+        let mut builder = WorldBuilder::new();
+        let geom_id = builder.attach(
+            rt::Geometry::Sphere {
+                center: glam::Vec3A::ZERO,
+                radius: 1.0,
+            },
+            Arc::new(OpenPBR::diffuse(glam::Vec3A::splat(0.5))),
+        );
+        let world = builder.commit();
+        let camera = Camera::new(
+            glam::Vec3A::new(0.0, 0.0, 5.0),
+            glam::Vec3A::ZERO,
+            glam::Vec3A::Y,
+            40.0,
+            1.0,
+            0.0,
+            5.0,
+        );
+        let settings = RenderSettings::new(1, 4, 32, 32, 0, 0.0, 0);
+        let renderer = Renderer::new(camera, world, LightList::new(), settings);
+
+        let aovs = renderer.render_aovs(AovRequest {
+            depth: true,
+            normal: true,
+            prim_id: true,
+            alpha: true,
+        });
+        let center = 16 * 32 + 16;
+        let corner = 0;
+
+        let depth = aovs.depth.as_ref().unwrap();
+        // Camera at z=5 looking at a unit sphere: front pole at z=1 → 4.
+        assert!(
+            (depth[center] - 4.0).abs() < 0.05,
+            "center depth {} != 4",
+            depth[center]
+        );
+        assert_eq!(depth[corner], f32::INFINITY);
+
+        let normal = aovs.normal.as_ref().unwrap();
+        // Pixel (16,16)'s center sits at (16.5/32, 16.5/32) — half a pixel
+        // off the optical axis — so the probe hits ~2.6° off the pole.
+        assert!(
+            (normal[center] - glam::Vec3A::Z).length() < 0.1,
+            "center normal {:?} should face the camera",
+            normal[center]
+        );
+        assert_eq!(normal[corner], glam::Vec3A::ZERO);
+
+        let ids = aovs.prim_id.as_ref().unwrap();
+        assert_eq!(ids[center], [geom_id, 0]);
+        assert_eq!(ids[corner], [u32::MAX, u32::MAX]);
+
+        let alpha = aovs.alpha.as_ref().unwrap();
+        assert_eq!(alpha[center], 1.0);
+        assert_eq!(alpha[corner], 0.0);
+
+        let sparse = renderer.render_aovs(AovRequest {
+            depth: true,
+            ..AovRequest::default()
+        });
+        assert!(sparse.depth.is_some());
+        assert!(sparse.normal.is_none() && sparse.prim_id.is_none() && sparse.alpha.is_none());
+    }
+}

--- a/crates/crust-core/src/buffer.rs
+++ b/crates/crust-core/src/buffer.rs
@@ -2,6 +2,7 @@ use glam::Vec3A;
 
 /// The `Buffer` struct represents a 2D image buffer used to store pixel colors.
 /// It provides methods to set and retrieve pixel values, as well as access RGB data.
+#[derive(Clone)]
 pub struct Buffer {
     /// The width of the buffer in pixels.
     width: usize,
@@ -74,5 +75,59 @@ impl Buffer {
     pub fn get_rgb(&self, x: usize, y: usize) -> (f32, f32, f32) {
         let pixel: Vec3A = self.get_pixel(x, self.height - 1 - y);
         (pixel.x, pixel.y, pixel.z)
+    }
+
+    /// The width of the buffer in pixels.
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    /// The height of the buffer in pixels.
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    /// The raw pixel storage: row-major, linear RGB, with **row 0 at the
+    /// bottom** of the image (`get_rgb` is the y-flipped, display-order
+    /// view). Suited to bulk copies by a host that manages orientation
+    /// itself; use [`Buffer::rows_top_down`] for display order.
+    pub fn as_slice(&self) -> &[Vec3A] {
+        &self.data
+    }
+
+    /// The buffer's rows in display order (top row first) — what a host
+    /// copies row-by-row into its own top-down framebuffer.
+    pub fn rows_top_down(&self) -> impl DoubleEndedIterator<Item = &[Vec3A]> + '_ {
+        self.data.chunks_exact(self.width.max(1)).rev()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The raw accessors and the historical `get_rgb` view must describe
+    /// the same image: `as_slice` row 0 is the bottom row, `rows_top_down`
+    /// starts at the top — exactly `get_rgb`'s orientation.
+    #[test]
+    fn raw_access_agrees_with_get_rgb() {
+        let (w, h) = (3, 2);
+        let mut buf = Buffer::new(w, h);
+        for y in 0..h {
+            for x in 0..w {
+                buf.set_pixel(x, y, Vec3A::new(x as f32, y as f32, 0.0));
+            }
+        }
+        assert_eq!((buf.width(), buf.height()), (w, h));
+        assert_eq!(buf.as_slice().len(), w * h);
+        assert_eq!(buf.as_slice()[0], Vec3A::new(0.0, 0.0, 0.0)); // bottom-left
+        assert_eq!(buf.as_slice()[w], Vec3A::new(0.0, 1.0, 0.0)); // second row up
+
+        for (display_y, row) in buf.rows_top_down().enumerate() {
+            for (x, pixel) in row.iter().enumerate() {
+                let (r, g, b) = buf.get_rgb(x, display_y);
+                assert_eq!((pixel.x, pixel.y, pixel.z), (r, g, b));
+            }
+        }
     }
 }

--- a/crates/crust-core/src/camera.rs
+++ b/crates/crust-core/src/camera.rs
@@ -1,5 +1,6 @@
+use crate::error::Error;
 use crate::ray::Ray;
-use glam::Vec3A;
+use glam::{Mat4, Vec3A, Vec4};
 use utils::concentric_disk;
 
 /// The `Camera` struct represents a virtual camera in the ray tracing system.
@@ -59,6 +60,117 @@ impl Camera {
         }
     }
 
+    /// Builds a camera from a world-to-camera (view) matrix and a projection
+    /// matrix — the pair a Hydra host hands its render delegate — instead of
+    /// lookat/vfov parameters.
+    ///
+    /// Works by unprojecting three NDC corners onto the camera-space focus
+    /// plane `z = -focus_dist` and expressing the existing viewport fields
+    /// from them, so `get_ray` is untouched and both constructors share one
+    /// ray-generation path. Unprojecting a near→far point pair per corner
+    /// (rather than assuming a depth convention) makes this indifferent to
+    /// GL/DX depth ranges and reverse-Z, and correct for off-axis/asymmetric
+    /// frustums: each corner lands wherever the projection actually looks.
+    ///
+    /// NDC x = -1 is the left edge and y = -1 the **bottom** edge (matching
+    /// the render loop's `v = (j + fy) / h` with row 0 at the bottom).
+    ///
+    /// # Errors
+    /// [`Error::InvalidCamera`] when either matrix is non-invertible, when
+    /// the projection is affine (orthographic — its rays would need
+    /// per-pixel origins, which this camera model cannot express), or when
+    /// the unprojected frustum degenerates (non-finite or zero-area).
+    pub fn from_view_projection(
+        view: Mat4,
+        proj: Mat4,
+        aperture: f32,
+        focus_dist: f32,
+    ) -> Result<Camera, Error> {
+        if !view.determinant().is_finite() || view.determinant().abs() < 1e-12 {
+            return Err(Error::InvalidCamera("view matrix is not invertible".into()));
+        }
+        if !proj.determinant().is_finite() || proj.determinant().abs() < 1e-12 {
+            return Err(Error::InvalidCamera(
+                "projection matrix is not invertible".into(),
+            ));
+        }
+        // A perspective projection feeds -z (or +z) into the output w; an
+        // affine one leaves w constant. `z_axis.w` is that coupling term
+        // (column-major: row 3 of the z column).
+        if proj.z_axis.w.abs() < 1e-8 {
+            return Err(Error::InvalidCamera(
+                "projection is affine (orthographic projections are not supported)".into(),
+            ));
+        }
+        if !(focus_dist.is_finite() && focus_dist > 0.0) {
+            return Err(Error::InvalidCamera(format!(
+                "focus distance must be finite and positive, got {focus_dist}"
+            )));
+        }
+
+        let inv_view = view.inverse();
+        let inv_proj = proj.inverse();
+
+        // Unproject one NDC (x, y) to the camera-space plane z = -focus_dist.
+        let corner_on_focus_plane = |x: f32, y: f32| -> Option<Vec3A> {
+            let near = inv_proj * Vec4::new(x, y, -1.0, 1.0);
+            let far = inv_proj * Vec4::new(x, y, 1.0, 1.0);
+            if near.w.abs() < 1e-12 || far.w.abs() < 1e-12 {
+                return None;
+            }
+            let a = near.truncate() / near.w;
+            let b = far.truncate() / far.w;
+            let dz = b.z - a.z;
+            if !dz.is_finite() || dz.abs() < 1e-12 {
+                return None;
+            }
+            let t = (-focus_dist - a.z) / dz;
+            let p = a + (b - a) * t;
+            let world = inv_view * p.extend(1.0);
+            let world = Vec3A::from_vec4(world);
+            world.is_finite().then_some(world)
+        };
+
+        let degenerate = || Error::InvalidCamera("frustum unprojection degenerates".into());
+        let c00 = corner_on_focus_plane(-1.0, -1.0).ok_or_else(degenerate)?; // bottom-left
+        let c10 = corner_on_focus_plane(1.0, -1.0).ok_or_else(degenerate)?; // bottom-right
+        let c01 = corner_on_focus_plane(-1.0, 1.0).ok_or_else(degenerate)?; // top-left
+
+        let origin = Vec3A::from_vec4(inv_view * Vec4::new(0.0, 0.0, 0.0, 1.0));
+        let horizontal = c10 - c00;
+        let vertical = c01 - c00;
+        if !origin.is_finite()
+            || horizontal.length_squared() < 1e-24
+            || vertical.length_squared() < 1e-24
+        {
+            return Err(degenerate());
+        }
+
+        // The lens offset axes: the camera's world-space right and up. Taken
+        // from the view matrix (not from horizontal/vertical) so depth of
+        // field keeps a circular lens even under an asymmetric frustum.
+        let u = Vec3A::from_vec4(inv_view.x_axis).normalize();
+        let v = Vec3A::from_vec4(inv_view.y_axis).normalize();
+
+        Ok(Camera {
+            origin,
+            lower_left_corner: c00,
+            horizontal,
+            vertical,
+            u,
+            v,
+            lens_radius: aperture / 2.0,
+        })
+    }
+
+    /// The camera's viewing direction: from the origin through the center of
+    /// the viewport. Works for both constructors (for `Camera::new` it is
+    /// `-w`, the lookfrom→lookat direction).
+    pub fn forward(&self) -> Vec3A {
+        (self.lower_left_corner + 0.5 * self.horizontal + 0.5 * self.vertical - self.origin)
+            .normalize()
+    }
+
     /// Generates a ray originating from the camera through the viewport.
     ///
     /// # Parameters
@@ -81,5 +193,130 @@ impl Camera {
         )
         .with_time(time)
         .with_mask(crate::ray::MASK_CAMERA)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::Vec3;
+    use glam::camera::rh::{proj, view};
+
+    fn assert_close(a: Vec3A, b: Vec3A, eps: f32, what: &str) {
+        assert!(
+            (a - b).length() <= eps,
+            "{what}: {a:?} vs {b:?} (Δ = {})",
+            (a - b).length()
+        );
+    }
+
+    /// The matrix constructor must reproduce the lookat constructor when
+    /// fed the equivalent view + projection pair — with and without
+    /// aperture, across the whole viewport.
+    #[test]
+    fn matrix_camera_matches_lookat_camera() {
+        let lookfrom = Vec3A::new(15.0, 3.0, 3.0);
+        let lookat = Vec3A::new(0.0, 1.0, 0.0);
+        let vup = Vec3A::new(0.0, 1.0, 0.0);
+        let (vfov, aspect, focus) = (20.0f32, 16.0 / 9.0, 10.0);
+        let view = view::look_at_mat4(lookfrom.into(), lookat.into(), vup.into());
+        let proj = proj::opengl::perspective(vfov.to_radians(), aspect, 0.1, 100.0);
+
+        for aperture in [0.0f32, 0.4] {
+            let reference = Camera::new(lookfrom, lookat, vup, vfov, aspect, aperture, focus);
+            let from_matrices =
+                Camera::from_view_projection(view, proj, aperture, focus).expect("valid camera");
+            for (s, t) in [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (0.5, 0.5), (0.3, 0.8)] {
+                let lens = [0.7, 0.3];
+                let a = reference.get_ray(s, t, lens, 0.0);
+                let b = from_matrices.get_ray(s, t, lens, 0.0);
+                assert_close(a.origin(), b.origin(), 1e-3, "origin");
+                assert_close(
+                    a.direction().normalize(),
+                    b.direction().normalize(),
+                    1e-4,
+                    "direction",
+                );
+            }
+            assert_close(
+                from_matrices.forward(),
+                (lookat - lookfrom).normalize(),
+                1e-4,
+                "forward",
+            );
+        }
+    }
+
+    /// An asymmetric (off-axis) frustum: every generated ray must pass
+    /// through the point glam's own matrix inversion unprojects for the
+    /// same NDC coordinate — an independent check of the corner-plane
+    /// construction.
+    #[test]
+    fn matrix_camera_handles_off_axis_frustums() {
+        // Right-handed GL-style frustum, deliberately lopsided.
+        let proj = proj::opengl::frustum(-0.02, 0.08, -0.01, 0.05, 0.1, 100.0);
+        let view = view::look_at_mat4(
+            Vec3::new(2.0, 1.0, 5.0),
+            Vec3::new(0.0, 0.5, 0.0),
+            Vec3::Y,
+        );
+        let camera = Camera::from_view_projection(view, proj, 0.0, 4.0).expect("valid camera");
+
+        let inv_vp = (proj * view).inverse();
+        for (s, t) in [(0.0f32, 0.0f32), (1.0, 1.0), (0.5, 0.5), (0.2, 0.9)] {
+            let ray = camera.get_ray(s, t, [0.5, 0.5], 0.0);
+            // The same NDC coordinate at an arbitrary depth, unprojected by
+            // glam: it must lie on the ray's line.
+            let ndc = Vec3::new(s * 2.0 - 1.0, t * 2.0 - 1.0, 0.5);
+            let p = Vec3A::from(inv_vp.project_point3(ndc));
+            let d = ray.direction().normalize();
+            let along = (p - ray.origin()).dot(d);
+            let off_axis_distance = ((p - ray.origin()) - along * d).length();
+            let scale = (p - ray.origin()).length().max(1.0);
+            assert!(
+                off_axis_distance / scale < 1e-4,
+                "NDC ({s}, {t}): unprojected point {p:?} misses the ray by {off_axis_distance}"
+            );
+        }
+    }
+
+    #[test]
+    fn orthographic_and_singular_matrices_are_rejected() {
+        let view = view::look_at_mat4(Vec3::new(0.0, 0.0, 5.0), Vec3::ZERO, Vec3::Y);
+        let ortho = proj::directx::orthographic(-1.0, 1.0, -1.0, 1.0, 0.1, 100.0);
+        assert!(Camera::from_view_projection(view, ortho, 0.0, 1.0).is_err());
+
+        let proj = proj::opengl::perspective(0.5, 1.0, 0.1, 100.0);
+        assert!(Camera::from_view_projection(Mat4::ZERO, proj, 0.0, 1.0).is_err());
+        assert!(Camera::from_view_projection(view, proj, 0.0, -1.0).is_err());
+        assert!(Camera::from_view_projection(view, proj, 0.0, 1.0).is_ok());
+    }
+
+    /// The unprojection must be indifferent to the projection's depth
+    /// convention: DirectX [0,1] z and reverse-Z infinite-far projections
+    /// describe the same frustum as their GL twin, so the camera they
+    /// build must generate the same rays.
+    #[test]
+    fn depth_convention_does_not_matter() {
+        let view = view::look_at_mat4(Vec3::new(3.0, 2.0, 4.0), Vec3::ZERO, Vec3::Y);
+        let gl = proj::opengl::perspective(0.8, 1.5, 0.1, 100.0);
+        let dx = proj::directx::perspective(0.8, 1.5, 0.1, 100.0);
+        let rev = proj::directx::perspective_infinite_reverse(0.8, 1.5, 0.1);
+        let a = Camera::from_view_projection(view, gl, 0.0, 5.0).unwrap();
+        let b = Camera::from_view_projection(view, dx, 0.0, 5.0).unwrap();
+        let c = Camera::from_view_projection(view, rev, 0.0, 5.0).unwrap();
+        for (s, t) in [(0.0, 0.0), (1.0, 1.0), (0.5, 0.5), (0.9, 0.1)] {
+            let ra = a.get_ray(s, t, [0.5, 0.5], 0.0);
+            for other in [&b, &c] {
+                let rb = other.get_ray(s, t, [0.5, 0.5], 0.0);
+                assert_close(ra.origin(), rb.origin(), 1e-4, "origin");
+                assert_close(
+                    ra.direction().normalize(),
+                    rb.direction().normalize(),
+                    1e-4,
+                    "direction",
+                );
+            }
+        }
     }
 }

--- a/crates/crust-core/src/error.rs
+++ b/crates/crust-core/src/error.rs
@@ -9,6 +9,10 @@ pub enum Error {
     NonUtf8Path(PathBuf),
     /// Opening or parsing the USD stage failed.
     UsdOpen { path: PathBuf, message: String },
+    /// A camera could not be built from the given matrices (non-invertible
+    /// view/projection, or a projection kind the camera model cannot
+    /// express, e.g. orthographic).
+    InvalidCamera(String),
 }
 
 impl fmt::Display for Error {
@@ -19,6 +23,9 @@ impl fmt::Display for Error {
             }
             Error::UsdOpen { path, message } => {
                 write!(f, "failed to open USD stage {}: {}", path.display(), message)
+            }
+            Error::InvalidCamera(message) => {
+                write!(f, "cannot build camera from matrices: {message}")
             }
         }
     }

--- a/crates/crust-core/src/lib.rs
+++ b/crates/crust-core/src/lib.rs
@@ -1,4 +1,11 @@
+// Safe Rust everywhere; the only `unsafe` in the crate is the test-only
+// counting allocator in `scene/subdiv.rs`, hence the `not(test)` guard.
+// The one sanctioned FFI exception lives outside the engine crates entirely
+// (the Hydra delegate boundary — see docs/hydra_delegate.md).
+#![cfg_attr(not(test), forbid(unsafe_code))]
+
 mod aabb;
+mod aov;
 mod buffer;
 mod camera;
 mod error;
@@ -28,6 +35,7 @@ pub type PathSampler = openqmc::SobolSampler;
 pub use crust_rt as rt;
 
 pub use aabb::AABB;
+pub use aov::{AovBuffers, AovRequest};
 pub use buffer::Buffer;
 pub use camera::Camera;
 pub use error::Error;
@@ -51,6 +59,9 @@ pub use stats::{
     peak_memory_bytes,
 };
 pub use texture::{PtexRef, PtexTexture};
-pub use tracer::{ProgressCallback, RenderSettings, Renderer, SamplingStrategy, ray_color};
+pub use tracer::{
+    ProgressCallback, ProgressiveRender, RenderSettings, Renderer, SamplingStrategy, StepStatus,
+    StopToken, ray_color,
+};
 pub use volume::{DensityField, PhaseMix, VolumeEvent, VolumeRegion, Volumes};
 pub use world::{get_settings, simple_scene};

--- a/crates/crust-core/src/tracer.rs
+++ b/crates/crust-core/src/tracer.rs
@@ -11,7 +11,8 @@ use crate::volume::{PhaseMix, VolumeEvent, Volumes};
 use crate::{LightList, PathSampler, camera::Camera};
 use glam::Vec3A;
 use rayon::prelude::*;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tracing::{info, warn};
 
 // OpenQMC domain-tree keys. The camera and the path subtree hang off the root
@@ -120,6 +121,86 @@ struct PassConfig {
     adaptive: bool,
 }
 
+/// A cancellation handle shared between a render and its host. Clone it,
+/// hand one side to [`Renderer::render_with_control`] (or a
+/// [`ProgressiveRender`] step) and call [`StopToken::stop`] on the other —
+/// from a signal handler, a UI thread, a Hydra `Stop()` — and the render
+/// winds down at the next work-unit (row/tile) boundary, returning a
+/// coherent partially-sampled image. Checked once per work unit, never per
+/// sample, so it costs the hot loop nothing.
+#[derive(Clone, Debug, Default)]
+pub struct StopToken(Arc<AtomicBool>);
+
+impl StopToken {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Request cancellation. Idempotent; there is no un-stop.
+    pub fn stop(&self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+
+    pub fn is_stopped(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+/// Everything one pixel has accumulated so far. Persisting exactly these
+/// five estimator values (plus the adaptive-stop latch) between sampling
+/// chunks is what makes progressive rendering bit-identical to the batch
+/// path: the sampler is a pure function of the sample index, so resuming at
+/// `taken` replays the identical IEEE addition sequence the one-shot loop
+/// would have run.
+#[derive(Clone, Copy)]
+struct PixelAccum {
+    /// Filter-weighted radiance sum Σwᵢ·Lᵢ (see `filter.rs`).
+    sum: Vec3A,
+    /// Filter weight sum Σwᵢ.
+    weight_sum: f32,
+    /// Luminance moments for the adaptive stop and the variance estimate.
+    lum_sum: f64,
+    lum_sq: f64,
+    /// Samples taken so far — the next chunk resumes at this index.
+    taken: u32,
+    /// Latched by the adaptive early stop; later chunks skip the pixel.
+    done: bool,
+}
+
+impl Default for PixelAccum {
+    fn default() -> Self {
+        PixelAccum {
+            sum: Vec3A::ZERO,
+            weight_sum: 0.0,
+            lum_sum: 0.0,
+            lum_sq: 0.0,
+            taken: 0,
+            done: false,
+        }
+    }
+}
+
+/// The persistent accumulation plane of an in-flight render: one
+/// [`PixelAccum`] per pixel, row-major with row 0 at the bottom (the
+/// `Buffer` convention). A batch render builds one, advances it to the full
+/// budget and resolves it; a progressive render keeps it alive between
+/// steps.
+struct Film {
+    width: usize,
+    height: usize,
+    pixels: Vec<PixelAccum>,
+}
+
+impl Film {
+    fn new(width: usize, height: usize) -> Self {
+        Film {
+            width,
+            height,
+            pixels: vec![PixelAccum::default(); width * height],
+        }
+    }
+}
+
 /// Image-quality statistics of one render pass.
 struct PassStats {
     /// Mean per-pixel variance of the pixel estimate — the inverse-variance
@@ -205,10 +286,90 @@ impl Renderer {
         progress: Option<ProgressCallback>,
     ) -> (Buffer, RayStats) {
         if self.settings.guiding {
-            return self.render_guided(tiled, progress);
+            let (buf, rays, _) = self.render_guided(tiled, progress, None);
+            return (buf, rays);
         }
-        let (buf, _, pass) = self.render_pass(self.final_pass_config(tiled), None, progress);
+        let (buf, _, pass, _) =
+            self.render_pass(self.final_pass_config(tiled), None, progress, None);
         (buf, pass.rays)
+    }
+
+    /// As the plain entry points, plus a [`StopToken`]: when it fires the
+    /// render winds down at the next row/tile boundary and returns the
+    /// coherent partial image (every pixel a valid mean of the samples it
+    /// took; unreached pixels black). The `bool` reports whether the render
+    /// ran to completion. With guiding enabled, a stop during a training
+    /// pass discards that pass — its partial sample set never reaches the
+    /// field — and blends the passes that completed.
+    pub fn render_with_control(
+        &self,
+        tiled: bool,
+        progress: Option<ProgressCallback>,
+        stop: Option<&StopToken>,
+    ) -> (Buffer, RayStats, bool) {
+        if self.settings.guiding {
+            return self.render_guided(tiled, progress, stop);
+        }
+        let cfg = self.final_pass_config(tiled);
+        let mut film = Film::new(self.settings.width, self.settings.height);
+        let (_, rays, completed) = self.advance_film(&mut film, cfg.spp, &cfg, None, progress, stop);
+        let (buffer, _, _) = self.finish_pass(&film, cfg.tiled);
+        (buffer, rays, completed)
+    }
+
+    /// Begins a progressive render session: the same render the batch entry
+    /// points produce, advanced in caller-sized sample chunks with a
+    /// readable partial image between chunks. Run to completion, the result
+    /// is **bit-identical** to [`Renderer::render`]/`render_with_tiles` —
+    /// the sampler is a pure function of the sample index and the film
+    /// persists every accumulator, so chunking cannot move a single bit.
+    ///
+    /// With guiding enabled, training passes run whole (one per `step` call,
+    /// however small the requested chunk — their sample stream feeds the
+    /// order-sensitive field update and must not be split); only the final
+    /// pass is chunked. Run to completion that too is bit-identical to the
+    /// batch guided render.
+    pub fn begin_progressive(&self, tiled: bool) -> ProgressiveRender<'_> {
+        let state = if self.settings.guiding {
+            match self.world.bounds() {
+                Some(bounds) => {
+                    let gcfg = GuidingConfig {
+                        train_iterations: self.settings.guiding_train_iterations,
+                        guide_prob: self.settings.guiding_prob,
+                        ..GuidingConfig::default()
+                    };
+                    ProgState::Training {
+                        field: GuidingField::new(bounds, gcfg),
+                        gcfg,
+                        passes: Vec::new(),
+                        k: 0,
+                        eff_unguided: None,
+                        eff_guided: None,
+                        train_spp_done: 0,
+                    }
+                }
+                None => {
+                    warn!(
+                        "path guiding enabled but the scene has no bounding box; rendering unguided"
+                    );
+                    ProgState::Simple {
+                        film: Film::new(self.settings.width, self.settings.height),
+                        spp_done: 0,
+                    }
+                }
+            }
+        } else {
+            ProgState::Simple {
+                film: Film::new(self.settings.width, self.settings.height),
+                spp_done: 0,
+            }
+        };
+        ProgressiveRender {
+            renderer: self,
+            tiled,
+            rays: RayStats::default(),
+            state,
+        }
     }
 
     /// Config of a final (image-quality) pass: full budget, adaptive
@@ -246,7 +407,8 @@ impl Renderer {
         &self,
         tiled: bool,
         progress: Option<ProgressCallback>,
-    ) -> (Buffer, RayStats) {
+        stop: Option<&StopToken>,
+    ) -> (Buffer, RayStats, bool) {
         // Every pass costs time, training included, so the counters cover
         // all of them rather than the final pass alone.
         let mut rays = RayStats::default();
@@ -254,9 +416,9 @@ impl Renderer {
             Some(b) => b,
             None => {
                 warn!("path guiding enabled but the scene has no bounding box; rendering unguided");
-                let (buf, _, pass) =
-                    self.render_pass(self.final_pass_config(tiled), None, progress);
-                return (buf, pass.rays);
+                let (buf, _, pass, completed) =
+                    self.render_pass(self.final_pass_config(tiled), None, progress, stop);
+                return (buf, pass.rays, completed);
             }
         };
         let cfg = GuidingConfig {
@@ -291,10 +453,23 @@ impl Renderer {
                 adaptive: false,
             };
             let start = std::time::Instant::now();
-            let (buffer, samples, stats) = self.render_pass(train_cfg, Some(&gctx), None);
+            let (buffer, samples, stats, completed) =
+                self.render_pass(train_cfg, Some(&gctx), None, stop);
             rays.merge(&stats.rays);
             let secs = start.elapsed().as_secs_f64();
             drop(gctx);
+            if !completed {
+                // The pass's sample set is partial (and dependent on where
+                // the stop landed), so the field never sees it and its image
+                // is not blended. Blend what completed; if nothing did, the
+                // interrupted pass's coherent partial image is still the
+                // best available.
+                info!("path guiding: stopped during training pass {} — discarding it", k + 1);
+                if passes.is_empty() {
+                    return (buffer, rays, false);
+                }
+                return (self.blend_passes(&passes), rays, false);
+            }
             info!(
                 "path guiding: training pass {}/{} at {} spp — {} samples, variance {:.3e}, {:.2}s",
                 k + 1,
@@ -313,13 +488,46 @@ impl Renderer {
             passes.push((buffer, stats.variance));
         }
 
-        let guide_final = match (&eff_unguided, &eff_guided) {
+        let guide_final = self.decide_guide_final(&passes, &eff_unguided, &eff_guided);
+
+        info!(
+            "path guiding: final pass at {} spp ({})",
+            self.settings.samples_per_pixel,
+            if guide_final { "guided" } else { "unguided" }
+        );
+        let gctx = GuidingContext {
+            field: &field,
+            training: false,
+        };
+        let final_gctx = if guide_final { Some(&gctx) } else { None };
+        let (final_buffer, _, final_stats, completed) =
+            self.render_pass(self.final_pass_config(tiled), final_gctx, progress, stop);
+        rays.merge(&final_stats.rays);
+        // An interrupted final pass carries infinite variance (some pixels
+        // hold <2 samples), so `blend_passes` gives it zero weight and the
+        // completed training passes carry the image — pushing it is still
+        // right, as the fallback when *nothing* completed.
+        passes.push((final_buffer, final_stats.variance));
+
+        (self.blend_passes(&passes), rays, completed)
+    }
+
+    /// The guiding efficiency verdict (see [`Renderer::render_guided`]):
+    /// should the final pass draw from the trained field at all? `true`
+    /// unless the measured efficiency ratio says training made things worse.
+    fn decide_guide_final(
+        &self,
+        passes: &[(Buffer, f64)],
+        eff_unguided: &Option<(Vec<f64>, f64)>,
+        eff_guided: &Option<(Vec<f64>, f64)>,
+    ) -> bool {
+        match (eff_unguided, eff_guided) {
             (Some((var_pt, cost_pt)), Some((var_pg, cost_pg))) if *cost_pg > 0.0 => {
                 // Reference image for relative error: the blend of all
                 // training passes — our stand-in for the paper's denoised
                 // accumulated image, and crucially the *same* image for both
                 // sides of the ratio.
-                let ref_lum = blend_luminance(&passes, self.settings.width, self.settings.height);
+                let ref_lum = blend_luminance(passes, self.settings.width, self.settings.height);
                 let mrse_pt = mean_relative_error(var_pt, &ref_lum);
                 let mrse_pg = mean_relative_error(var_pg, &ref_lum);
                 if mrse_pt.is_finite() && mrse_pg.is_finite() && mrse_pt > 0.0 && mrse_pg > 0.0 {
@@ -342,30 +550,13 @@ impl Renderer {
             // degenerate statistics give no basis to overrule the scene's
             // explicit opt-in — keep guiding.
             _ => true,
-        };
-
-        info!(
-            "path guiding: final pass at {} spp ({})",
-            self.settings.samples_per_pixel,
-            if guide_final { "guided" } else { "unguided" }
-        );
-        let gctx = GuidingContext {
-            field: &field,
-            training: false,
-        };
-        let final_gctx = if guide_final { Some(&gctx) } else { None };
-        let (final_buffer, _, final_stats) =
-            self.render_pass(self.final_pass_config(tiled), final_gctx, progress);
-        rays.merge(&final_stats.rays);
-        passes.push((final_buffer, final_stats.variance));
-
-        (self.blend_passes(passes), rays)
+        }
     }
 
     /// Inverse-variance blend of independent unbiased passes. Passes whose
     /// variance could not be estimated (spp < 2) get zero weight; if nothing
     /// is weightable, the last (final) pass is returned as-is.
-    fn blend_passes(&self, mut passes: Vec<(Buffer, f64)>) -> Buffer {
+    fn blend_passes(&self, passes: &[(Buffer, f64)]) -> Buffer {
         let weights: Vec<f64> = passes
             .iter()
             .map(|(_, var)| {
@@ -378,7 +569,11 @@ impl Renderer {
             .collect();
         let total: f64 = weights.iter().sum();
         if total <= 0.0 {
-            return passes.pop().expect("at least the final pass exists").0;
+            return passes
+                .last()
+                .expect("at least the final pass exists")
+                .0
+                .clone();
         }
         info!(
             "path guiding: blending {} passes, weight shares {:?}",
@@ -402,32 +597,75 @@ impl Renderer {
         out
     }
 
-    /// One full-frame pass at `spp` samples per pixel. Returns the image,
-    /// whatever training samples the pass recorded (empty unless a training
-    /// `GuidingContext` is supplied), and the pass's [`PassStats`].
+    /// One full-frame pass at `cfg.spp` samples per pixel. Returns the
+    /// image, whatever training samples the pass recorded (empty unless a
+    /// training `GuidingContext` is supplied), the pass's [`PassStats`], and
+    /// whether the pass ran to completion (`false` only when `stop` fired).
     fn render_pass(
         &self,
         cfg: PassConfig,
         gctx: Option<&GuidingContext>,
         progress: Option<ProgressCallback>,
-    ) -> (Buffer, Vec<SampleData>, PassStats) {
-        let mut buffer = Buffer::new(self.settings.width, self.settings.height);
+        stop: Option<&StopToken>,
+    ) -> (Buffer, Vec<SampleData>, PassStats, bool) {
+        let mut film = Film::new(self.settings.width, self.settings.height);
+        let (all_samples, rays, completed) =
+            self.advance_film(&mut film, cfg.spp, &cfg, gctx, progress, stop);
+        let (buffer, variance, var_map) = self.finish_pass(&film, cfg.tiled);
+        (
+            buffer,
+            all_samples,
+            PassStats {
+                variance,
+                var_map,
+                rays,
+            },
+        completed,
+        )
+    }
+
+    /// Advances every pixel of `film` to `target_spp` samples (skipping
+    /// pixels the adaptive stop already finished). This is the one scheduling
+    /// loop in the renderer — batch passes advance a fresh film to the full
+    /// budget in a single call, progressive rendering calls it repeatedly
+    /// with a rising target. Sample indices are consumed in ascending order
+    /// with no gaps, so how the budget is chunked cannot change the result.
+    ///
+    /// Returns the training samples recorded, the ray counters, and whether
+    /// the advance completed (`false` when `stop` cut it short at a row/tile
+    /// boundary — the film stays coherent either way).
+    fn advance_film(
+        &self,
+        film: &mut Film,
+        target_spp: u32,
+        cfg: &PassConfig,
+        gctx: Option<&GuidingContext>,
+        progress: Option<ProgressCallback>,
+        stop: Option<&StopToken>,
+    ) -> (Vec<SampleData>, RayStats, bool) {
         let mut all_samples = Vec::new();
-        let mut variance_sum = 0.0f64;
         let mut rays = RayStats::default();
-        let mut var_map = vec![0.0f64; self.settings.width * self.settings.height];
-        let pixel_count = (self.settings.width * self.settings.height) as f64;
-        // One tabulation per pass, shared read-only by every worker.
+        // One tabulation per advance, shared read-only by every worker.
         let filter = FilterSampler::new(self.settings.pixel_filter);
 
         if cfg.tiled {
             let tiles = generate_tiles(self.settings.width, self.settings.height, 16); // tile size: 16x16
             let total = tiles.len() as u64;
             let done = AtomicU64::new(0);
-            type TileOut = (Vec<(usize, usize, Vec3A, f64)>, Vec<SampleData>, RayStats);
-            let results: Vec<TileOut> = tiles
+            type TileOut = (Vec<(usize, usize, PixelAccum)>, Vec<SampleData>, RayStats);
+            // Shared read view for the workers; each tile copies its accums
+            // out, advances them privately, and the sequential merge below
+            // writes them back — keeping the merge order identical to the
+            // scheduling order however rayon interleaves the tiles.
+            let film_ref: &Film = film;
+            let results: Vec<Option<TileOut>> = tiles
                 .into_par_iter()
                 .map(|tile| {
+                    // A fired stop skips tiles that have not started; whole
+                    // tiles either run or don't, so the film stays coherent.
+                    if stop.is_some_and(|s| s.is_stopped()) {
+                        return None;
+                    }
                     let mut pixels = Vec::with_capacity(tile.width * tile.height);
                     let mut samples = Vec::new();
                     // Private to this tile, so no two threads share a
@@ -438,104 +676,158 @@ impl Renderer {
                     let mut scratch = PathScratch::new(self.settings.max_depth as usize);
                     for j in tile.y..tile.y + tile.height {
                         for i in tile.x..tile.x + tile.width {
-                            let (color, mut s, v) = self.render_pixel(
+                            let mut acc = film_ref.pixels[j * film_ref.width + i];
+                            let mut s = self.sample_pixel(
                                 i,
                                 j,
-                                &cfg,
+                                &mut acc,
+                                target_spp,
+                                cfg,
                                 &filter,
                                 gctx,
                                 &mut scratch,
                                 &mut tile_rays,
                             );
-                            pixels.push((i, j, color, v));
+                            pixels.push((i, j, acc));
                             samples.append(&mut s);
                         }
                     }
                     if let Some(cb) = progress {
                         cb(done.fetch_add(1, Ordering::Relaxed) + 1, total);
                     }
-                    (pixels, samples, tile_rays)
+                    Some((pixels, samples, tile_rays))
                 })
                 .collect();
-            for (pixels, samples, tile_rays) in results {
+            let mut completed = true;
+            for result in results {
+                let Some((pixels, samples, tile_rays)) = result else {
+                    completed = false;
+                    continue;
+                };
                 rays.merge(&tile_rays);
-                for (i, j, color, var) in pixels {
-                    buffer.set_pixel(i, j, color);
-                    var_map[j * self.settings.width + i] = var;
-                    variance_sum += var;
+                for (i, j, acc) in pixels {
+                    film.pixels[j * film.width + i] = acc;
                 }
                 all_samples.extend(samples);
             }
+            (all_samples, rays, completed)
         } else {
             let total = self.settings.height as u64;
             let mut done = 0u64;
+            let mut completed = true;
+            let width = film.width;
             for j in (0..self.settings.height).rev() {
+                // A fired stop ends the advance at the next row boundary.
+                if stop.is_some_and(|s| s.is_stopped()) {
+                    completed = false;
+                    break;
+                }
                 // `map_init` rather than `map`: the path scratch is reused
                 // across every pixel rayon hands one worker, instead of being
                 // rebuilt per pixel. (This path parallelises over pixels, so
                 // unlike the tiled path there is no per-work-unit closure to
                 // hang the buffer on.)
-                let row: Vec<(Vec3A, Vec<SampleData>, f64, RayStats)> = (0..self.settings.width)
-                    .into_par_iter()
+                let row_accums = &mut film.pixels[j * width..(j + 1) * width];
+                let row: Vec<(Vec<SampleData>, RayStats)> = row_accums
+                    .par_iter_mut()
+                    .enumerate()
                     .map_init(
                         || PathScratch::new(self.settings.max_depth as usize),
-                        |scratch, i| {
+                        |scratch, (i, acc)| {
                             let mut px = RayStats::default();
-                            let (c, s, v) =
-                                self.render_pixel(i, j, &cfg, &filter, gctx, scratch, &mut px);
-                            (c, s, v, px)
+                            let s = self.sample_pixel(
+                                i, j, acc, target_spp, cfg, &filter, gctx, scratch, &mut px,
+                            );
+                            (s, px)
                         },
                     )
                     .collect();
-                for (i, (color, samples, var, px_rays)) in row.into_iter().enumerate() {
+                for (samples, px_rays) in row {
                     rays.merge(&px_rays);
-                    buffer.set_pixel(i, j, color);
                     all_samples.extend(samples);
-                    var_map[j * self.settings.width + i] = var;
-                    variance_sum += var;
                 }
                 done += 1;
                 if let Some(cb) = progress {
                     cb(done, total);
                 }
             }
+            (all_samples, rays, completed)
         }
-
-        (
-            buffer,
-            all_samples,
-            PassStats {
-                variance: variance_sum / pixel_count,
-                var_map,
-                rays,
-            },
-        )
     }
 
-    fn render_pixel(
+    /// Resolves a film into the pass image and its variance statistics.
+    ///
+    /// Pixels are visited in the *scheduling order* of the pass mode
+    /// (scanline: rows top-down, i ascending; tiled: tile order) purely so
+    /// the f64 `variance_sum` accumulates in the same order the pre-film
+    /// code produced — that mean feeds the guided blend weights, and a
+    /// reordered float sum would move the final image by ulps.
+    fn finish_pass(&self, film: &Film, tiled: bool) -> (Buffer, f64, Vec<f64>) {
+        let mut buffer = Buffer::new(film.width, film.height);
+        let mut var_map = vec![0.0f64; film.width * film.height];
+        let mut variance_sum = 0.0f64;
+        let pixel_count = (film.width * film.height) as f64;
+        let mut resolve = |i: usize, j: usize| {
+            let (color, var) = resolve_pixel(&film.pixels[j * film.width + i]);
+            buffer.set_pixel(i, j, color);
+            var_map[j * film.width + i] = var;
+            variance_sum += var;
+        };
+        if tiled {
+            for tile in generate_tiles(film.width, film.height, 16) {
+                for j in tile.y..tile.y + tile.height {
+                    for i in tile.x..tile.x + tile.width {
+                        resolve(i, j);
+                    }
+                }
+            }
+        } else {
+            for j in (0..film.height).rev() {
+                for i in 0..film.width {
+                    resolve(i, j);
+                }
+            }
+        }
+        drop(resolve);
+        (buffer, variance_sum / pixel_count, var_map)
+    }
+
+    /// Advances one pixel's accumulator from `acc.taken` to `target_spp`
+    /// samples (or to its adaptive stop), returning the training samples the
+    /// new samples recorded. The loop body is the renderer's hot path; the
+    /// accumulator state lives in locals for the duration of the loop and is
+    /// stored back once per call.
+    #[allow(clippy::too_many_arguments)]
+    fn sample_pixel(
         &self,
         i: usize,
         j: usize,
+        acc: &mut PixelAccum,
+        target_spp: u32,
         cfg: &PassConfig,
         filter: &FilterSampler,
         gctx: Option<&GuidingContext>,
         scratch: &mut PathScratch,
         stats: &mut RayStats,
-    ) -> (Vec3A, Vec<SampleData>, f64) {
-        let mut sum = Vec3A::ZERO;
+    ) -> Vec<SampleData> {
+        let mut samples = Vec::new();
+        if acc.done || acc.taken >= target_spp {
+            return samples;
+        }
         // FIS weight sum (see `filter.rs`): the pixel estimate is the
         // weighted average Σwᵢ·Lᵢ / Σwᵢ. For box and triangle every wᵢ is
         // exactly 1.0, so the sum is exactly `taken as f32` and the estimate
         // is the plain mean — box at radius 0.5 stays bit-identical to the
         // historical unweighted, unfiltered estimator.
-        let mut weight_sum = 0.0f32;
-        let mut samples = Vec::new();
-        let mut lum_sum = 0.0f64;
-        let mut lum_sq = 0.0f64;
+        let mut sum = acc.sum;
+        let mut weight_sum = acc.weight_sum;
+        let mut lum_sum = acc.lum_sum;
+        let mut lum_sq = acc.lum_sq;
 
         let threshold = self.settings.variance_threshold as f64;
         let min_spp = self.settings.min_samples_per_pixel.max(2);
-        let mut taken = 0u32;
+        let mut taken = acc.taken;
+        let mut done = false;
 
         // OpenQMC decorrelates pixels within a 256×256 tile; distinguish tiles
         // with an extra domain so images wider/taller than 256 stay fully
@@ -555,7 +847,7 @@ impl Renderer {
         // domain that is never derived leaves `root` untouched.
         let motion = self.world.has_motion();
 
-        for sample in 0..cfg.spp {
+        for sample in acc.taken..target_spp {
             let root =
                 PathSampler::new(i as i32, j as i32, cfg.seed as i32, sample as i32).new_domain(tile);
             let cam = root.new_domain(K_CAMERA).draw_sample_f32::<4>();
@@ -612,28 +904,474 @@ impl Renderer {
                     ((lum_sq - lum_sum * lum_sum / n) / (n - 1.0) / n).max(0.0);
                 let mean = (lum_sum / n).max(1e-4);
                 if var_of_mean.sqrt() / mean < threshold {
+                    done = true;
                     break;
                 }
             }
         }
 
-        // Unbiased variance of the pixel-mean luminance.
-        let n = taken as f64;
-        let variance = if taken >= 2 {
-            ((lum_sq - lum_sum * lum_sum / n) / (n - 1.0) / n).max(0.0)
-        } else {
-            f64::INFINITY
-        };
-        // Weighted-average film estimator. A Mitchell pixel whose few
-        // samples all landed on negative lobes could zero the denominator;
-        // the plain mean is the sane fallback there.
-        let mean = if weight_sum > 0.0 {
-            sum / weight_sum
-        } else {
-            sum / taken as f32
-        };
-        (mean, samples, variance)
+        acc.sum = sum;
+        acc.weight_sum = weight_sum;
+        acc.lum_sum = lum_sum;
+        acc.lum_sq = lum_sq;
+        acc.taken = taken;
+        acc.done = done;
+        samples
     }
+}
+
+/// Resolves an accumulator into its pixel estimate and the unbiased
+/// variance of the pixel-mean luminance. A pure function of the persisted
+/// state, so *when* a pixel is resolved (per pass, per progressive
+/// snapshot) cannot change what it resolves to.
+fn resolve_pixel(acc: &PixelAccum) -> (Vec3A, f64) {
+    // A pixel a cancelled render never reached: black, with variance
+    // "unknown" — unreachable in a completed pass.
+    if acc.taken == 0 {
+        return (Vec3A::ZERO, f64::INFINITY);
+    }
+    let n = acc.taken as f64;
+    let variance = if acc.taken >= 2 {
+        ((acc.lum_sq - acc.lum_sum * acc.lum_sum / n) / (n - 1.0) / n).max(0.0)
+    } else {
+        f64::INFINITY
+    };
+    // Weighted-average film estimator. A Mitchell pixel whose few
+    // samples all landed on negative lobes could zero the denominator;
+    // the plain mean is the sane fallback there.
+    let mean = if acc.weight_sum > 0.0 {
+        acc.sum / acc.weight_sum
+    } else {
+        acc.sum / acc.taken as f32
+    };
+    (mean, variance)
+}
+
+/// Outcome of one [`ProgressiveRender::step`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepStatus {
+    /// The step reached its target; more of the budget remains.
+    InProgress { spp_done: u32 },
+    /// The stop token fired mid-step. The image stays coherent, and a later
+    /// `step` resumes exactly where this one was cut off.
+    Stopped { spp_done: u32 },
+    /// The full sample budget is rendered; further `step`s are no-ops.
+    Complete { spp_done: u32 },
+}
+
+impl StepStatus {
+    /// Samples per pixel fully banked so far (budgeted samples of completed
+    /// chunks — pixels the adaptive stop finished early hold fewer by
+    /// design).
+    pub fn spp_done(self) -> u32 {
+        match self {
+            StepStatus::InProgress { spp_done }
+            | StepStatus::Stopped { spp_done }
+            | StepStatus::Complete { spp_done } => spp_done,
+        }
+    }
+}
+
+/// State of an in-flight progressive render — see
+/// [`Renderer::begin_progressive`].
+enum ProgState {
+    /// Unguided: one film advanced toward the full budget.
+    Simple { film: Film, spp_done: u32 },
+    /// Guided, in the training phase: passes run whole, one per step.
+    Training {
+        field: GuidingField,
+        gcfg: GuidingConfig,
+        passes: Vec<(Buffer, f64)>,
+        k: u32,
+        eff_unguided: Option<(Vec<f64>, f64)>,
+        eff_guided: Option<(Vec<f64>, f64)>,
+        train_spp_done: u32,
+    },
+    /// Guided, in the (chunkable) final pass. `field` is `None` when the
+    /// efficiency estimate turned guiding off for the final pass.
+    Final {
+        field: Option<GuidingField>,
+        passes: Vec<(Buffer, f64)>,
+        film: Film,
+        train_spp_done: u32,
+        spp_done: u32,
+    },
+    Done { buffer: Buffer, spp_done: u32 },
+    /// Placeholder while `step` owns the state; never observable.
+    Transitioning,
+}
+
+/// A progressive render session (see [`Renderer::begin_progressive`]): the
+/// host thread owns it, calls [`ProgressiveRender::step`] to advance the
+/// image by a sample budget, and may read a coherent intermediate image
+/// with [`ProgressiveRender::snapshot`] between steps — the reason there is
+/// no locking anywhere in this type.
+pub struct ProgressiveRender<'a> {
+    renderer: &'a Renderer,
+    tiled: bool,
+    rays: RayStats,
+    state: ProgState,
+}
+
+impl ProgressiveRender<'_> {
+    /// Advances the render by (up to) `spp` more samples per pixel. In the
+    /// guided training phase the chunk size is ignored and the next whole
+    /// training pass runs instead (see [`Renderer::begin_progressive`]).
+    pub fn step(
+        &mut self,
+        spp: u32,
+        progress: Option<ProgressCallback>,
+        stop: Option<&StopToken>,
+    ) -> StepStatus {
+        let renderer = self.renderer;
+        let total_spp = renderer.settings.samples_per_pixel;
+        let state = std::mem::replace(&mut self.state, ProgState::Transitioning);
+        let (state, status) = match state {
+            ProgState::Done { buffer, spp_done } => (
+                ProgState::Done { buffer, spp_done },
+                StepStatus::Complete { spp_done },
+            ),
+
+            ProgState::Simple { mut film, spp_done } => {
+                let target = spp_done.saturating_add(spp.max(1)).min(total_spp);
+                let cfg = renderer.final_pass_config(self.tiled);
+                let (_, rays, chunk_done) =
+                    renderer.advance_film(&mut film, target, &cfg, None, progress, stop);
+                self.rays.merge(&rays);
+                if !chunk_done {
+                    (
+                        ProgState::Simple { film, spp_done },
+                        StepStatus::Stopped { spp_done },
+                    )
+                } else if target >= total_spp {
+                    let (buffer, _, _) = renderer.finish_pass(&film, self.tiled);
+                    (
+                        ProgState::Done {
+                            buffer,
+                            spp_done: target,
+                        },
+                        StepStatus::Complete { spp_done: target },
+                    )
+                } else {
+                    (
+                        ProgState::Simple {
+                            film,
+                            spp_done: target,
+                        },
+                        StepStatus::InProgress { spp_done: target },
+                    )
+                }
+            }
+
+            ProgState::Training {
+                mut field,
+                gcfg,
+                mut passes,
+                k,
+                mut eff_unguided,
+                mut eff_guided,
+                train_spp_done,
+            } => {
+                // Mirror of the batch schedule in `render_guided` — same
+                // budgets, same seeds, same field updates, so a progressive
+                // guided render trains the identical field.
+                let spp_k = (1u32 << k.min(16)).max(2);
+                let seed = (renderer.settings.frame as u32)
+                    .wrapping_add((k + 1).wrapping_mul(0x9E37_79B9));
+                let train_cfg = PassConfig {
+                    spp: spp_k,
+                    seed,
+                    tiled: self.tiled,
+                    adaptive: false,
+                };
+                let gctx = GuidingContext {
+                    field: &field,
+                    training: true,
+                };
+                let start = std::time::Instant::now();
+                let (buffer, samples, stats, completed) =
+                    renderer.render_pass(train_cfg, Some(&gctx), progress, stop);
+                let secs = start.elapsed().as_secs_f64();
+                drop(gctx);
+                self.rays.merge(&stats.rays);
+                if !completed {
+                    // Discard the interrupted pass wholesale (partial sample
+                    // sets must not train the field); the next step re-runs
+                    // it from scratch.
+                    info!(
+                        "path guiding: stopped during training pass {} — discarding it",
+                        k + 1
+                    );
+                    (
+                        ProgState::Training {
+                            field,
+                            gcfg,
+                            passes,
+                            k,
+                            eff_unguided,
+                            eff_guided,
+                            train_spp_done,
+                        },
+                        StepStatus::Stopped {
+                            spp_done: train_spp_done,
+                        },
+                    )
+                } else {
+                    info!(
+                        "path guiding: training pass {}/{} at {} spp — {} samples, variance {:.3e}, {:.2}s",
+                        k + 1,
+                        gcfg.train_iterations,
+                        spp_k,
+                        samples.len(),
+                        stats.variance,
+                        secs
+                    );
+                    if k == 0 {
+                        eff_unguided = Some((stats.var_map, secs));
+                    } else if k == gcfg.train_iterations - 1 {
+                        eff_guided = Some((stats.var_map, secs));
+                    }
+                    field.update(&samples, k + 1);
+                    passes.push((buffer, stats.variance));
+                    let train_spp_done = train_spp_done + spp_k;
+                    let k = k + 1;
+                    if k < gcfg.train_iterations {
+                        (
+                            ProgState::Training {
+                                field,
+                                gcfg,
+                                passes,
+                                k,
+                                eff_unguided,
+                                eff_guided,
+                                train_spp_done,
+                            },
+                            StepStatus::InProgress {
+                                spp_done: train_spp_done,
+                            },
+                        )
+                    } else {
+                        let guide_final =
+                            renderer.decide_guide_final(&passes, &eff_unguided, &eff_guided);
+                        info!(
+                            "path guiding: final pass at {} spp ({})",
+                            total_spp,
+                            if guide_final { "guided" } else { "unguided" }
+                        );
+                        (
+                            ProgState::Final {
+                                field: guide_final.then_some(field),
+                                passes,
+                                film: Film::new(
+                                    renderer.settings.width,
+                                    renderer.settings.height,
+                                ),
+                                train_spp_done,
+                                spp_done: 0,
+                            },
+                            StepStatus::InProgress {
+                                spp_done: train_spp_done,
+                            },
+                        )
+                    }
+                }
+            }
+
+            ProgState::Final {
+                field,
+                mut passes,
+                mut film,
+                train_spp_done,
+                spp_done,
+            } => {
+                let target = spp_done.saturating_add(spp.max(1)).min(total_spp);
+                let cfg = renderer.final_pass_config(self.tiled);
+                let gctx_store;
+                let gctx = match &field {
+                    Some(f) => {
+                        gctx_store = GuidingContext {
+                            field: f,
+                            training: false,
+                        };
+                        Some(&gctx_store)
+                    }
+                    None => None,
+                };
+                let (_, rays, chunk_done) =
+                    renderer.advance_film(&mut film, target, &cfg, gctx, progress, stop);
+                self.rays.merge(&rays);
+                if !chunk_done {
+                    (
+                        ProgState::Final {
+                            field,
+                            passes,
+                            film,
+                            train_spp_done,
+                            spp_done,
+                        },
+                        StepStatus::Stopped {
+                            spp_done: train_spp_done + spp_done,
+                        },
+                    )
+                } else if target >= total_spp {
+                    let (buffer, variance, _) = renderer.finish_pass(&film, self.tiled);
+                    passes.push((buffer, variance));
+                    let blended = renderer.blend_passes(&passes);
+                    (
+                        ProgState::Done {
+                            buffer: blended,
+                            spp_done: train_spp_done + target,
+                        },
+                        StepStatus::Complete {
+                            spp_done: train_spp_done + target,
+                        },
+                    )
+                } else {
+                    (
+                        ProgState::Final {
+                            field,
+                            passes,
+                            film,
+                            train_spp_done,
+                            spp_done: target,
+                        },
+                        StepStatus::InProgress {
+                            spp_done: train_spp_done + target,
+                        },
+                    )
+                }
+            }
+
+            ProgState::Transitioning => unreachable!("ProgState::Transitioning escaped step()"),
+        };
+        self.state = state;
+        status
+    }
+
+    /// A coherent copy of the image as rendered so far. Call between steps
+    /// (the session is single-owner, so there is nothing to race). In the
+    /// guided final phase the partial final pass joins the blend weighted by
+    /// its variance so far — an approximation that only ever affects
+    /// intermediate snapshots, never the completed render.
+    pub fn snapshot(&self) -> Buffer {
+        let renderer = self.renderer;
+        match &self.state {
+            ProgState::Done { buffer, .. } => buffer.clone(),
+            ProgState::Simple { film, .. } => renderer.finish_pass(film, self.tiled).0,
+            ProgState::Training { passes, .. } => {
+                if passes.is_empty() {
+                    Buffer::new(renderer.settings.width, renderer.settings.height)
+                } else {
+                    blend_pass_refs(
+                        &passes.iter().map(|(b, v)| (b, *v)).collect::<Vec<_>>(),
+                        renderer.settings.width,
+                        renderer.settings.height,
+                    )
+                }
+            }
+            ProgState::Final { passes, film, .. } => {
+                let (partial, variance, _) = renderer.finish_pass(film, self.tiled);
+                let mut entries: Vec<(&Buffer, f64)> =
+                    passes.iter().map(|(b, v)| (b, *v)).collect();
+                entries.push((&partial, variance));
+                blend_pass_refs(
+                    &entries,
+                    renderer.settings.width,
+                    renderer.settings.height,
+                )
+            }
+            ProgState::Transitioning => unreachable!("ProgState::Transitioning escaped step()"),
+        }
+    }
+
+    /// As [`ProgressiveRender::snapshot`], writing into a caller-owned
+    /// buffer (resized to the image if it does not match).
+    pub fn snapshot_into(&self, buf: &mut Buffer) {
+        match &self.state {
+            ProgState::Simple { film, .. } => {
+                if buf.width() != film.width || buf.height() != film.height {
+                    *buf = Buffer::new(film.width, film.height);
+                }
+                for j in 0..film.height {
+                    for i in 0..film.width {
+                        buf.set_pixel(i, j, resolve_pixel(&film.pixels[j * film.width + i]).0);
+                    }
+                }
+            }
+            _ => *buf = self.snapshot(),
+        }
+    }
+
+    /// Budgeted samples per pixel banked so far (training + final for
+    /// guided sessions).
+    pub fn spp_done(&self) -> u32 {
+        match &self.state {
+            ProgState::Simple { spp_done, .. } => *spp_done,
+            ProgState::Training { train_spp_done, .. } => *train_spp_done,
+            ProgState::Final {
+                train_spp_done,
+                spp_done,
+                ..
+            } => train_spp_done + spp_done,
+            ProgState::Done { spp_done, .. } => *spp_done,
+            ProgState::Transitioning => unreachable!("ProgState::Transitioning escaped step()"),
+        }
+    }
+
+    pub fn is_complete(&self) -> bool {
+        matches!(self.state, ProgState::Done { .. })
+    }
+
+    /// Consumes the session, returning the image as rendered so far (the
+    /// final image when complete) and the ray counters across every step.
+    pub fn finish(self) -> (Buffer, RayStats) {
+        if matches!(self.state, ProgState::Done { .. }) {
+            let rays = self.rays;
+            match self.state {
+                ProgState::Done { buffer, .. } => (buffer, rays),
+                _ => unreachable!(),
+            }
+        } else {
+            let buffer = self.snapshot();
+            (buffer, self.rays)
+        }
+    }
+}
+
+/// Inverse-variance blend over borrowed passes — `blend_passes` for the
+/// snapshot path, minus the ownership and the logging (snapshots may run
+/// every frame). Non-finite/zero variances get zero weight; if nothing is
+/// weightable the last pass is returned as-is.
+fn blend_pass_refs(passes: &[(&Buffer, f64)], width: usize, height: usize) -> Buffer {
+    let weights: Vec<f64> = passes
+        .iter()
+        .map(|(_, var)| {
+            if var.is_finite() && *var > 0.0 {
+                1.0 / var
+            } else {
+                0.0
+            }
+        })
+        .collect();
+    let total: f64 = weights.iter().sum();
+    if total <= 0.0 {
+        return passes
+            .last()
+            .expect("at least one pass exists")
+            .0
+            .clone();
+    }
+    let mut out = Buffer::new(width, height);
+    for y in 0..height {
+        for x in 0..width {
+            let mut c = Vec3A::ZERO;
+            for ((pass, _), w) in passes.iter().zip(&weights) {
+                c += pass.get_pixel(x, y) * (*w / total) as f32;
+            }
+            out.set_pixel(x, y, c);
+        }
+    }
+    out
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -660,6 +1398,16 @@ pub struct RenderSettings {
     pixel_filter: PixelFilter,
 }
 impl RenderSettings {
+    /// Image width in pixels.
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    /// Image height in pixels.
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
     pub fn new(
         samples_per_pixel: u32,
         max_depth: u32,
@@ -1665,6 +2413,159 @@ mod tests {
         let balance = SamplingStrategy::BalanceMis.light_weight(a, b);
         let power = SamplingStrategy::PowerMis.light_weight(a, b);
         assert!(power > balance, "power {power} <= balance {balance}");
+    }
+
+    use super::{Renderer, StepStatus, StopToken};
+    use crate::tracer::RenderSettings;
+    use crate::world::simple_scene;
+    use crate::{Buffer, Camera};
+    use glam::Vec3A;
+
+    /// A tiny renderer over the procedural scene — small enough that the
+    /// bitwise progressive-vs-batch comparisons below run in milliseconds.
+    fn tiny_renderer(spp: u32, adaptive: bool) -> Renderer {
+        let (world, lights) = simple_scene();
+        let camera = Camera::new(
+            Vec3A::new(15.0, 3.0, 3.0),
+            Vec3A::new(0.0, 1.0, 0.0),
+            Vec3A::new(0.0, 1.0, 0.0),
+            20.0,
+            64.0 / 36.0,
+            0.1,
+            10.0,
+        );
+        // variance_threshold > 0 with a low min_spp arms the adaptive early
+        // stop; 0 disables it.
+        let (min_spp, threshold) = if adaptive { (4, 0.5) } else { (0, 0.0) };
+        let settings = RenderSettings::new(spp, 8, 64, 36, min_spp, threshold, 0);
+        Renderer::new(camera, world, lights, settings)
+    }
+
+    fn assert_buffers_bit_identical(a: &Buffer, b: &Buffer, what: &str) {
+        assert_eq!((a.width(), a.height()), (b.width(), b.height()));
+        for (idx, (pa, pb)) in a.as_slice().iter().zip(b.as_slice()).enumerate() {
+            assert_eq!(
+                [pa.x.to_bits(), pa.y.to_bits(), pa.z.to_bits()],
+                [pb.x.to_bits(), pb.y.to_bits(), pb.z.to_bits()],
+                "{what}: pixel {idx} differs ({pa:?} vs {pb:?})"
+            );
+        }
+    }
+
+    /// The load-bearing Phase 0 guarantee: a progressive render run to
+    /// completion is bit-identical to the batch render — for any chunk
+    /// size, with adaptive sampling off and on, scanline and tiled.
+    #[test]
+    fn progressive_equals_batch_bitwise() {
+        for adaptive in [false, true] {
+            for tiled in [false, true] {
+                let renderer = tiny_renderer(16, adaptive);
+                let batch = if tiled {
+                    renderer.render_with_tiles()
+                } else {
+                    renderer.render()
+                };
+                for chunk in [1u32, 3, 5, 16] {
+                    let mut session = renderer.begin_progressive(tiled);
+                    while !session.is_complete() {
+                        session.step(chunk, None, None);
+                    }
+                    let (progressive, _) = session.finish();
+                    assert_buffers_bit_identical(
+                        &batch,
+                        &progressive,
+                        &format!("adaptive={adaptive} tiled={tiled} chunk={chunk}"),
+                    );
+                }
+            }
+        }
+    }
+
+    /// Guided progressive (whole training passes, chunked final pass) must
+    /// reproduce the guided batch render bit for bit.
+    ///
+    /// One training iteration on purpose: with two or more, the guiding
+    /// efficiency estimate (`decide_guide_final`) compares *wall-clock*
+    /// pass costs, so even two batch renders of the same scene can
+    /// legitimately pick different final passes when ΔEff sits near 1 —
+    /// a pre-existing property of the guided pipeline, not of the
+    /// progressive refactor. A single iteration never produces the
+    /// estimate, making the guided/unguided decision (and therefore the
+    /// image) deterministic.
+    #[test]
+    fn guided_progressive_equals_guided_batch() {
+        let mut renderer = tiny_renderer(8, false);
+        renderer.settings = renderer.settings.with_guiding(true, 1, 0.5);
+        let batch = renderer.render();
+        let mut session = renderer.begin_progressive(false);
+        while !session.is_complete() {
+            session.step(3, None, None);
+        }
+        let (progressive, _) = session.finish();
+        assert_buffers_bit_identical(&batch, &progressive, "guided");
+    }
+
+    /// A fired stop leaves a coherent partial image (no NaNs, unreached
+    /// pixels black), and resuming afterwards still converges to the exact
+    /// batch result.
+    #[test]
+    fn stopped_render_is_coherent_and_resumes() {
+        let renderer = tiny_renderer(16, false);
+        let batch = renderer.render();
+
+        let stop = StopToken::new();
+        stop.stop(); // fire before the first row: the whole step is skipped
+        let mut session = renderer.begin_progressive(false);
+        let status = session.step(16, None, Some(&stop));
+        assert_eq!(status, StepStatus::Stopped { spp_done: 0 });
+        let snapshot = session.snapshot();
+        for p in snapshot.as_slice() {
+            assert!(p.is_finite(), "stopped snapshot contains non-finite pixels");
+        }
+
+        // Resume without the token: the interrupted work is picked back up
+        // and the completed render matches batch bitwise.
+        while !session.is_complete() {
+            session.step(4, None, None);
+        }
+        let (resumed, _) = session.finish();
+        assert_buffers_bit_identical(&batch, &resumed, "stop/resume");
+
+        // The controlled one-shot entry point reports the interruption too.
+        let stop2 = StopToken::new();
+        stop2.stop();
+        let (partial, _, completed) = renderer.render_with_control(false, None, Some(&stop2));
+        assert!(!completed);
+        for p in partial.as_slice() {
+            assert!(p.is_finite());
+        }
+    }
+
+    /// `render_with_control` without a token is exactly the plain render.
+    #[test]
+    fn controlled_render_without_token_matches_batch() {
+        let renderer = tiny_renderer(8, true);
+        let batch = renderer.render();
+        let (controlled, _, completed) = renderer.render_with_control(false, None, None);
+        assert!(completed);
+        assert_buffers_bit_identical(&batch, &controlled, "render_with_control");
+    }
+
+    /// Mid-flight snapshots are coherent and `snapshot_into` agrees with
+    /// `snapshot`.
+    #[test]
+    fn snapshots_are_coherent_mid_render() {
+        let renderer = tiny_renderer(16, false);
+        let mut session = renderer.begin_progressive(true);
+        session.step(4, None, None);
+        assert_eq!(session.spp_done(), 4);
+        let snap = session.snapshot();
+        let mut into = Buffer::new(1, 1); // wrong size on purpose: must resize
+        session.snapshot_into(&mut into);
+        assert_buffers_bit_identical(&snap, &into, "snapshot_into");
+        for p in snap.as_slice() {
+            assert!(p.is_finite());
+        }
     }
 }
 

--- a/crates/crust-render/src/main.rs
+++ b/crates/crust-render/src/main.rs
@@ -1,8 +1,11 @@
+#![forbid(unsafe_code)]
+
 use clap::Parser;
 use crust_core::Buffer;
 use crust_core::PixelFilter;
 use crust_core::Renderer;
 use crust_core::SamplingStrategy;
+use crust_core::{AovRequest, StepStatus, StopToken};
 use crust_core::{AssetLoader, EnvironmentMap, PtexTexture, Scene, Vec3A};
 use crust_core::{get_settings, simple_scene};
 use exr::prelude::*;
@@ -393,6 +396,25 @@ struct Cli {
     /// render, output) when the render finishes.
     #[arg(long, default_value_t = false)]
     stats: bool,
+    /// Render progressively, advancing the image by this many samples per
+    /// pixel per chunk. Run to completion the result is bit-identical to
+    /// the one-shot render — this exists for previews (--preview) and
+    /// early termination (--time-limit).
+    #[arg(long, value_name = "SPP")]
+    progressive: Option<u32>,
+    /// With --progressive: every N chunks, write a tone-mapped snapshot
+    /// PNG next to the output (out.pass###.png).
+    #[arg(long, value_name = "N")]
+    preview: Option<u32>,
+    /// Stop rendering after this many seconds and write the coherent
+    /// partial image accumulated so far.
+    #[arg(long, value_name = "SECONDS")]
+    time_limit: Option<u64>,
+    /// Also render AOV sidecars next to the output: primary-hit depth,
+    /// world normal, alpha and [geom_id, prim_id] (out.depth.exr,
+    /// out.normal.exr, out.alpha.exr, out.id.exr).
+    #[arg(long, default_value_t = false)]
+    aovs: bool,
 }
 
 #[derive(clap::ValueEnum, Clone, Debug, Copy)]
@@ -486,6 +508,69 @@ fn write_png(
         }
     }
     img.save(path)
+}
+
+/// Render the AOV planes and write them as EXR sidecars next to `output`:
+/// `.depth.exr`, `.normal.exr`, `.alpha.exr` (linear f32 RGB), and
+/// `.id.exr` carrying the primary hit's `[geom_id, prim_id]` as two u32
+/// channels (ids must survive exactly — a float channel would corrupt them
+/// past 2^24). A failed sidecar logs and continues: the beauty image is
+/// already on disk.
+fn write_aovs(renderer: &Renderer, output: &str) {
+    let aovs = renderer.render_aovs(AovRequest {
+        depth: true,
+        normal: true,
+        prim_id: true,
+        alpha: true,
+    });
+    let (w, h) = (aovs.width, aovs.height);
+    // AOV planes keep row 0 at the bottom (the engine convention); EXR
+    // scanlines run top-down.
+    let flip = |x: usize, y: usize| (h - 1 - y) * w + x;
+
+    let depth = aovs.depth.as_ref().expect("requested above");
+    let path = Path::new(output).with_extension("depth.exr");
+    match write_rgb_file(&path, w, h, |x, y| {
+        let d = depth[flip(x, y)];
+        (d, d, d)
+    }) {
+        Ok(_) => info!("AOV written to: {:?}", path),
+        Err(e) => error!("Error writing depth AOV: {}", e),
+    }
+
+    let normal = aovs.normal.as_ref().expect("requested above");
+    let path = Path::new(output).with_extension("normal.exr");
+    match write_rgb_file(&path, w, h, |x, y| {
+        let n = normal[flip(x, y)];
+        (n.x, n.y, n.z)
+    }) {
+        Ok(_) => info!("AOV written to: {:?}", path),
+        Err(e) => error!("Error writing normal AOV: {}", e),
+    }
+
+    let alpha = aovs.alpha.as_ref().expect("requested above");
+    let path = Path::new(output).with_extension("alpha.exr");
+    match write_rgb_file(&path, w, h, |x, y| {
+        let a = alpha[flip(x, y)];
+        (a, a, a)
+    }) {
+        Ok(_) => info!("AOV written to: {:?}", path),
+        Err(e) => error!("Error writing alpha AOV: {}", e),
+    }
+
+    let ids = aovs.prim_id.as_ref().expect("requested above");
+    let path = Path::new(output).with_extension("id.exr");
+    let channels = SpecificChannels::build()
+        .with_channel("geom_id")
+        .with_channel("prim_id")
+        .with_pixel_fn(|pos: Vec2<usize>| {
+            let [geom, prim] = ids[flip(pos.x(), pos.y())];
+            (geom, prim)
+        });
+    match Image::from_channels((w, h), channels).write().to_file(&path) {
+        Ok(_) => info!("AOV written to: {:?}", path),
+        Err(e) => error!("Error writing id AOV: {}", e),
+    }
 }
 
 fn main() {
@@ -585,7 +670,62 @@ fn main() {
         }
         progress_bar.set_position(done);
     };
-    let (buffer, ray_stats) = renderer.render_with_stats(cli.bucket, &progress);
+    // --time-limit arms a stop token from a watchdog thread; the render
+    // winds down at the next row/tile boundary and the partial image is
+    // written through the normal output path.
+    let stop = StopToken::new();
+    if let Some(secs) = cli.time_limit {
+        let stop = stop.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_secs(secs));
+            stop.stop();
+        });
+    }
+
+    let (buffer, ray_stats) = if let Some(chunk) = cli.progressive {
+        let mut session = renderer.begin_progressive(cli.bucket);
+        let mut chunk_idx = 0u32;
+        loop {
+            let status = session.step(chunk.max(1), Some(&progress), Some(&stop));
+            chunk_idx += 1;
+            match status {
+                StepStatus::Complete { .. } => break,
+                StepStatus::Stopped { spp_done } => {
+                    info!("render stopped at {spp_done} spp; writing the partial image");
+                    break;
+                }
+                StepStatus::InProgress { spp_done } => {
+                    if let Some(every) = cli.preview
+                        && every > 0
+                        && chunk_idx % every == 0
+                    {
+                        let snapshot = session.snapshot();
+                        let preview_path =
+                            Path::new(&output).with_extension(format!("pass{chunk_idx:03}.png"));
+                        match write_png(
+                            &snapshot,
+                            snapshot.width(),
+                            snapshot.height(),
+                            &preview_path,
+                        ) {
+                            Ok(_) => info!("preview at {spp_done} spp: {preview_path:?}"),
+                            Err(e) => error!("Error writing preview PNG: {e}"),
+                        }
+                    }
+                }
+            }
+        }
+        session.finish()
+    } else if cli.time_limit.is_some() {
+        let (buffer, ray_stats, completed) =
+            renderer.render_with_control(cli.bucket, Some(&progress), Some(&stop));
+        if !completed {
+            info!("render stopped by --time-limit; writing the partial image");
+        }
+        (buffer, ray_stats)
+    } else {
+        renderer.render_with_stats(cli.bucket, &progress)
+    };
     bar.finish();
     // Close Timer
     let duration: Duration = start.elapsed();
@@ -609,6 +749,9 @@ fn main() {
             error!("Error writing PNG: {}", e);
             std::process::exit(1);
         }
+    }
+    if cli.aovs {
+        write_aovs(&renderer, &output);
     }
     stats.record("Write output", 0, output_start.elapsed());
 

--- a/crates/crust-rt/src/lib.rs
+++ b/crates/crust-rt/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! Crust Render's ray tracing kernel — the intersection layer only,
 //! factored out of the renderer the way `openqmc-rs` factored out
 //! sampling. The API is deliberately **Embree-shaped** (geometry objects

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 mod common;
 pub use common::Lerp;
 pub use common::{

--- a/docs/embree_comparison.md
+++ b/docs/embree_comparison.md
@@ -216,7 +216,10 @@ Rust bindings exist (`embree4-sys`, `embree4-rs`). Cycles-class traversal speed,
 instancing, curves, and motion blur essentially for free — at the cost of the
 project's two founding constraints: **safe Rust** (an FFI kernel is unsafe C++ at the
 bottom of every ray) and self-containedness (a large native dependency, ISA/build
-matrix, no wasm story). Given that crust is explicitly a toy/learning renderer in
+matrix, no wasm story). (The safe-Rust constraint has since gained one sanctioned
+exception — the Hydra render delegate boundary, `crust-capi` + `hdCrust`; see
+`docs/hydra_delegate.md`. That exception is scoped to those boundary crates and does
+not extend to the kernel, so this trade-off analysis is unchanged.) Given that crust is explicitly a toy/learning renderer in
 safe Rust, this route is coherent only as an optional, feature-gated backend behind
 the existing `Hittable` seam — `trait` object in, `Hit` out — which the codebase's
 narrow query interface (`hit(ray, t_min, t_max)`) would make straightforward to slot

--- a/docs/hydra_delegate.md
+++ b/docs/hydra_delegate.md
@@ -1,14 +1,15 @@
 # Hydra render delegate (hdCrust): decision record and roadmap
 
-Status: **Phases 0 and 1 landed.** Phase 0 (engine groundwork) and Phase 1
-(`crust-capi` + the `hdCrust` plugin MVP) are implemented on this branch.
-`crust-capi` is tested from both sides of the ABI (`cargo test -p
-crust-capi`, `scripts/test_capi_c.sh`); `hdCrust` is compile- **and
-runtime-verified** against OpenUSD v25.11 — a headless harness
-(`hydra/hdCrust/tests/testHdCrust.cpp`) loads the plugin through
-`HdRendererPluginRegistry`, renders a cube via hd's unit-test scene
-delegate, and asserts the color buffer converges nonzero. Interactive
-usdview verification and Phase 2 remain.
+Status: **Phases 0, 1 and 2 landed.** Phase 0 (engine groundwork), Phase 1
+(`crust-capi` + the `hdCrust` plugin MVP) and Phase 2 (incrementality +
+materials) are implemented on this branch. `crust-capi` is tested from both
+sides of the ABI (`cargo test -p crust-capi`, `scripts/test_capi_c.sh`);
+`hdCrust` is compile- **and runtime-verified** against OpenUSD v25.11 — the
+headless harness (`hydra/hdCrust/tests/testHdCrust.cpp`) loads the plugin
+through `HdRendererPluginRegistry` and exercises a converging beauty
+render, UsdPreviewSurface bind + edit, and transform / camera / instancer
+edits re-converging. Interactive usdview verification remains, as do the
+later ideas below (surface textures, volume/curve rprims).
 
 ## The decision
 
@@ -84,13 +85,28 @@ bit-identical):
   compiles clean, and the headless `testHdCrust` harness proves registry
   discovery → delegate → synced scene → converged nonzero image.
 
-### Phase 2 — incrementality and materials
+### Phase 2 — incrementality and materials (landed)
 
-- Retained scene: per-geometry replace, transform-only refit, `Arc<dyn Material>`
-  slot swap — so camera orbits and material tweaks stop paying a full SBVH rebuild.
-- `HdMaterialNetwork2` → OpenPBR translation (transplant the existing
-  UsdPreviewSurface mapping out of `usd_import.rs`'s USD-prim reads).
-- Instancer sync, light edits, render-settings sync.
+- **Prototype geometry cache** (`CrustGeoCache` + `crust_scene_add_instance`):
+  each mesh's triangles commit to an inner `rt::Scene` once and survive scene
+  rebuilds keyed by (prim-path hash, geometry version); placements are kernel
+  `Instance`s, so any edit rebuilds only the top-level BVH over instance
+  bounds. Zero engine changes — the kernel's existing `Arc<rt::Scene>`
+  sharing (the USD importer's own prototype pattern) carries it.
+- **In-place edits** (`crust_renderer_update_camera`/`update_settings`): a
+  camera orbit restarts sampling with no world work at all. Inside the capi,
+  `RendererHandle::edit` is the one place a `&mut Renderer` is formed — the
+  film session (the renderer's only borrower) is dropped first.
+- **UsdPreviewSurface → OpenPBR** in the plugin, replicating the engine
+  importer's mapping exactly (values verbatim, no color-space decode,
+  emission on iff emissiveColor nonzero, clearcoat → coat); texture-connected
+  inputs warn and fall back; meshes track `DirtyMaterialId`.
+- **Dome textures**: `crust_scene_add_dome_light_file` decodes .exr/.hdr/LDR
+  with the CLI `AssetLoader`'s exact semantics (capi-side `exr`/`image` deps).
+- Fixed en route: Phase 1 never synced instancers (the render index does not
+  sync them — the rprim must call `HdInstancer::_SyncInstancerAndParents`,
+  as hdEmbree does), so instance transforms were silently identity. Caught
+  by the extended headless harness.
 
 ## Non-goals
 

--- a/docs/hydra_delegate.md
+++ b/docs/hydra_delegate.md
@@ -1,6 +1,14 @@
 # Hydra render delegate (hdCrust): decision record and roadmap
 
-Status: **Phase 0 in progress** (engine groundwork). Phases 1–2 are planned, not started.
+Status: **Phases 0 and 1 landed.** Phase 0 (engine groundwork) and Phase 1
+(`crust-capi` + the `hdCrust` plugin MVP) are implemented on this branch.
+`crust-capi` is tested from both sides of the ABI (`cargo test -p
+crust-capi`, `scripts/test_capi_c.sh`); `hdCrust` is compile- **and
+runtime-verified** against OpenUSD v25.11 — a headless harness
+(`hydra/hdCrust/tests/testHdCrust.cpp`) loads the plugin through
+`HdRendererPluginRegistry`, renders a cube via hd's unit-test scene
+delegate, and asserts the color buffer converges nonzero. Interactive
+usdview verification and Phase 2 remain.
 
 ## The decision
 
@@ -55,18 +63,26 @@ bit-identical):
   a pure function of the persisted accumulators). CLI: `--progressive`, `--preview`,
   `--time-limit`.
 
-### Phase 1 — `crust-capi` + `hdCrust` MVP
+### Phase 1 — `crust-capi` + `hdCrust` MVP (landed)
 
-- `crates/crust-capi`: `cdylib` exposing scene build (mesh/camera/light/material
-  subset), render start/stop, framebuffer + AOV reads over a C ABI (cbindgen).
-  This is where `unsafe` first appears — `extern "C"` exports and raw-pointer
-  buffer views, nothing else.
-- `hydra/hdCrust/`: C++ plugin — `HdRenderDelegate`, `HdRenderPass`,
-  `HdRenderBuffer`, `HdMesh`/`HdCamera`/light adapters, `plugInfo.json`, CMake
-  against a host OpenUSD build. MVP semantics: rebuild the whole crust scene on any
-  dirty bit; color + depth AOVs; verify in usdview.
-- Note: this repo's CI container has no OpenUSD C++ build; the C++ side is
-  compile-verified against a local USD install, documented in the plugin's README.
+- `crates/crust-capi`: `cdylib`+`staticlib` exposing scene build (meshes,
+  spheres, the four light types, matrix camera, settings), progressive
+  step/stop, framebuffer + AOV reads over a hand-written C header
+  (`include/crust.h`). This is where `unsafe` first appears — `extern "C"`
+  exports, raw-pointer buffer views, and the pinned self-reference tying the
+  `ProgressiveRender` session to its boxed `Renderer` (see
+  `src/handles.rs`). Because the workspace builds release with
+  `panic = "abort"`, the boundary validates every input rather than relying
+  on `catch_unwind`.
+- `hydra/hdCrust/`: the C++ plugin — `HdRenderDelegate`, `HdRenderPass`
+  (synchronous stepping: one `crust_renderer_step` per Hydra `Execute`;
+  usdview's convergence loop supplies progressiveness), `HdRenderBuffer`,
+  mesh/instancer/light adapters, a no-op material stub, `plugInfo.json`,
+  CMake. MVP semantics: rebuild the whole crust scene on any dirty bit;
+  displayColor shading; color + depth + primId AOVs (picking works).
+- Verified against a from-source OpenUSD v25.11 build (no Python, no GL):
+  compiles clean, and the headless `testHdCrust` harness proves registry
+  discovery → delegate → synced scene → converged nonzero image.
 
 ### Phase 2 — incrementality and materials
 

--- a/docs/hydra_delegate.md
+++ b/docs/hydra_delegate.md
@@ -1,0 +1,85 @@
+# Hydra render delegate (hdCrust): decision record and roadmap
+
+Status: **Phase 0 in progress** (engine groundwork). Phases 1–2 are planned, not started.
+
+## The decision
+
+Crust Render will grow a USD **Hydra render delegate** — the plugin form
+(`HdRenderDelegate`) that lets usdview, Houdini/Solaris, Maya and other Hydra hosts
+render their viewport through crust. To make that possible, the project's safe-Rust
+constraint is amended with exactly **one sanctioned exception**:
+
+> All engine crates (`crust-rt`, `crust-core`, `crust-render`, `utils`) remain 100%
+> safe Rust, enforced by `forbid(unsafe_code)` in each crate root (test-only
+> carve-outs excepted). The **Hydra delegate boundary** — a future `crust-capi`
+> C-ABI crate and the `hdCrust` C++ plugin — may use `unsafe`/FFI. No engine crate
+> may ever depend on a boundary crate, so the exception cannot leak inward.
+
+## Why the exception is unavoidable (and why `openusd` is not the answer)
+
+- `HdRenderDelegate` is a **C++ plugin ABI** in OpenUSD's imaging stack
+  (`pxr/imaging/hd`). Hosts load delegates as C++ plugins (`plugInfo.json`) against
+  *their own* OpenUSD build. No pure-Rust crate can be that plugin; the boundary is
+  C++ by definition.
+- The pure-Rust [`openusd`](https://github.com/mxpv/openusd) crate covers the data
+  model (`sdf`/`pcp`/`usd` + schemas) and has no imaging half — and doesn't need
+  one, because **a delegate never parses USD**. Hydra hands it already-composed
+  scene data through `HdSceneDelegate`/scene indexes (`GetMeshTopology()`, points,
+  `HdMaterialNetwork2`, …). The importer (`scene/usd_import.rs`) is therefore
+  *bypassed* by the delegate path, not extended; it keeps serving the CLI.
+- What a delegate drives instead is crust-core's programmatic API, which is already
+  public and openusd-free: `WorldBuilder::attach/commit`, the `Material` trait,
+  `LightList`, `Camera`, `Renderer` (`rt_world.rs`, `lib.rs` re-exports).
+
+## Roadmap
+
+### Phase 0 — engine groundwork (pure Rust, CLI-testable; this phase)
+
+Everything the delegate needs that requires no FFI, gated by the repo's
+golden-image discipline (`scripts/check_images.sh` — batch renders stay
+bit-identical):
+
+- **Raw framebuffer access**: `Buffer::as_slice` / `rows_top_down` so a host can
+  copy rows without per-pixel calls.
+- **Matrix camera**: `Camera::from_view_projection(view, proj, aperture, focus)` —
+  Hydra hands matrices, including off-axis frustums, not lookat/vfov.
+- **AOVs**: depth / world normal / `[geom_id, prim_id]` / alpha via a per-pixel
+  primary-hit probe pass (`Renderer::render_aovs`) — ids point-sampled at pixel
+  centers, which is what Hydra picking requires. CLI: `--aovs` writes EXR sidecars.
+- **Cancellation**: `StopToken` checked per row/tile;
+  `Renderer::render_with_control`. A stopped render is a coherent partial image.
+- **Progressive rendering**: `Renderer::begin_progressive` → `ProgressiveRender`
+  (`step(spp)` / `snapshot()` / `finish()`), persisting per-pixel accumulation so a
+  progressive render run to completion is **bit-identical** to the batch render
+  (the QMC sampler is stateless per sample index and the adaptive-stop predicate is
+  a pure function of the persisted accumulators). CLI: `--progressive`, `--preview`,
+  `--time-limit`.
+
+### Phase 1 — `crust-capi` + `hdCrust` MVP
+
+- `crates/crust-capi`: `cdylib` exposing scene build (mesh/camera/light/material
+  subset), render start/stop, framebuffer + AOV reads over a C ABI (cbindgen).
+  This is where `unsafe` first appears — `extern "C"` exports and raw-pointer
+  buffer views, nothing else.
+- `hydra/hdCrust/`: C++ plugin — `HdRenderDelegate`, `HdRenderPass`,
+  `HdRenderBuffer`, `HdMesh`/`HdCamera`/light adapters, `plugInfo.json`, CMake
+  against a host OpenUSD build. MVP semantics: rebuild the whole crust scene on any
+  dirty bit; color + depth AOVs; verify in usdview.
+- Note: this repo's CI container has no OpenUSD C++ build; the C++ side is
+  compile-verified against a local USD install, documented in the plugin's README.
+
+### Phase 2 — incrementality and materials
+
+- Retained scene: per-geometry replace, transform-only refit, `Arc<dyn Material>`
+  slot swap — so camera orbits and material tweaks stop paying a full SBVH rebuild.
+- `HdMaterialNetwork2` → OpenPBR translation (transplant the existing
+  UsdPreviewSurface mapping out of `usd_import.rs`'s USD-prim reads).
+- Instancer sync, light edits, render-settings sync.
+
+## Non-goals
+
+- No GPU backend (unchanged project constraint).
+- No Storm/Hgi integration — hdCrust is a CPU renderer plugin presenting AOV
+  buffers, like hdEmbree.
+- The kernel stays safe Rust; Embree bindings remain a hypothetical discussed in
+  `docs/embree_comparison.md`, not part of this roadmap.

--- a/hydra/hdCrust/CMakeLists.txt
+++ b/hydra/hdCrust/CMakeLists.txt
@@ -18,9 +18,16 @@ project(hdCrust LANGUAGES CXX)
 find_package(pxr REQUIRED)
 
 set(CRUST_CAPI_DIR "" CACHE PATH
-    "Directory containing libcrust_capi.so (cargo's target/release)")
+    "Directory containing the crust_capi library (cargo's target/release)")
+# On Windows, cargo's cdylib produces crust_capi.dll + crust_capi.dll.lib
+# (the import library, found by the "crust_capi.dll" name) alongside the
+# staticlib crust_capi.lib — prefer the import library so the plugin links
+# against the DLL instead of pulling the whole engine in statically (which
+# would also need Rust's system libraries spelled out by hand). On
+# Linux/macOS the first name matches nothing and libcrust_capi.so/.dylib
+# resolves via the second.
 find_library(CRUST_CAPI_LIB
-    NAMES crust_capi
+    NAMES crust_capi.dll crust_capi
     HINTS "${CRUST_CAPI_DIR}"
     REQUIRED)
 # include/crust.h lives in the crate, two levels up from target/release by
@@ -49,11 +56,19 @@ target_include_directories(hdCrust PRIVATE "${CRUST_INCLUDE_DIR}")
 # `hd` transitively pulls the pxr base/usd libraries it needs.
 target_link_libraries(hdCrust PRIVATE hd "${CRUST_CAPI_LIB}")
 
+# plugInfo.json carries the platform's actual library file name
+# (libhdCrust.so / libhdCrust.dylib / libhdCrust.dll).
+set(HDCRUST_LIBRARY_FILE "libhdCrust${CMAKE_SHARED_LIBRARY_SUFFIX}")
+configure_file(plugInfo.json.in "${CMAKE_CURRENT_BINARY_DIR}/plugInfo.json" @ONLY)
+
 # Install layout: point PXR_PLUGINPATH_NAME at
 # <prefix>/plugin/usd/hdCrust/resources (see README.md).
+# RUNTIME covers Windows, where a SHARED library's .dll installs as a
+# runtime artifact; LIBRARY covers .so/.dylib.
 install(TARGETS hdCrust
-    LIBRARY DESTINATION plugin/usd/hdCrust)
-install(FILES plugInfo.json
+    LIBRARY DESTINATION plugin/usd/hdCrust
+    RUNTIME DESTINATION plugin/usd/hdCrust)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/plugInfo.json"
     DESTINATION plugin/usd/hdCrust/resources)
 
 # Headless smoke test (no GL, no usdview): loads the plugin through the

--- a/hydra/hdCrust/CMakeLists.txt
+++ b/hydra/hdCrust/CMakeLists.txt
@@ -31,6 +31,7 @@ set(CRUST_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../crates/crust-capi/inclu
 add_library(hdCrust SHARED
     instancer.cpp
     light.cpp
+    material.cpp
     mesh.cpp
     renderBuffer.cpp
     renderDelegate.cpp

--- a/hydra/hdCrust/CMakeLists.txt
+++ b/hydra/hdCrust/CMakeLists.txt
@@ -1,0 +1,70 @@
+# hdCrust — the Crust Render Hydra render delegate plugin.
+#
+# Needs: an OpenUSD C++ build (imaging enabled; GL not required) and the
+# crust-capi cdylib from this repository (`cargo build --release -p
+# crust-capi`). Typical configure:
+#
+#   cmake -S hydra/hdCrust -B build/hdCrust \
+#         -DCMAKE_PREFIX_PATH=$USD_ROOT \
+#         -DCRUST_CAPI_DIR=$PWD/target/release \
+#         -DCMAKE_INSTALL_PREFIX=$PWD/install
+#   cmake --build build/hdCrust --target install
+#
+# See README.md for the usdview launch environment.
+
+cmake_minimum_required(VERSION 3.20)
+project(hdCrust LANGUAGES CXX)
+
+find_package(pxr REQUIRED)
+
+set(CRUST_CAPI_DIR "" CACHE PATH
+    "Directory containing libcrust_capi.so (cargo's target/release)")
+find_library(CRUST_CAPI_LIB
+    NAMES crust_capi
+    HINTS "${CRUST_CAPI_DIR}"
+    REQUIRED)
+# include/crust.h lives in the crate, two levels up from target/release by
+# default; allow an explicit override.
+set(CRUST_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../crates/crust-capi/include"
+    CACHE PATH "Directory containing crust.h")
+
+add_library(hdCrust SHARED
+    instancer.cpp
+    light.cpp
+    mesh.cpp
+    renderBuffer.cpp
+    renderDelegate.cpp
+    renderPass.cpp
+    rendererPlugin.cpp
+)
+
+set_target_properties(hdCrust PROPERTIES
+    PREFIX "lib"
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)
+
+target_include_directories(hdCrust PRIVATE "${CRUST_INCLUDE_DIR}")
+# `hd` transitively pulls the pxr base/usd libraries it needs.
+target_link_libraries(hdCrust PRIVATE hd "${CRUST_CAPI_LIB}")
+
+# Install layout: point PXR_PLUGINPATH_NAME at
+# <prefix>/plugin/usd/hdCrust/resources (see README.md).
+install(TARGETS hdCrust
+    LIBRARY DESTINATION plugin/usd/hdCrust)
+install(FILES plugInfo.json
+    DESTINATION plugin/usd/hdCrust/resources)
+
+# Headless smoke test (no GL, no usdview): loads the plugin through the
+# registry, renders a cube via hd's unit-test scene delegate, asserts the
+# color buffer converged nonzero. Run with PXR_PLUGINPATH_NAME pointing at
+# the installed resources dir.
+option(HDCRUST_BUILD_TESTS "Build the headless hdCrust smoke test" OFF)
+if(HDCRUST_BUILD_TESTS)
+    add_executable(testHdCrust tests/testHdCrust.cpp)
+    set_target_properties(testHdCrust PROPERTIES
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED ON)
+    target_include_directories(testHdCrust PRIVATE "${CRUST_INCLUDE_DIR}")
+    target_link_libraries(testHdCrust PRIVATE hd cameraUtil "${CRUST_CAPI_LIB}")
+endif()

--- a/hydra/hdCrust/README.md
+++ b/hydra/hdCrust/README.md
@@ -27,12 +27,26 @@ This is **Phase 2** of `docs/hydra_delegate.md`:
 
 ## Building
 
-Requirements: an OpenUSD C++ build with imaging enabled (GL not required —
-a `build_usd.py --no-python --imaging` build is enough), CMake ≥ 3.20, a
-C++17 compiler, and the crust-capi cdylib.
+Requirements on every platform:
+
+- An **OpenUSD C++ build with imaging enabled** (GL not required — a
+  `build_usd.py --no-python --imaging` build is enough). The plugin must be
+  compiled with the **same compiler family and C++ runtime as that USD
+  build** — USD's C++ ABI is not stable across toolchains.
+- **CMake ≥ 3.20** and a **C++17 compiler**.
+- A **Rust toolchain** (rustc ≥ 1.85, the edition-2024 floor) for the
+  crust-capi library the plugin links against.
+
+`$USD_ROOT` / `%USD_ROOT%` below is the USD install prefix (the directory
+containing `pxrConfig.cmake`).
+
+### Linux (and macOS)
+
+Any recent gcc or clang works (match the one that built USD).
 
 ```bash
-# 1. The Rust side (from the repository root)
+# 1. The Rust side (from the repository root) — produces
+#    target/release/libcrust_capi.so
 cargo build --release -p crust-capi
 
 # 2. The plugin
@@ -43,13 +57,58 @@ cmake -S hydra/hdCrust -B build/hdCrust \
 cmake --build build/hdCrust --target install
 ```
 
+### Windows
+
+Use **MSVC** (the toolchain USD requires on Windows) from an *x64 Native
+Tools Command Prompt for VS*, and the MSVC Rust toolchain
+(`x86_64-pc-windows-msvc`, rustup's default on Windows). Cargo's cdylib
+produces `crust_capi.dll` plus its import library `crust_capi.dll.lib`;
+CMake links the import library (preferred automatically over the
+also-produced static `crust_capi.lib`) and the DLL is loaded at run time.
+
+```bat
+:: 1. The Rust side (from the repository root) — produces
+::    target\release\crust_capi.dll (+ .dll.lib)
+cargo build --release -p crust-capi
+
+:: 2. The plugin (multi-config generator: pick Release at build time)
+cmake -S hydra\hdCrust -B build\hdCrust ^
+      -DCMAKE_PREFIX_PATH=%USD_ROOT% ^
+      -DCRUST_CAPI_DIR=%CD%\target\release ^
+      -DCMAKE_INSTALL_PREFIX=%CD%\install
+cmake --build build\hdCrust --config Release --target install
+```
+
+Notes:
+- `plugInfo.json` is configured by CMake with the platform's library file
+  name (`libhdCrust.so` / `.dylib` / `.dll`), so the same source tree
+  builds everywhere.
+- The C smoke test (`scripts/test_capi_c.sh`) is a bash script; on Windows
+  run the Rust-side twin instead: `cargo test -p crust-capi`.
+
 ## Running
+
+Linux/macOS:
 
 ```bash
 export PXR_PLUGINPATH_NAME=$PWD/install/plugin/usd/hdCrust/resources:$PXR_PLUGINPATH_NAME
 export LD_LIBRARY_PATH=$PWD/target/release:$USD_ROOT/lib:$LD_LIBRARY_PATH
 usdview samples/cornellbox.usda   # then View > Renderer > Crust
 ```
+
+Windows (DLL resolution goes through `PATH` — it must reach both
+`crust_capi.dll` and USD's own DLLs):
+
+```bat
+set PXR_PLUGINPATH_NAME=%CD%\install\plugin\usd\hdCrust\resources;%PXR_PLUGINPATH_NAME%
+set PATH=%CD%\target\release;%USD_ROOT%\lib;%USD_ROOT%\bin;%PATH%
+usdview samples\cornellbox.usda   :: then View > Renderer > Crust
+```
+
+Only the Linux path is exercised by this repository's checks (the headless
+harness below runs against a from-source Linux USD build); the Windows
+instructions follow USD's standard plugin conventions but are not covered
+by CI — please report anything that doesn't hold.
 
 The headless harness (`-DHDCRUST_BUILD_TESTS=ON` → `testHdCrust`, run with
 the same two environment variables) covers what usdview would exercise:

--- a/hydra/hdCrust/README.md
+++ b/hydra/hdCrust/README.md
@@ -1,0 +1,71 @@
+# hdCrust — Crust Render as a Hydra render delegate
+
+A C++ `HdRenderDelegate` plugin that lets Hydra hosts (usdview, Solaris,
+Maya, …) render their viewport through Crust Render's CPU path tracer, via
+the `crust-capi` C ABI (`crates/crust-capi/include/crust.h`).
+
+This is the **Phase 1 MVP** of `docs/hydra_delegate.md`:
+
+- Rprims: meshes (triangulated via `HdMeshUtil`; vertex normals honored).
+- Instancing: point instancers flatten to one crust mesh per placement
+  (real kernel instancing through the C API is the Phase 2 seam).
+- Lights: sphere, rect, distant, dome — UsdLux `intensity`/`exposure`/
+  `color` respected; **dome textures render as the uniform color** for now.
+- Shading: **displayColor only** — materials are accepted and ignored
+  (`HdMaterialNetwork` → OpenPBR translation is Phase 2).
+- AOVs: color (float32/float16/unorm8 RGBA), depth, primId (picking works).
+- Edits: **any** change (camera orbit included) rebuilds the whole crust
+  scene — correct, not yet fast. Progressive refinement between edits:
+  every Hydra `Execute` adds a few samples until the budget converges.
+
+## Building
+
+Requirements: an OpenUSD C++ build with imaging enabled (GL not required —
+a `build_usd.py --no-python --imaging` build is enough), CMake ≥ 3.20, a
+C++17 compiler, and the crust-capi cdylib.
+
+```bash
+# 1. The Rust side (from the repository root)
+cargo build --release -p crust-capi
+
+# 2. The plugin
+cmake -S hydra/hdCrust -B build/hdCrust \
+      -DCMAKE_PREFIX_PATH=$USD_ROOT \
+      -DCRUST_CAPI_DIR=$PWD/target/release \
+      -DCMAKE_INSTALL_PREFIX=$PWD/install
+cmake --build build/hdCrust --target install
+```
+
+## Running
+
+```bash
+export PXR_PLUGINPATH_NAME=$PWD/install/plugin/usd/hdCrust/resources:$PXR_PLUGINPATH_NAME
+export LD_LIBRARY_PATH=$PWD/target/release:$USD_ROOT/lib:$LD_LIBRARY_PATH
+usdview samples/cornellbox.usda   # then View > Renderer > Crust
+```
+
+Environment knobs (all `TF_ENV_SETTING`s):
+
+| variable | default | meaning |
+| --- | --- | --- |
+| `HDCRUST_SAMPLES_PER_PIXEL` | 64 | total per-pixel budget (convergence target) |
+| `HDCRUST_SAMPLES_PER_STEP` | 4 | samples added per Hydra `Execute` call |
+| `HDCRUST_MAX_DEPTH` | 8 | path length bound |
+
+## Design notes
+
+- The renderer is driven **synchronously**: one `crust_renderer_step` per
+  `_Execute`, and Hydra's own convergence loop (usdview re-executes until
+  `IsConverged()`) provides progressive refinement. A background
+  `HdRenderThread` wrapper can be added later without touching the ABI —
+  cancellation already crosses threads through `CrustStopToken`.
+- Framebuffer rows are bottom-up on both sides (crust's native layout and
+  Hydra/GL's), so color/AOV copies are straight `y*width+x` loops.
+- Matrices pass from `GfMatrix4d::GetArray()` into the C API **without
+  transposition**: USD's row-major row-vector storage equals the
+  column-major column-vector layout crust expects, element for element.
+- Depth converts crust's camera-forward distance to `[0,1]` NDC depth
+  through the projection matrix in the render pass.
+- primId: the pass maps crust's per-geometry ids back to Hydra rprim ids,
+  so viewport picking resolves to the right prim even through flattened
+  instancing.

--- a/hydra/hdCrust/README.md
+++ b/hydra/hdCrust/README.md
@@ -4,19 +4,26 @@ A C++ `HdRenderDelegate` plugin that lets Hydra hosts (usdview, Solaris,
 Maya, …) render their viewport through Crust Render's CPU path tracer, via
 the `crust-capi` C ABI (`crates/crust-capi/include/crust.h`).
 
-This is the **Phase 1 MVP** of `docs/hydra_delegate.md`:
+This is **Phase 2** of `docs/hydra_delegate.md`:
 
 - Rprims: meshes (triangulated via `HdMeshUtil`; vertex normals honored).
-- Instancing: point instancers flatten to one crust mesh per placement
-  (real kernel instancing through the C API is the Phase 2 seam).
+- Instancing: point instancers place a **shared kernel prototype** per
+  instance (one committed BVH per mesh, N placements).
 - Lights: sphere, rect, distant, dome — UsdLux `intensity`/`exposure`/
-  `color` respected; **dome textures render as the uniform color** for now.
-- Shading: **displayColor only** — materials are accepted and ignored
-  (`HdMaterialNetwork` → OpenPBR translation is Phase 2).
+  `color` respected; **dome textures load** (.exr/.hdr linear, LDR
+  sRGB→linear) with uniform-color fallback on decode failure.
+- Shading: **UsdPreviewSurface constants** via `HdMaterialNetwork`
+  (diffuseColor, metallic, roughness, ior, opacity, clearcoat,
+  clearcoatRoughness, emissiveColor — same mapping as crust's USD
+  importer); texture-connected inputs warn and use defaults; unbound
+  meshes shade from displayColor.
 - AOVs: color (float32/float16/unorm8 RGBA), depth, primId (picking works).
-- Edits: **any** change (camera orbit included) rebuilds the whole crust
-  scene — correct, not yet fast. Progressive refinement between edits:
-  every Hydra `Execute` adds a few samples until the budget converges.
+- Edits are cheap: a **camera orbit restarts sampling with zero scene
+  work** (`crust_renderer_update_camera`); geometry/material/light edits
+  rebuild only the top-level BVH over instance bounds — mesh triangles and
+  their inner BVHs live in a cross-rebuild prototype cache keyed by prim
+  path + geometry version. Progressive refinement between edits: every
+  Hydra `Execute` adds a few samples until the budget converges.
 
 ## Building
 
@@ -43,6 +50,11 @@ export PXR_PLUGINPATH_NAME=$PWD/install/plugin/usd/hdCrust/resources:$PXR_PLUGIN
 export LD_LIBRARY_PATH=$PWD/target/release:$USD_ROOT/lib:$LD_LIBRARY_PATH
 usdview samples/cornellbox.usda   # then View > Renderer > Crust
 ```
+
+The headless harness (`-DHDCRUST_BUILD_TESTS=ON` → `testHdCrust`, run with
+the same two environment variables) covers what usdview would exercise:
+registry discovery, a converging beauty render, material bind + edit,
+transform / camera / instancer edits re-converging.
 
 Environment knobs (all `TF_ENV_SETTING`s):
 

--- a/hydra/hdCrust/instancer.cpp
+++ b/hydra/hdCrust/instancer.cpp
@@ -1,0 +1,158 @@
+#include "instancer.h"
+
+#include <pxr/base/gf/quatd.h>
+#include <pxr/base/gf/quatf.h>
+#include <pxr/base/gf/quath.h>
+#include <pxr/base/gf/rotation.h>
+#include <pxr/base/gf/vec3f.h>
+#include <pxr/base/gf/vec4f.h>
+#include <pxr/imaging/hd/changeTracker.h>
+#include <pxr/imaging/hd/renderIndex.h>
+#include <pxr/imaging/hd/sceneDelegate.h>
+#include <pxr/imaging/hd/tokens.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+HdCrustInstancer::HdCrustInstancer(HdSceneDelegate* delegate, SdfPath const& id)
+    : HdInstancer(delegate, id) {}
+
+HdCrustInstancer::~HdCrustInstancer() = default;
+
+void HdCrustInstancer::Sync(HdSceneDelegate* sceneDelegate,
+                            HdRenderParam* renderParam,
+                            HdDirtyBits* dirtyBits) {
+    (void)renderParam;
+    _UpdateInstancer(sceneDelegate, dirtyBits);
+    if (HdChangeTracker::IsAnyPrimvarDirty(*dirtyBits, GetId())) {
+        _SyncPrimvars(sceneDelegate, *dirtyBits);
+    }
+}
+
+void HdCrustInstancer::_SyncPrimvars(HdSceneDelegate* sceneDelegate,
+                                     HdDirtyBits dirtyBits) {
+    SdfPath const& id = GetId();
+    HdPrimvarDescriptorVector primvars =
+        sceneDelegate->GetPrimvarDescriptors(id, HdInterpolationInstance);
+    std::lock_guard<std::mutex> lock(_instanceLock);
+    for (HdPrimvarDescriptor const& pv : primvars) {
+        if (!HdChangeTracker::IsPrimvarDirty(dirtyBits, id, pv.name)) {
+            continue;
+        }
+        VtValue value = sceneDelegate->Get(id, pv.name);
+        if (!value.IsEmpty()) {
+            _primvarMap[pv.name] = value;
+        }
+    }
+}
+
+/// One rotation as GfQuatd, whatever encoding the scene delegate handed
+/// over; identity when the index or type is unexpected.
+static GfQuatd _RotationAt(VtValue const& value, int index) {
+    size_t i = size_t(index);
+    if (value.IsHolding<VtQuathArray>()) {
+        auto const& a = value.UncheckedGet<VtQuathArray>();
+        if (i < a.size()) return GfQuatd(a[i]);
+    } else if (value.IsHolding<VtQuatfArray>()) {
+        auto const& a = value.UncheckedGet<VtQuatfArray>();
+        if (i < a.size()) return GfQuatd(a[i]);
+    } else if (value.IsHolding<VtQuatdArray>()) {
+        auto const& a = value.UncheckedGet<VtQuatdArray>();
+        if (i < a.size()) return a[i];
+    } else if (value.IsHolding<VtVec4fArray>()) {
+        // Legacy <real, i, j, k> vec4 encoding (hdEmbree's convention).
+        auto const& a = value.UncheckedGet<VtVec4fArray>();
+        if (i < a.size()) return GfQuatd(a[i][0], a[i][1], a[i][2], a[i][3]);
+    }
+    return GfQuatd::GetIdentity();
+}
+
+static GfVec3f _Vec3At(VtValue const& value, int index, GfVec3f fallback) {
+    if (value.IsHolding<VtVec3fArray>()) {
+        auto const& a = value.UncheckedGet<VtVec3fArray>();
+        if (size_t(index) < a.size()) return a[index];
+    }
+    return fallback;
+}
+
+VtMatrix4dArray HdCrustInstancer::ComputeInstanceTransforms(
+    SdfPath const& prototypeId) {
+    // The composition below is USD row-vector convention: point * M applies
+    // the leftmost factor first, so `final = instanceTransform * scale *
+    // rotate * translate * instancerTransform` is scale∘rotate∘translate
+    // under the instancer's own transform — UsdGeomPointInstancer's order.
+    HdSceneDelegate* delegate = GetDelegate();
+    SdfPath const& id = GetId();
+    VtIntArray instanceIndices = delegate->GetInstanceIndices(id, prototypeId);
+    GfMatrix4d instancerTransform = delegate->GetInstancerTransform(id);
+
+    VtMatrix4dArray transforms(instanceIndices.size());
+    for (size_t i = 0; i < instanceIndices.size(); ++i) {
+        transforms[i] = instancerTransform;
+    }
+
+    std::lock_guard<std::mutex> lock(_instanceLock);
+
+    auto found = _primvarMap.find(HdInstancerTokens->instanceTranslations);
+    if (found != _primvarMap.end()) {
+        for (size_t i = 0; i < instanceIndices.size(); ++i) {
+            GfMatrix4d mat(1.0);
+            mat.SetTranslate(GfVec3d(
+                _Vec3At(found->second, instanceIndices[i], GfVec3f(0.0f))));
+            transforms[i] = mat * transforms[i];
+        }
+    }
+
+    found = _primvarMap.find(HdInstancerTokens->instanceRotations);
+    if (found != _primvarMap.end()) {
+        for (size_t i = 0; i < instanceIndices.size(); ++i) {
+            GfMatrix4d mat(1.0);
+            mat.SetRotate(GfRotation(_RotationAt(found->second, instanceIndices[i])));
+            transforms[i] = mat * transforms[i];
+        }
+    }
+
+    found = _primvarMap.find(HdInstancerTokens->instanceScales);
+    if (found != _primvarMap.end()) {
+        for (size_t i = 0; i < instanceIndices.size(); ++i) {
+            GfMatrix4d mat(1.0);
+            mat.SetScale(GfVec3d(
+                _Vec3At(found->second, instanceIndices[i], GfVec3f(1.0f))));
+            transforms[i] = mat * transforms[i];
+        }
+    }
+
+    found = _primvarMap.find(HdInstancerTokens->instanceTransforms);
+    if (found != _primvarMap.end() &&
+        found->second.IsHolding<VtMatrix4dArray>()) {
+        auto const& mats = found->second.UncheckedGet<VtMatrix4dArray>();
+        for (size_t i = 0; i < instanceIndices.size(); ++i) {
+            if (size_t(instanceIndices[i]) < mats.size()) {
+                transforms[i] = mats[instanceIndices[i]] * transforms[i];
+            }
+        }
+    }
+
+    SdfPath parentId = GetParentId();
+    if (parentId.IsEmpty()) {
+        return transforms;
+    }
+
+    HdInstancer* parent =
+        GetDelegate()->GetRenderIndex().GetInstancer(parentId);
+    if (!TF_VERIFY(parent)) {
+        return transforms;
+    }
+    VtMatrix4dArray parentTransforms =
+        static_cast<HdCrustInstancer*>(parent)->ComputeInstanceTransforms(id);
+
+    VtMatrix4dArray composed(parentTransforms.size() * transforms.size());
+    for (size_t i = 0; i < parentTransforms.size(); ++i) {
+        for (size_t j = 0; j < transforms.size(); ++j) {
+            composed[i * transforms.size() + j] =
+                transforms[j] * parentTransforms[i];
+        }
+    }
+    return composed;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/hydra/hdCrust/instancer.h
+++ b/hydra/hdCrust/instancer.h
@@ -1,0 +1,41 @@
+#ifndef HDCRUST_INSTANCER_H
+#define HDCRUST_INSTANCER_H
+
+#include <pxr/base/gf/matrix4d.h>
+#include <pxr/base/tf/hashmap.h>
+#include <pxr/base/vt/array.h>
+#include <pxr/base/vt/value.h>
+#include <pxr/imaging/hd/instancer.h>
+#include <pxr/pxr.h>
+
+#include <mutex>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// The canonical CPU instancer (hdEmbree's pattern): sync the
+/// instance-rate primvars, then compose per-prototype transforms from
+/// instanceTranslations / instanceRotations / instanceScales /
+/// instanceTransforms under the instancer's own transform — recursing into
+/// a parent instancer when nested. Primvars are kept as VtValues and
+/// accessed by held type, so quaternion encodings (quath/quatf/quatd, or
+/// legacy vec4) are handled without layout assumptions.
+class HdCrustInstancer final : public HdInstancer {
+public:
+    HdCrustInstancer(HdSceneDelegate* delegate, SdfPath const& id);
+    ~HdCrustInstancer() override;
+
+    void Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
+              HdDirtyBits* dirtyBits) override;
+
+    VtMatrix4dArray ComputeInstanceTransforms(SdfPath const& prototypeId);
+
+private:
+    void _SyncPrimvars(HdSceneDelegate* sceneDelegate, HdDirtyBits dirtyBits);
+
+    std::mutex _instanceLock;
+    TfHashMap<TfToken, VtValue, TfToken::HashFunctor> _primvarMap;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDCRUST_INSTANCER_H

--- a/hydra/hdCrust/light.cpp
+++ b/hydra/hdCrust/light.cpp
@@ -4,6 +4,7 @@
 
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/imaging/hd/tokens.h>
+#include <pxr/usd/sdf/assetPath.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -44,16 +45,13 @@ void HdCrustLight::Sync(HdSceneDelegate* sceneDelegate,
     } else if (_lightType == HdPrimTypeTokens->distantLight) {
         light.angle = _Param(sceneDelegate, id, HdLightTokens->angle, 0.53f);
     } else if (_lightType == HdPrimTypeTokens->domeLight) {
-        // Dome textures are deferred (Phase 1 renders the uniform color;
-        // the crust C API already accepts equirect pixels for when EXR/HDR
-        // decoding lands in the plugin).
         VtValue texture =
             sceneDelegate->GetLightParamValue(id, HdLightTokens->textureFile);
-        if (!texture.IsEmpty()) {
-            TF_WARN(
-                "hdCrust: dome light %s has a texture; Phase 1 renders its "
-                "uniform color instead",
-                id.GetText());
+        if (texture.IsHolding<SdfAssetPath>()) {
+            SdfAssetPath const& asset = texture.UncheckedGet<SdfAssetPath>();
+            light.texturePath = asset.GetResolvedPath().empty()
+                                    ? asset.GetAssetPath()
+                                    : asset.GetResolvedPath();
         }
     }
 

--- a/hydra/hdCrust/light.cpp
+++ b/hydra/hdCrust/light.cpp
@@ -1,0 +1,68 @@
+#include "light.h"
+
+#include "renderParam.h"
+
+#include <pxr/imaging/hd/sceneDelegate.h>
+#include <pxr/imaging/hd/tokens.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+HdCrustLight::HdCrustLight(SdfPath const& id, TfToken const& lightType)
+    : HdLight(id), _lightType(lightType) {}
+
+HdDirtyBits HdCrustLight::GetInitialDirtyBitsMask() const {
+    return HdLight::AllDirty;
+}
+
+template <typename T>
+static T _Param(HdSceneDelegate* sceneDelegate, SdfPath const& id,
+                TfToken const& token, T fallback) {
+    VtValue value = sceneDelegate->GetLightParamValue(id, token);
+    if (value.IsHolding<T>()) {
+        return value.UncheckedGet<T>();
+    }
+    return fallback;
+}
+
+void HdCrustLight::Sync(HdSceneDelegate* sceneDelegate,
+                        HdRenderParam* renderParam, HdDirtyBits* dirtyBits) {
+    SdfPath const& id = GetId();
+    auto* param = static_cast<HdCrustRenderParam*>(renderParam);
+
+    HdCrustCachedLight light;
+    light.type = _lightType;
+    light.xform = sceneDelegate->GetTransform(id);
+    light.color = _Param(sceneDelegate, id, HdLightTokens->color,
+                         GfVec3f(1.0f, 1.0f, 1.0f));
+    light.intensity = _Param(sceneDelegate, id, HdLightTokens->intensity, 1.0f);
+    light.exposure = _Param(sceneDelegate, id, HdLightTokens->exposure, 0.0f);
+    if (_lightType == HdPrimTypeTokens->sphereLight) {
+        light.radius = _Param(sceneDelegate, id, HdLightTokens->radius, 0.5f);
+    } else if (_lightType == HdPrimTypeTokens->rectLight) {
+        light.width = _Param(sceneDelegate, id, HdLightTokens->width, 1.0f);
+        light.height = _Param(sceneDelegate, id, HdLightTokens->height, 1.0f);
+    } else if (_lightType == HdPrimTypeTokens->distantLight) {
+        light.angle = _Param(sceneDelegate, id, HdLightTokens->angle, 0.53f);
+    } else if (_lightType == HdPrimTypeTokens->domeLight) {
+        // Dome textures are deferred (Phase 1 renders the uniform color;
+        // the crust C API already accepts equirect pixels for when EXR/HDR
+        // decoding lands in the plugin).
+        VtValue texture =
+            sceneDelegate->GetLightParamValue(id, HdLightTokens->textureFile);
+        if (!texture.IsEmpty()) {
+            TF_WARN(
+                "hdCrust: dome light %s has a texture; Phase 1 renders its "
+                "uniform color instead",
+                id.GetText());
+        }
+    }
+
+    param->UpdateLight(id, light);
+    *dirtyBits = HdLight::Clean;
+}
+
+void HdCrustLight::Finalize(HdRenderParam* renderParam) {
+    static_cast<HdCrustRenderParam*>(renderParam)->RemoveLight(GetId());
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/hydra/hdCrust/light.h
+++ b/hydra/hdCrust/light.h
@@ -1,0 +1,31 @@
+#ifndef HDCRUST_LIGHT_H
+#define HDCRUST_LIGHT_H
+
+#include <pxr/imaging/hd/light.h>
+#include <pxr/pxr.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// One HdLight covering the four supported UsdLux types (sphere, rect,
+/// distant, dome), distinguished by the type token it was created with.
+/// Sync caches the raw UsdLux parameters in the render param; the render
+/// pass converts them to crust's per-type conventions when it rebuilds.
+class HdCrustLight final : public HdLight {
+public:
+    HdCrustLight(SdfPath const& id, TfToken const& lightType);
+    ~HdCrustLight() override = default;
+
+    HdDirtyBits GetInitialDirtyBitsMask() const override;
+
+    void Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
+              HdDirtyBits* dirtyBits) override;
+
+    void Finalize(HdRenderParam* renderParam) override;
+
+private:
+    TfToken _lightType;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDCRUST_LIGHT_H

--- a/hydra/hdCrust/material.cpp
+++ b/hydra/hdCrust/material.cpp
@@ -1,0 +1,132 @@
+#include "material.h"
+
+#include "renderParam.h"
+
+#include <pxr/base/gf/vec3f.h>
+#include <pxr/base/tf/staticTokens.h>
+#include <pxr/imaging/hd/sceneDelegate.h>
+#include <pxr/imaging/hd/tokens.h>
+
+#include <algorithm>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// usdImaging (where UsdImagingTokens->UsdPreviewSurface lives) is not a
+// dependency of a render delegate; a private token is what Storm itself
+// does (hdSt/materialNetwork.cpp). The strings are pinned by usdShaders'
+// shaderDefs.usda.
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
+    (UsdPreviewSurface)
+    (diffuseColor)
+    (emissiveColor)
+    (metallic)
+    (roughness)
+    (ior)
+    (opacity)
+    (clearcoat)
+    (clearcoatRoughness)
+);
+
+HdCrustMaterial::HdCrustMaterial(SdfPath const& id) : HdMaterial(id) {}
+
+static void _ReadFloat(HdMaterialNode2 const& node, TfToken const& name,
+                       float* out) {
+    auto it = node.parameters.find(name);
+    if (it != node.parameters.end() && it->second.IsHolding<float>()) {
+        *out = it->second.UncheckedGet<float>();
+    }
+}
+
+static bool _ReadColor(HdMaterialNode2 const& node, TfToken const& name,
+                       float out[3]) {
+    auto it = node.parameters.find(name);
+    if (it != node.parameters.end() && it->second.IsHolding<GfVec3f>()) {
+        GfVec3f c = it->second.UncheckedGet<GfVec3f>();
+        out[0] = c[0];
+        out[1] = c[1];
+        out[2] = c[2];
+        return true;
+    }
+    return false;
+}
+
+// The engine's `preview_surface_openpbr` mapping, from HdMaterialNetwork
+// data instead of USD attributes. `crust_material_default()` equals the
+// OpenPBR defaults the engine falls back to, so unset (or
+// texture-connected, hence absent) inputs land in the same place.
+static CrustMaterial _TranslatePreviewSurface(SdfPath const& materialId,
+                                              HdMaterialNode2 const& node) {
+    CrustMaterial m;
+    crust_material_default(&m);
+    _ReadColor(node, _tokens->diffuseColor, m.base_color); // verbatim, no decode
+    _ReadFloat(node, _tokens->metallic, &m.metalness);
+    _ReadFloat(node, _tokens->roughness, &m.roughness);
+    _ReadFloat(node, _tokens->ior, &m.ior);
+    _ReadFloat(node, _tokens->opacity, &m.opacity);
+    _ReadFloat(node, _tokens->clearcoat, &m.coat_weight);
+    _ReadFloat(node, _tokens->clearcoatRoughness, &m.coat_roughness);
+    float emissive[3] = {0.0f, 0.0f, 0.0f};
+    if (_ReadColor(node, _tokens->emissiveColor, emissive)) {
+        m.emission_color[0] = emissive[0];
+        m.emission_color[1] = emissive[1];
+        m.emission_color[2] = emissive[2];
+        m.emission_luminance =
+            std::max({emissive[0], emissive[1], emissive[2]}) > 0.0f ? 1.0f
+                                                                     : 0.0f;
+    }
+    if (!node.inputConnections.empty()) {
+        TF_WARN(
+            "hdCrust: material %s has %zu texture-connected input(s); "
+            "surface textures are not supported yet, using constants",
+            materialId.GetText(), node.inputConnections.size());
+    }
+    return m;
+}
+
+void HdCrustMaterial::Sync(HdSceneDelegate* sceneDelegate,
+                           HdRenderParam* renderParam,
+                           HdDirtyBits* dirtyBits) {
+    SdfPath const& id = GetId();
+    auto* param = static_cast<HdCrustRenderParam*>(renderParam);
+
+    CrustMaterial material;
+    crust_material_default(&material);
+    bool translated = false;
+
+    VtValue resource = sceneDelegate->GetMaterialResource(id);
+    if (resource.IsHolding<HdMaterialNetworkMap>()) {
+        HdMaterialNetwork2 network = HdConvertToHdMaterialNetwork2(
+            resource.UncheckedGet<HdMaterialNetworkMap>());
+        auto terminal =
+            network.terminals.find(HdMaterialTerminalTokens->surface);
+        if (terminal != network.terminals.end()) {
+            auto node = network.nodes.find(terminal->second.upstreamNode);
+            if (node != network.nodes.end()) {
+                if (node->second.nodeTypeId == _tokens->UsdPreviewSurface) {
+                    material = _TranslatePreviewSurface(id, node->second);
+                    translated = true;
+                } else {
+                    TF_WARN(
+                        "hdCrust: material %s's surface terminal is %s; only "
+                        "UsdPreviewSurface is supported — shading mid-grey",
+                        id.GetText(), node->second.nodeTypeId.GetText());
+                }
+            }
+        }
+    }
+    if (!translated) {
+        // The engine's unknown-shader fallback is mid-grey diffuse.
+        material.base_color[0] = 0.5f;
+        material.base_color[1] = 0.5f;
+        material.base_color[2] = 0.5f;
+    }
+
+    param->UpdateMaterial(id, material);
+    *dirtyBits = HdMaterial::Clean;
+}
+
+void HdCrustMaterial::Finalize(HdRenderParam* renderParam) {
+    static_cast<HdCrustRenderParam*>(renderParam)->RemoveMaterial(GetId());
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/hydra/hdCrust/material.h
+++ b/hydra/hdCrust/material.h
@@ -1,0 +1,35 @@
+#ifndef HDCRUST_MATERIAL_H
+#define HDCRUST_MATERIAL_H
+
+#include <pxr/imaging/hd/material.h>
+#include <pxr/pxr.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// Translates a bound material's HdMaterialNetwork into a CrustMaterial:
+/// the surface terminal's UsdPreviewSurface constants map onto crust's
+/// OpenPBR übershader with exactly the semantics of the engine's own USD
+/// importer (`preview_surface_openpbr` in crust-core) — authored values
+/// pass verbatim (no color-space decode), unset inputs keep OpenPBR
+/// defaults, emission luminance switches on when emissiveColor is nonzero,
+/// clearcoat maps to the coat lobe. Texture-connected inputs warn and use
+/// the default (surface textures are a later phase); non-UsdPreviewSurface
+/// terminals warn and shade mid-grey.
+class HdCrustMaterial final : public HdMaterial {
+public:
+    explicit HdCrustMaterial(SdfPath const& id);
+    ~HdCrustMaterial() override = default;
+
+    HdDirtyBits GetInitialDirtyBitsMask() const override {
+        return HdMaterial::AllDirty;
+    }
+
+    void Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
+              HdDirtyBits* dirtyBits) override;
+
+    void Finalize(HdRenderParam* renderParam) override;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDCRUST_MATERIAL_H

--- a/hydra/hdCrust/mesh.cpp
+++ b/hydra/hdCrust/mesh.cpp
@@ -4,6 +4,7 @@
 #include "renderParam.h"
 
 #include <pxr/base/gf/vec3f.h>
+#include <pxr/base/tf/hash.h>
 #include <pxr/imaging/hd/changeTracker.h>
 #include <pxr/imaging/hd/meshUtil.h>
 #include <pxr/imaging/hd/renderIndex.h>
@@ -23,6 +24,7 @@ HdDirtyBits HdCrustMesh::GetInitialDirtyBitsMask() const {
         | HdChangeTracker::DirtyPrimvar
         | HdChangeTracker::DirtyNormals
         | HdChangeTracker::DirtyInstancer
+        | HdChangeTracker::DirtyMaterialId
         | HdChangeTracker::DirtyPrimID;
 }
 
@@ -62,13 +64,28 @@ void HdCrustMesh::Sync(HdSceneDelegate* sceneDelegate,
         _UpdateVisibility(sceneDelegate, dirtyBits);
     }
     _UpdateInstancer(sceneDelegate, dirtyBits);
+    if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
+        SetMaterialId(sceneDelegate->GetMaterialId(id));
+    }
 
-    // Phase 1 rebuilds the whole crust scene on any change, so the cache
-    // entry is simply recomputed from scratch on every Sync — cheap next
-    // to the render, and immune to partial-dirty bookkeeping bugs.
+    // The GEOMETRY version moves only when the geometry itself did — that
+    // is what lets the render pass keep hitting the crust prototype cache
+    // across transform/material/color/instancing edits.
+    if (_geoVersion == 0 ||
+        (*dirtyBits & (HdChangeTracker::DirtyPoints |
+                       HdChangeTracker::DirtyTopology |
+                       HdChangeTracker::DirtyNormals))) {
+        ++_geoVersion;
+    }
+
+    // The cache entry itself is recomputed from scratch on every Sync —
+    // cheap next to the render, and immune to partial-dirty bookkeeping
+    // bugs; only the version above is stateful.
     HdCrustCachedMesh mesh;
     mesh.visible = IsVisible();
     mesh.primId = GetPrimId();
+    mesh.geoVersion = _geoVersion;
+    mesh.materialId = GetMaterialId();
     mesh.xform = sceneDelegate->GetTransform(id);
     mesh.displayColor = _GetDisplayColor(sceneDelegate, id);
 
@@ -102,6 +119,12 @@ void HdCrustMesh::Sync(HdSceneDelegate* sceneDelegate,
 
     SdfPath instancerId = GetInstancerId();
     if (!instancerId.IsEmpty()) {
+        // The render index does NOT sync instancers on its own — the rprim
+        // must pull its instancer chain up to date before reading it
+        // (hdEmbree does the same; the helper is mutex-guarded for
+        // concurrent rprim syncs).
+        HdInstancer::_SyncInstancerAndParents(sceneDelegate->GetRenderIndex(),
+                                              instancerId);
         HdInstancer* instancer =
             sceneDelegate->GetRenderIndex().GetInstancer(instancerId);
         if (TF_VERIFY(instancer)) {
@@ -116,7 +139,11 @@ void HdCrustMesh::Sync(HdSceneDelegate* sceneDelegate,
 }
 
 void HdCrustMesh::Finalize(HdRenderParam* renderParam) {
-    static_cast<HdCrustRenderParam*>(renderParam)->RemoveMesh(GetId());
+    auto* param = static_cast<HdCrustRenderParam*>(renderParam);
+    param->RemoveMesh(GetId());
+    // Let the render pass evict this mesh's prototype from the crust
+    // geometry cache — same key derivation as the rebuild uses.
+    param->AddDeadGeoKey(TfHash()(GetId()));
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/hydra/hdCrust/mesh.cpp
+++ b/hydra/hdCrust/mesh.cpp
@@ -1,0 +1,122 @@
+#include "mesh.h"
+
+#include "instancer.h"
+#include "renderParam.h"
+
+#include <pxr/base/gf/vec3f.h>
+#include <pxr/imaging/hd/changeTracker.h>
+#include <pxr/imaging/hd/meshUtil.h>
+#include <pxr/imaging/hd/renderIndex.h>
+#include <pxr/imaging/hd/sceneDelegate.h>
+#include <pxr/imaging/hd/tokens.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+HdCrustMesh::HdCrustMesh(SdfPath const& id) : HdMesh(id) {}
+
+HdDirtyBits HdCrustMesh::GetInitialDirtyBitsMask() const {
+    return HdChangeTracker::Clean
+        | HdChangeTracker::DirtyPoints
+        | HdChangeTracker::DirtyTopology
+        | HdChangeTracker::DirtyTransform
+        | HdChangeTracker::DirtyVisibility
+        | HdChangeTracker::DirtyPrimvar
+        | HdChangeTracker::DirtyNormals
+        | HdChangeTracker::DirtyInstancer
+        | HdChangeTracker::DirtyPrimID;
+}
+
+void HdCrustMesh::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBits) {
+    (void)reprToken;
+    (void)dirtyBits;
+}
+
+HdDirtyBits HdCrustMesh::_PropagateDirtyBits(HdDirtyBits bits) const {
+    return bits;
+}
+
+// The constant/uniform displayColor, or mid-grey — Phase 1 is
+// displayColor-only (HdMaterialNetwork translation is Phase 2).
+static GfVec3f _GetDisplayColor(HdSceneDelegate* sceneDelegate,
+                                SdfPath const& id) {
+    VtValue value = sceneDelegate->Get(id, HdTokens->displayColor);
+    if (value.IsHolding<VtVec3fArray>()) {
+        VtVec3fArray colors = value.UncheckedGet<VtVec3fArray>();
+        if (!colors.empty()) {
+            return colors[0];
+        }
+    } else if (value.IsHolding<GfVec3f>()) {
+        return value.UncheckedGet<GfVec3f>();
+    }
+    return GfVec3f(0.5f, 0.5f, 0.5f);
+}
+
+void HdCrustMesh::Sync(HdSceneDelegate* sceneDelegate,
+                       HdRenderParam* renderParam, HdDirtyBits* dirtyBits,
+                       TfToken const& reprToken) {
+    (void)reprToken;
+    SdfPath const& id = GetId();
+    auto* param = static_cast<HdCrustRenderParam*>(renderParam);
+
+    if (HdChangeTracker::IsVisibilityDirty(*dirtyBits, id)) {
+        _UpdateVisibility(sceneDelegate, dirtyBits);
+    }
+    _UpdateInstancer(sceneDelegate, dirtyBits);
+
+    // Phase 1 rebuilds the whole crust scene on any change, so the cache
+    // entry is simply recomputed from scratch on every Sync — cheap next
+    // to the render, and immune to partial-dirty bookkeeping bugs.
+    HdCrustCachedMesh mesh;
+    mesh.visible = IsVisible();
+    mesh.primId = GetPrimId();
+    mesh.xform = sceneDelegate->GetTransform(id);
+    mesh.displayColor = _GetDisplayColor(sceneDelegate, id);
+
+    VtValue pointsValue = sceneDelegate->Get(id, HdTokens->points);
+    if (pointsValue.IsHolding<VtVec3fArray>()) {
+        mesh.points = pointsValue.UncheckedGet<VtVec3fArray>();
+    }
+
+    // Hydra's own triangulator: handles arbitrary polygons and holes, and
+    // keeps triangle indices in terms of the original vertex order, so
+    // vertex-interpolated primvars (points, normals) stay aligned.
+    HdMeshTopology topology = GetMeshTopology(sceneDelegate);
+    HdMeshUtil meshUtil(&topology, id);
+    VtIntArray trianglePrimitiveParams;
+    meshUtil.ComputeTriangleIndices(&mesh.triangles, &trianglePrimitiveParams);
+
+    // Vertex-interpolated authored normals only; anything else falls back
+    // to the kernel's geometric normals.
+    for (HdPrimvarDescriptor const& pv :
+         sceneDelegate->GetPrimvarDescriptors(id, HdInterpolationVertex)) {
+        if (pv.name == HdTokens->normals) {
+            VtValue normalsValue = sceneDelegate->Get(id, HdTokens->normals);
+            if (normalsValue.IsHolding<VtVec3fArray>()) {
+                VtVec3fArray normals = normalsValue.UncheckedGet<VtVec3fArray>();
+                if (normals.size() == mesh.points.size()) {
+                    mesh.normals = normals;
+                }
+            }
+        }
+    }
+
+    SdfPath instancerId = GetInstancerId();
+    if (!instancerId.IsEmpty()) {
+        HdInstancer* instancer =
+            sceneDelegate->GetRenderIndex().GetInstancer(instancerId);
+        if (TF_VERIFY(instancer)) {
+            mesh.instanceXforms =
+                static_cast<HdCrustInstancer*>(instancer)
+                    ->ComputeInstanceTransforms(id);
+        }
+    }
+
+    param->UpdateMesh(id, std::move(mesh));
+    *dirtyBits = HdChangeTracker::Clean;
+}
+
+void HdCrustMesh::Finalize(HdRenderParam* renderParam) {
+    static_cast<HdCrustRenderParam*>(renderParam)->RemoveMesh(GetId());
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/hydra/hdCrust/mesh.h
+++ b/hydra/hdCrust/mesh.h
@@ -26,6 +26,13 @@ public:
 protected:
     void _InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBits) override;
     HdDirtyBits _PropagateDirtyBits(HdDirtyBits bits) const override;
+
+private:
+    /// The (path-hash, geoVersion) pair keys the crust geometry cache:
+    /// bumped only when a Sync saw geometry-changing dirty bits, so
+    /// transform/material/instancing edits keep hitting the committed
+    /// prototype.
+    uint32_t _geoVersion = 0;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/hydra/hdCrust/mesh.h
+++ b/hydra/hdCrust/mesh.h
@@ -1,0 +1,33 @@
+#ifndef HDCRUST_MESH_H
+#define HDCRUST_MESH_H
+
+#include <pxr/imaging/hd/mesh.h>
+#include <pxr/pxr.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// An HdMesh whose Sync does exactly one thing: write the prim's current
+/// state (triangulated topology, points, vertex normals, transform,
+/// displayColor, flattened instance transforms) into the render param's
+/// scene cache and bump the scene version. All rendering happens later,
+/// when the render pass rebuilds the crust scene from that cache.
+class HdCrustMesh final : public HdMesh {
+public:
+    explicit HdCrustMesh(SdfPath const& id);
+    ~HdCrustMesh() override = default;
+
+    HdDirtyBits GetInitialDirtyBitsMask() const override;
+
+    void Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
+              HdDirtyBits* dirtyBits, TfToken const& reprToken) override;
+
+    void Finalize(HdRenderParam* renderParam) override;
+
+protected:
+    void _InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBits) override;
+    HdDirtyBits _PropagateDirtyBits(HdDirtyBits bits) const override;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDCRUST_MESH_H

--- a/hydra/hdCrust/plugInfo.json
+++ b/hydra/hdCrust/plugInfo.json
@@ -1,0 +1,22 @@
+{
+    "Plugins": [
+        {
+            "Info": {
+                "Types": {
+                    "HdCrustRendererPlugin": {
+                        "bases": [
+                            "HdRendererPlugin"
+                        ],
+                        "displayName": "Crust",
+                        "priority": 99
+                    }
+                }
+            },
+            "LibraryPath": "libhdCrust.so",
+            "Name": "hdCrust",
+            "ResourcePath": "resources",
+            "Root": "..",
+            "Type": "library"
+        }
+    ]
+}

--- a/hydra/hdCrust/plugInfo.json.in
+++ b/hydra/hdCrust/plugInfo.json.in
@@ -12,7 +12,7 @@
                     }
                 }
             },
-            "LibraryPath": "libhdCrust.so",
+            "LibraryPath": "@HDCRUST_LIBRARY_FILE@",
             "Name": "hdCrust",
             "ResourcePath": "resources",
             "Root": "..",

--- a/hydra/hdCrust/renderBuffer.cpp
+++ b/hydra/hdCrust/renderBuffer.cpp
@@ -1,0 +1,38 @@
+#include "renderBuffer.h"
+
+#include <pxr/base/tf/diagnostic.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+HdCrustRenderBuffer::HdCrustRenderBuffer(SdfPath const& id)
+    : HdRenderBuffer(id) {}
+
+bool HdCrustRenderBuffer::Allocate(GfVec3i const& dimensions, HdFormat format,
+                                   bool multiSampled) {
+    _Deallocate();
+    if (dimensions[2] != 1) {
+        TF_WARN("hdCrust render buffers are 2D; depth %d ignored",
+                dimensions[2]);
+    }
+    // Crust resolves its own per-pixel film; Hydra-side multisampling is
+    // declined rather than emulated.
+    (void)multiSampled;
+    _width = static_cast<unsigned int>(dimensions[0]);
+    _height = static_cast<unsigned int>(dimensions[1]);
+    _format = format;
+    size_t pixelSize = HdDataSizeOfFormat(format);
+    _storage.assign(
+        static_cast<size_t>(_width) * static_cast<size_t>(_height) * pixelSize,
+        0);
+    return true;
+}
+
+void HdCrustRenderBuffer::_Deallocate() {
+    _width = 0;
+    _height = 0;
+    _format = HdFormatInvalid;
+    _storage.clear();
+    _converged.store(false);
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/hydra/hdCrust/renderBuffer.cpp
+++ b/hydra/hdCrust/renderBuffer.cpp
@@ -2,6 +2,8 @@
 
 #include <pxr/base/tf/diagnostic.h>
 
+#include <cstdint>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 HdCrustRenderBuffer::HdCrustRenderBuffer(SdfPath const& id)
@@ -10,20 +12,38 @@ HdCrustRenderBuffer::HdCrustRenderBuffer(SdfPath const& id)
 bool HdCrustRenderBuffer::Allocate(GfVec3i const& dimensions, HdFormat format,
                                    bool multiSampled) {
     _Deallocate();
+    // Crust resolves its own per-pixel film; Hydra-side multisampling is
+    // declined rather than emulated.
+    (void)multiSampled;
+
+    // Reject rather than wrap: a negative dimension cast to unsigned turns
+    // into a huge value, and an under-allocation from a later overflow
+    // would become an out-of-bounds write in the render pass.
+    if (dimensions[0] <= 0 || dimensions[1] <= 0) {
+        TF_WARN("hdCrust: invalid render buffer dimensions %d x %d",
+                dimensions[0], dimensions[1]);
+        return false;
+    }
     if (dimensions[2] != 1) {
         TF_WARN("hdCrust render buffers are 2D; depth %d ignored",
                 dimensions[2]);
     }
-    // Crust resolves its own per-pixel film; Hydra-side multisampling is
-    // declined rather than emulated.
-    (void)multiSampled;
-    _width = static_cast<unsigned int>(dimensions[0]);
-    _height = static_cast<unsigned int>(dimensions[1]);
+    const size_t pixelSize = HdDataSizeOfFormat(format);
+    if (pixelSize == 0) {
+        TF_WARN("hdCrust: unsupported render buffer format %d", int(format));
+        return false;
+    }
+    const size_t w = static_cast<size_t>(dimensions[0]);
+    const size_t h = static_cast<size_t>(dimensions[1]);
+    if (w > SIZE_MAX / h || w * h > SIZE_MAX / pixelSize) {
+        TF_WARN("hdCrust: render buffer size %zu x %zu x %zu overflows",
+                w, h, pixelSize);
+        return false;
+    }
+    _width = static_cast<unsigned int>(w);
+    _height = static_cast<unsigned int>(h);
     _format = format;
-    size_t pixelSize = HdDataSizeOfFormat(format);
-    _storage.assign(
-        static_cast<size_t>(_width) * static_cast<size_t>(_height) * pixelSize,
-        0);
+    _storage.assign(w * h * pixelSize, 0);
     return true;
 }
 

--- a/hydra/hdCrust/renderBuffer.h
+++ b/hydra/hdCrust/renderBuffer.h
@@ -1,0 +1,64 @@
+#ifndef HDCRUST_RENDER_BUFFER_H
+#define HDCRUST_RENDER_BUFFER_H
+
+#include <pxr/base/gf/vec3i.h>
+#include <pxr/imaging/hd/renderBuffer.h>
+#include <pxr/pxr.h>
+
+#include <atomic>
+#include <vector>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// A CPU render buffer: owned storage, refcounted Map/Unmap, no
+/// multisampling (crust resolves its own film; Resolve is a no-op).
+/// Rows follow the Hydra/GL convention — row 0 is the bottom scanline —
+/// which is also exactly what the crust C API produces, so the render pass
+/// copies rows straight through.
+class HdCrustRenderBuffer final : public HdRenderBuffer {
+public:
+    explicit HdCrustRenderBuffer(SdfPath const& id);
+    ~HdCrustRenderBuffer() override = default;
+
+    bool Allocate(GfVec3i const& dimensions, HdFormat format,
+                  bool multiSampled) override;
+
+    unsigned int GetWidth() const override { return _width; }
+    unsigned int GetHeight() const override { return _height; }
+    unsigned int GetDepth() const override { return 1; }
+    HdFormat GetFormat() const override { return _format; }
+    bool IsMultiSampled() const override { return false; }
+
+    void* Map() override {
+        _mappers.fetch_add(1);
+        return _storage.data();
+    }
+    void Unmap() override { _mappers.fetch_sub(1); }
+    bool IsMapped() const override { return _mappers.load() != 0; }
+
+    /// The render pass writes the film directly; there is nothing to
+    /// resolve.
+    void Resolve() override {}
+
+    bool IsConverged() const override { return _converged.load(); }
+    void SetConverged(bool converged) { _converged.store(converged); }
+
+    /// Direct storage access for the render pass (the producer side of
+    /// Map, without the refcount ceremony).
+    uint8_t* GetStorage() { return _storage.data(); }
+    size_t GetStorageSize() const { return _storage.size(); }
+
+private:
+    void _Deallocate() override;
+
+    unsigned int _width = 0;
+    unsigned int _height = 0;
+    HdFormat _format = HdFormatInvalid;
+    std::vector<uint8_t> _storage;
+    std::atomic<int> _mappers{0};
+    std::atomic<bool> _converged{false};
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDCRUST_RENDER_BUFFER_H

--- a/hydra/hdCrust/renderDelegate.cpp
+++ b/hydra/hdCrust/renderDelegate.cpp
@@ -1,0 +1,168 @@
+#include "renderDelegate.h"
+
+#include "instancer.h"
+#include "light.h"
+#include "mesh.h"
+#include "renderBuffer.h"
+#include "renderPass.h"
+
+#include <pxr/base/tf/diagnostic.h>
+#include <pxr/imaging/hd/camera.h>
+#include <pxr/imaging/hd/material.h>
+#include <pxr/imaging/hd/resourceRegistry.h>
+#include <pxr/imaging/hd/tokens.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+const TfTokenVector HdCrustRenderDelegate::SUPPORTED_RPRIM_TYPES = {
+    HdPrimTypeTokens->mesh,
+};
+
+const TfTokenVector HdCrustRenderDelegate::SUPPORTED_SPRIM_TYPES = {
+    HdPrimTypeTokens->camera,       HdPrimTypeTokens->material,
+    HdPrimTypeTokens->sphereLight,  HdPrimTypeTokens->rectLight,
+    HdPrimTypeTokens->distantLight, HdPrimTypeTokens->domeLight,
+};
+
+const TfTokenVector HdCrustRenderDelegate::SUPPORTED_BPRIM_TYPES = {
+    HdPrimTypeTokens->renderBuffer,
+};
+
+/// Accepted and ignored: Phase 1 shades from displayColor, and the stub
+/// keeps material-heavy stages (every production asset binds materials
+/// everywhere) from spraying unsupported-prim errors.
+class HdCrustMaterial final : public HdMaterial {
+public:
+    explicit HdCrustMaterial(SdfPath const& id) : HdMaterial(id) {}
+    HdDirtyBits GetInitialDirtyBitsMask() const override {
+        return HdMaterial::AllDirty;
+    }
+    void Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
+              HdDirtyBits* dirtyBits) override {
+        (void)sceneDelegate;
+        (void)renderParam;
+        *dirtyBits = HdMaterial::Clean;
+    }
+};
+
+HdCrustRenderDelegate::HdCrustRenderDelegate() : HdRenderDelegate() {
+    _Initialize();
+}
+
+HdCrustRenderDelegate::HdCrustRenderDelegate(
+    HdRenderSettingsMap const& settingsMap)
+    : HdRenderDelegate(settingsMap) {
+    _Initialize();
+}
+
+void HdCrustRenderDelegate::_Initialize() {
+    _renderParam = std::make_unique<HdCrustRenderParam>();
+    _resourceRegistry = std::make_shared<HdResourceRegistry>();
+}
+
+HdCrustRenderDelegate::~HdCrustRenderDelegate() = default;
+
+const TfTokenVector& HdCrustRenderDelegate::GetSupportedRprimTypes() const {
+    return SUPPORTED_RPRIM_TYPES;
+}
+const TfTokenVector& HdCrustRenderDelegate::GetSupportedSprimTypes() const {
+    return SUPPORTED_SPRIM_TYPES;
+}
+const TfTokenVector& HdCrustRenderDelegate::GetSupportedBprimTypes() const {
+    return SUPPORTED_BPRIM_TYPES;
+}
+
+HdRenderParam* HdCrustRenderDelegate::GetRenderParam() const {
+    return _renderParam.get();
+}
+
+HdResourceRegistrySharedPtr HdCrustRenderDelegate::GetResourceRegistry() const {
+    return _resourceRegistry;
+}
+
+HdRenderPassSharedPtr HdCrustRenderDelegate::CreateRenderPass(
+    HdRenderIndex* index, HdRprimCollection const& collection) {
+    return HdRenderPassSharedPtr(
+        new HdCrustRenderPass(index, collection, _renderParam.get()));
+}
+
+HdInstancer* HdCrustRenderDelegate::CreateInstancer(HdSceneDelegate* delegate,
+                                                    SdfPath const& id) {
+    return new HdCrustInstancer(delegate, id);
+}
+
+void HdCrustRenderDelegate::DestroyInstancer(HdInstancer* instancer) {
+    delete instancer;
+}
+
+HdRprim* HdCrustRenderDelegate::CreateRprim(TfToken const& typeId,
+                                            SdfPath const& rprimId) {
+    if (typeId == HdPrimTypeTokens->mesh) {
+        return new HdCrustMesh(rprimId);
+    }
+    TF_CODING_ERROR("Unknown rprim type %s", typeId.GetText());
+    return nullptr;
+}
+
+void HdCrustRenderDelegate::DestroyRprim(HdRprim* rprim) { delete rprim; }
+
+HdSprim* HdCrustRenderDelegate::CreateSprim(TfToken const& typeId,
+                                            SdfPath const& sprimId) {
+    if (typeId == HdPrimTypeTokens->camera) {
+        return new HdCamera(sprimId);
+    }
+    if (typeId == HdPrimTypeTokens->material) {
+        return new HdCrustMaterial(sprimId);
+    }
+    if (typeId == HdPrimTypeTokens->sphereLight ||
+        typeId == HdPrimTypeTokens->rectLight ||
+        typeId == HdPrimTypeTokens->distantLight ||
+        typeId == HdPrimTypeTokens->domeLight) {
+        return new HdCrustLight(sprimId, typeId);
+    }
+    TF_CODING_ERROR("Unknown sprim type %s", typeId.GetText());
+    return nullptr;
+}
+
+HdSprim* HdCrustRenderDelegate::CreateFallbackSprim(TfToken const& typeId) {
+    return CreateSprim(typeId, SdfPath::EmptyPath());
+}
+
+void HdCrustRenderDelegate::DestroySprim(HdSprim* sprim) { delete sprim; }
+
+HdBprim* HdCrustRenderDelegate::CreateBprim(TfToken const& typeId,
+                                            SdfPath const& bprimId) {
+    if (typeId == HdPrimTypeTokens->renderBuffer) {
+        return new HdCrustRenderBuffer(bprimId);
+    }
+    TF_CODING_ERROR("Unknown bprim type %s", typeId.GetText());
+    return nullptr;
+}
+
+HdBprim* HdCrustRenderDelegate::CreateFallbackBprim(TfToken const& typeId) {
+    return CreateBprim(typeId, SdfPath::EmptyPath());
+}
+
+void HdCrustRenderDelegate::DestroyBprim(HdBprim* bprim) { delete bprim; }
+
+void HdCrustRenderDelegate::CommitResources(HdChangeTracker* tracker) {
+    (void)tracker;
+}
+
+HdAovDescriptor HdCrustRenderDelegate::GetDefaultAovDescriptor(
+    TfToken const& name) const {
+    if (name == HdAovTokens->color) {
+        return HdAovDescriptor(HdFormatFloat32Vec4, false,
+                               VtValue(GfVec4f(0.0f)));
+    }
+    if (name == HdAovTokens->depth) {
+        return HdAovDescriptor(HdFormatFloat32, false, VtValue(1.0f));
+    }
+    if (name == HdAovTokens->primId || name == HdAovTokens->instanceId ||
+        name == HdAovTokens->elementId) {
+        return HdAovDescriptor(HdFormatInt32, false, VtValue(-1));
+    }
+    return HdAovDescriptor();
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/hydra/hdCrust/renderDelegate.cpp
+++ b/hydra/hdCrust/renderDelegate.cpp
@@ -2,13 +2,13 @@
 
 #include "instancer.h"
 #include "light.h"
+#include "material.h"
 #include "mesh.h"
 #include "renderBuffer.h"
 #include "renderPass.h"
 
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/imaging/hd/camera.h>
-#include <pxr/imaging/hd/material.h>
 #include <pxr/imaging/hd/resourceRegistry.h>
 #include <pxr/imaging/hd/tokens.h>
 
@@ -26,23 +26,6 @@ const TfTokenVector HdCrustRenderDelegate::SUPPORTED_SPRIM_TYPES = {
 
 const TfTokenVector HdCrustRenderDelegate::SUPPORTED_BPRIM_TYPES = {
     HdPrimTypeTokens->renderBuffer,
-};
-
-/// Accepted and ignored: Phase 1 shades from displayColor, and the stub
-/// keeps material-heavy stages (every production asset binds materials
-/// everywhere) from spraying unsupported-prim errors.
-class HdCrustMaterial final : public HdMaterial {
-public:
-    explicit HdCrustMaterial(SdfPath const& id) : HdMaterial(id) {}
-    HdDirtyBits GetInitialDirtyBitsMask() const override {
-        return HdMaterial::AllDirty;
-    }
-    void Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam,
-              HdDirtyBits* dirtyBits) override {
-        (void)sceneDelegate;
-        (void)renderParam;
-        *dirtyBits = HdMaterial::Clean;
-    }
 };
 
 HdCrustRenderDelegate::HdCrustRenderDelegate() : HdRenderDelegate() {

--- a/hydra/hdCrust/renderDelegate.h
+++ b/hydra/hdCrust/renderDelegate.h
@@ -1,0 +1,68 @@
+#ifndef HDCRUST_RENDER_DELEGATE_H
+#define HDCRUST_RENDER_DELEGATE_H
+
+#include "renderParam.h"
+
+#include <pxr/imaging/hd/renderDelegate.h>
+#include <pxr/pxr.h>
+
+#include <memory>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// The hdCrust render delegate: meshes, the four UsdLux light types crust
+/// supports, cameras, render buffers, and a no-op material stub (Phase 1
+/// shades from displayColor; HdMaterialNetwork translation is Phase 2 —
+/// see docs/hydra_delegate.md in the crust-render repository).
+class HdCrustRenderDelegate final : public HdRenderDelegate {
+public:
+    HdCrustRenderDelegate();
+    explicit HdCrustRenderDelegate(HdRenderSettingsMap const& settingsMap);
+    ~HdCrustRenderDelegate() override;
+
+    HdCrustRenderDelegate(const HdCrustRenderDelegate&) = delete;
+    HdCrustRenderDelegate& operator=(const HdCrustRenderDelegate&) = delete;
+
+    const TfTokenVector& GetSupportedRprimTypes() const override;
+    const TfTokenVector& GetSupportedSprimTypes() const override;
+    const TfTokenVector& GetSupportedBprimTypes() const override;
+
+    HdRenderParam* GetRenderParam() const override;
+    HdResourceRegistrySharedPtr GetResourceRegistry() const override;
+
+    HdRenderPassSharedPtr CreateRenderPass(
+        HdRenderIndex* index, HdRprimCollection const& collection) override;
+
+    HdInstancer* CreateInstancer(HdSceneDelegate* delegate,
+                                 SdfPath const& id) override;
+    void DestroyInstancer(HdInstancer* instancer) override;
+
+    HdRprim* CreateRprim(TfToken const& typeId, SdfPath const& rprimId) override;
+    void DestroyRprim(HdRprim* rprim) override;
+
+    HdSprim* CreateSprim(TfToken const& typeId, SdfPath const& sprimId) override;
+    HdSprim* CreateFallbackSprim(TfToken const& typeId) override;
+    void DestroySprim(HdSprim* sprim) override;
+
+    HdBprim* CreateBprim(TfToken const& typeId, SdfPath const& bprimId) override;
+    HdBprim* CreateFallbackBprim(TfToken const& typeId) override;
+    void DestroyBprim(HdBprim* bprim) override;
+
+    void CommitResources(HdChangeTracker* tracker) override;
+
+    HdAovDescriptor GetDefaultAovDescriptor(TfToken const& name) const override;
+
+private:
+    void _Initialize();
+
+    static const TfTokenVector SUPPORTED_RPRIM_TYPES;
+    static const TfTokenVector SUPPORTED_SPRIM_TYPES;
+    static const TfTokenVector SUPPORTED_BPRIM_TYPES;
+
+    std::unique_ptr<HdCrustRenderParam> _renderParam;
+    HdResourceRegistrySharedPtr _resourceRegistry;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDCRUST_RENDER_DELEGATE_H

--- a/hydra/hdCrust/renderParam.h
+++ b/hydra/hdCrust/renderParam.h
@@ -1,0 +1,100 @@
+#ifndef HDCRUST_RENDER_PARAM_H
+#define HDCRUST_RENDER_PARAM_H
+
+#include <pxr/base/gf/matrix4d.h>
+#include <pxr/base/gf/vec3f.h>
+#include <pxr/base/tf/token.h>
+#include <pxr/base/vt/array.h>
+#include <pxr/imaging/hd/renderDelegate.h>
+#include <pxr/pxr.h>
+#include <pxr/usd/sdf/path.h>
+
+#include <map>
+#include <mutex>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// One synced mesh, in object space. The render pass bakes `xform` (and
+/// each instance transform) into world-space vertices when it feeds the
+/// crust scene — the Phase 1 C API has no instance object yet, so
+/// instancing is flattened here (the documented Phase 2 seam).
+struct HdCrustCachedMesh {
+    VtVec3fArray points;
+    VtVec3iArray triangles;      // from HdMeshUtil, indexing `points`
+    VtVec3fArray normals;        // vertex-interpolated, or empty
+    GfMatrix4d xform{1.0};
+    VtMatrix4dArray instanceXforms; // empty = one placement at `xform`
+    GfVec3f displayColor{0.5f, 0.5f, 0.5f};
+    int primId = 0;              // Hydra's rprim id, for the primId AOV
+    bool visible = true;
+};
+
+/// One synced light, parameters as UsdLux authors them; the render pass
+/// converts to crust's radiance/irradiance conventions per type.
+struct HdCrustCachedLight {
+    TfToken type;                // HdPrimTypeTokens->{sphere,rect,distant,dome}Light
+    GfMatrix4d xform{1.0};
+    GfVec3f color{1.0f, 1.0f, 1.0f};
+    float intensity = 1.0f;
+    float exposure = 0.0f;
+    float radius = 0.5f;         // sphereLight
+    float width = 1.0f;          // rectLight
+    float height = 1.0f;         // rectLight
+    float angle = 0.53f;         // distantLight (angular diameter, degrees)
+};
+
+/// The rebuild spine: prims write their cached state here during Sync and
+/// bump the scene version; the render pass compares versions and rebuilds
+/// the crust scene from a snapshot when anything changed —
+/// rebuild-everything-on-any-dirty-bit, exactly the Phase 1 contract of
+/// docs/hydra_delegate.md.
+class HdCrustRenderParam final : public HdRenderParam {
+public:
+    void UpdateMesh(SdfPath const& id, HdCrustCachedMesh mesh) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _meshes[id] = std::move(mesh);
+        ++_version;
+    }
+    void RemoveMesh(SdfPath const& id) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        if (_meshes.erase(id) > 0) {
+            ++_version;
+        }
+    }
+    void UpdateLight(SdfPath const& id, HdCrustCachedLight light) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _lights[id] = std::move(light);
+        ++_version;
+    }
+    void RemoveLight(SdfPath const& id) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        if (_lights.erase(id) > 0) {
+            ++_version;
+        }
+    }
+
+    int GetVersion() const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _version;
+    }
+
+    /// A consistent copy for the render pass to build from, with the
+    /// version it corresponds to.
+    int Snapshot(std::map<SdfPath, HdCrustCachedMesh>* meshes,
+                 std::map<SdfPath, HdCrustCachedLight>* lights) const {
+        std::lock_guard<std::mutex> lock(_mutex);
+        *meshes = _meshes;
+        *lights = _lights;
+        return _version;
+    }
+
+private:
+    mutable std::mutex _mutex;
+    std::map<SdfPath, HdCrustCachedMesh> _meshes;
+    std::map<SdfPath, HdCrustCachedLight> _lights;
+    int _version = 1;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDCRUST_RENDER_PARAM_H

--- a/hydra/hdCrust/renderParam.h
+++ b/hydra/hdCrust/renderParam.h
@@ -9,15 +9,20 @@
 #include <pxr/pxr.h>
 #include <pxr/usd/sdf/path.h>
 
+#include <crust.h>
+
 #include <map>
 #include <mutex>
+#include <string>
+#include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-/// One synced mesh, in object space. The render pass bakes `xform` (and
-/// each instance transform) into world-space vertices when it feeds the
-/// crust scene — the Phase 1 C API has no instance object yet, so
-/// instancing is flattened here (the documented Phase 2 seam).
+/// One synced mesh, in object space. The render pass hands the arrays to
+/// the crust geometry cache keyed by (path hash, `geoVersion`) and places
+/// them as kernel instances — `geoVersion` only moves when the geometry
+/// itself (points/topology/normals) changes, so transform, color, material
+/// and instancing edits reuse the committed triangles.
 struct HdCrustCachedMesh {
     VtVec3fArray points;
     VtVec3iArray triangles;      // from HdMeshUtil, indexing `points`
@@ -25,6 +30,8 @@ struct HdCrustCachedMesh {
     GfMatrix4d xform{1.0};
     VtMatrix4dArray instanceXforms; // empty = one placement at `xform`
     GfVec3f displayColor{0.5f, 0.5f, 0.5f};
+    SdfPath materialId;          // bound material sprim, or empty
+    uint32_t geoVersion = 0;     // bumped on geometry-changing dirty bits
     int primId = 0;              // Hydra's rprim id, for the primId AOV
     bool visible = true;
 };
@@ -41,6 +48,7 @@ struct HdCrustCachedLight {
     float width = 1.0f;          // rectLight
     float height = 1.0f;         // rectLight
     float angle = 0.53f;         // distantLight (angular diameter, degrees)
+    std::string texturePath;     // domeLight equirect file, or empty
 };
 
 /// The rebuild spine: prims write their cached state here during Sync and
@@ -72,6 +80,28 @@ public:
             ++_version;
         }
     }
+    void UpdateMaterial(SdfPath const& id, CrustMaterial material) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _materials[id] = material;
+        ++_version;
+    }
+    void RemoveMaterial(SdfPath const& id) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        if (_materials.erase(id) > 0) {
+            ++_version;
+        }
+    }
+
+    /// Records a deleted mesh's cache key so the render pass can evict its
+    /// prototype from the crust geometry cache at the next rebuild.
+    void AddDeadGeoKey(uint64_t key) {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _deadGeoKeys.push_back(key);
+    }
+    std::vector<uint64_t> TakeDeadGeoKeys() {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return std::move(_deadGeoKeys);
+    }
 
     int GetVersion() const {
         std::lock_guard<std::mutex> lock(_mutex);
@@ -81,10 +111,12 @@ public:
     /// A consistent copy for the render pass to build from, with the
     /// version it corresponds to.
     int Snapshot(std::map<SdfPath, HdCrustCachedMesh>* meshes,
-                 std::map<SdfPath, HdCrustCachedLight>* lights) const {
+                 std::map<SdfPath, HdCrustCachedLight>* lights,
+                 std::map<SdfPath, CrustMaterial>* materials) const {
         std::lock_guard<std::mutex> lock(_mutex);
         *meshes = _meshes;
         *lights = _lights;
+        *materials = _materials;
         return _version;
     }
 
@@ -92,6 +124,8 @@ private:
     mutable std::mutex _mutex;
     std::map<SdfPath, HdCrustCachedMesh> _meshes;
     std::map<SdfPath, HdCrustCachedLight> _lights;
+    std::map<SdfPath, CrustMaterial> _materials;
+    std::vector<uint64_t> _deadGeoKeys;
     int _version = 1;
 };
 

--- a/hydra/hdCrust/renderPass.cpp
+++ b/hydra/hdCrust/renderPass.cpp
@@ -1,0 +1,343 @@
+#include "renderPass.h"
+
+#include "renderBuffer.h"
+
+#include <pxr/base/gf/half.h>
+#include <pxr/base/gf/vec3d.h>
+#include <pxr/base/gf/vec3f.h>
+#include <pxr/base/tf/diagnostic.h>
+#include <pxr/base/tf/envSetting.h>
+#include <pxr/imaging/hd/renderPassState.h>
+#include <pxr/imaging/hd/tokens.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_ENV_SETTING(HDCRUST_SAMPLES_PER_PIXEL, 64,
+                      "Total path-tracing sample budget per pixel");
+TF_DEFINE_ENV_SETTING(HDCRUST_SAMPLES_PER_STEP, 4,
+                      "Samples per pixel added per Hydra Execute call");
+TF_DEFINE_ENV_SETTING(HDCRUST_MAX_DEPTH, 8, "Path length bound");
+
+HdCrustRenderPass::HdCrustRenderPass(HdRenderIndex* index,
+                                     HdRprimCollection const& collection,
+                                     HdCrustRenderParam* renderParam)
+    : HdRenderPass(index, collection), _renderParam(renderParam) {}
+
+HdCrustRenderPass::~HdCrustRenderPass() { _DestroyRenderer(); }
+
+void HdCrustRenderPass::_DestroyRenderer() {
+    if (_token) {
+        // Wound-down first so a hypothetical in-flight step ends promptly;
+        // in this synchronous design nothing is in flight, but the order
+        // costs nothing and survives a future HdRenderThread wrapper.
+        crust_stop_token_stop(_token);
+    }
+    if (_renderer) {
+        crust_renderer_destroy(_renderer);
+        _renderer = nullptr;
+    }
+    if (_token) {
+        crust_stop_token_destroy(_token);
+        _token = nullptr;
+    }
+}
+
+// UsdLux normalizes light energy as color * intensity * 2^exposure.
+static GfVec3f _LightEnergy(HdCrustCachedLight const& light) {
+    float scale = light.intensity * std::pow(2.0f, light.exposure);
+    return light.color * scale;
+}
+
+static void _AddLight(CrustScene* scene, HdCrustCachedLight const& light) {
+    GfVec3f energy = _LightEnergy(light);
+    float const* energyPtr = energy.data();
+
+    if (light.type == HdPrimTypeTokens->sphereLight) {
+        GfVec3d p = light.xform.ExtractTranslation();
+        float center[3] = {float(p[0]), float(p[1]), float(p[2])};
+        // A uniformly scaled light scales its radius; take the mean axis
+        // length for the (rare) non-uniform case.
+        GfVec3d rows[3] = {GfVec3d(light.xform.GetRow3(0)),
+                           GfVec3d(light.xform.GetRow3(1)),
+                           GfVec3d(light.xform.GetRow3(2))};
+        double scale =
+            (rows[0].GetLength() + rows[1].GetLength() + rows[2].GetLength()) /
+            3.0;
+        float radius = std::max(1e-4f, float(light.radius * scale));
+        crust_scene_add_sphere_light(scene, center, radius, energyPtr);
+    } else if (light.type == HdPrimTypeTokens->rectLight) {
+        // UsdLux rect: local XY plane, emitting along local -Z. crust's
+        // rect light emits along edge_u x edge_v, so span the quad with
+        // +X and -Y edges: X x -Y = -Z.
+        GfVec3d origin =
+            light.xform.Transform(GfVec3d(-light.width / 2.0, light.height / 2.0, 0.0));
+        GfVec3d edgeU = light.xform.TransformDir(GfVec3d(light.width, 0.0, 0.0));
+        GfVec3d edgeV = light.xform.TransformDir(GfVec3d(0.0, -light.height, 0.0));
+        float o[3] = {float(origin[0]), float(origin[1]), float(origin[2])};
+        float u[3] = {float(edgeU[0]), float(edgeU[1]), float(edgeU[2])};
+        float v[3] = {float(edgeV[0]), float(edgeV[1]), float(edgeV[2])};
+        crust_scene_add_rect_light(scene, o, u, v, energyPtr);
+    } else if (light.type == HdPrimTypeTokens->distantLight) {
+        // Points down its local -Z; energy is irradiance (the engine's
+        // distant-light convention matches UsdLux's normalized one).
+        GfVec3d dir = light.xform.TransformDir(GfVec3d(0.0, 0.0, -1.0));
+        float d[3] = {float(dir[0]), float(dir[1]), float(dir[2])};
+        crust_scene_add_distant_light(scene, d, energyPtr, light.angle);
+    } else if (light.type == HdPrimTypeTokens->domeLight) {
+        // Only the rotation of a dome's frame matters (it sits at
+        // infinity). Row-major row-vector 3x3 laid out row-after-row is
+        // exactly the column-major column-vector array crust expects —
+        // the same transpose-cancellation as the 4x4 camera matrices.
+        float rotation[9];
+        for (int row = 0; row < 3; ++row) {
+            for (int col = 0; col < 3; ++col) {
+                rotation[row * 3 + col] = float(light.xform[row][col]);
+            }
+        }
+        crust_scene_add_dome_light(scene, energyPtr, 0, 0, nullptr, rotation);
+    }
+}
+
+void HdCrustRenderPass::_RebuildScene(GfMatrix4d const& view,
+                                      GfMatrix4d const& proj, uint32_t width,
+                                      uint32_t height) {
+    _DestroyRenderer();
+    _converged = false;
+    _geomToPrimId.clear();
+
+    std::map<SdfPath, HdCrustCachedMesh> meshes;
+    std::map<SdfPath, HdCrustCachedLight> lights;
+    _lastVersion = _renderParam->Snapshot(&meshes, &lights);
+    _lastView = view;
+    _lastProj = proj;
+    _width = width;
+    _height = height;
+
+    CrustScene* scene = crust_scene_create();
+
+    for (auto const& entry : meshes) {
+        HdCrustCachedMesh const& mesh = entry.second;
+        if (!mesh.visible || mesh.points.empty() || mesh.triangles.empty()) {
+            continue;
+        }
+        CrustMaterial material;
+        crust_material_default(&material);
+        material.base_color[0] = mesh.displayColor[0];
+        material.base_color[1] = mesh.displayColor[1];
+        material.base_color[2] = mesh.displayColor[2];
+
+        // One capi mesh per placement, world-space baked — the Phase 1 C
+        // API has no instance object (the documented Phase 2 seam), so
+        // instancing is flattened here.
+        VtMatrix4dArray const singlePlacement(1, mesh.xform);
+        VtMatrix4dArray const& placements =
+            mesh.instanceXforms.empty() ? singlePlacement : mesh.instanceXforms;
+
+        std::vector<float> positions(mesh.points.size() * 3);
+        std::vector<float> normals;
+        std::vector<uint32_t> indices(mesh.triangles.size() * 3);
+        for (size_t t = 0; t < mesh.triangles.size(); ++t) {
+            indices[3 * t] = uint32_t(mesh.triangles[t][0]);
+            indices[3 * t + 1] = uint32_t(mesh.triangles[t][1]);
+            indices[3 * t + 2] = uint32_t(mesh.triangles[t][2]);
+        }
+
+        for (GfMatrix4d const& placement : placements) {
+            GfMatrix4d xform = mesh.instanceXforms.empty()
+                                   ? placement
+                                   : mesh.xform * placement;
+            for (size_t i = 0; i < mesh.points.size(); ++i) {
+                GfVec3d p = xform.Transform(GfVec3d(mesh.points[i]));
+                positions[3 * i] = float(p[0]);
+                positions[3 * i + 1] = float(p[1]);
+                positions[3 * i + 2] = float(p[2]);
+            }
+            const float* normalsPtr = nullptr;
+            if (!mesh.normals.empty()) {
+                // Normals map through the inverse transpose (mirrors and
+                // non-uniform scales included).
+                GfMatrix4d normalXf = xform.GetInverse().GetTranspose();
+                normals.resize(mesh.normals.size() * 3);
+                for (size_t i = 0; i < mesh.normals.size(); ++i) {
+                    GfVec3d n = normalXf.TransformDir(GfVec3d(mesh.normals[i]));
+                    n.Normalize();
+                    normals[3 * i] = float(n[0]);
+                    normals[3 * i + 1] = float(n[1]);
+                    normals[3 * i + 2] = float(n[2]);
+                }
+                normalsPtr = normals.data();
+            }
+            uint32_t geomId = 0;
+            CrustStatus status = crust_scene_add_mesh(
+                scene, positions.data(), mesh.points.size(), indices.data(),
+                mesh.triangles.size(), normalsPtr, &material, &geomId);
+            if (status != CRUST_OK) {
+                TF_WARN("hdCrust: add_mesh(%s) failed: %s",
+                        entry.first.GetText(), crust_status_string(status));
+                continue;
+            }
+            if (_geomToPrimId.size() <= geomId) {
+                _geomToPrimId.resize(geomId + 1, -1);
+            }
+            _geomToPrimId[geomId] = mesh.primId;
+        }
+    }
+
+    for (auto const& entry : lights) {
+        _AddLight(scene, entry.second);
+    }
+
+    CrustStatus status = crust_scene_set_camera(
+        scene, view.GetArray(), proj.GetArray(), 0.0f, 1.0f);
+    if (status != CRUST_OK) {
+        TF_WARN("hdCrust: set_camera failed: %s", crust_status_string(status));
+    }
+
+    CrustRenderSettings settings;
+    crust_render_settings_default(&settings);
+    settings.width = width;
+    settings.height = height;
+    settings.samples_per_pixel =
+        uint32_t(std::max(1, TfGetEnvSetting(HDCRUST_SAMPLES_PER_PIXEL)));
+    settings.max_depth = uint32_t(std::max(1, TfGetEnvSetting(HDCRUST_MAX_DEPTH)));
+    crust_scene_set_render_settings(scene, &settings);
+
+    _token = crust_stop_token_create();
+    status = crust_scene_commit(scene, _token, &_renderer);
+    crust_scene_destroy(scene);
+    if (status != CRUST_OK) {
+        TF_WARN("hdCrust: commit failed: %s", crust_status_string(status));
+        _DestroyRenderer();
+    }
+}
+
+// Camera-forward distance -> the [0,1] depth Hydra expects, through the
+// projection (row-vector convention: clip = v * P).
+static float _NdcDepth(GfMatrix4d const& proj, float distance) {
+    if (!std::isfinite(distance)) {
+        return 1.0f;
+    }
+    double zCam = -double(distance);
+    double zClip = proj[2][2] * zCam + proj[3][2];
+    double wClip = proj[2][3] * zCam + proj[3][3];
+    if (wClip == 0.0) {
+        return 1.0f;
+    }
+    double ndc = zClip / wClip;
+    return float(GfClamp(ndc * 0.5 + 0.5, 0.0, 1.0));
+}
+
+void HdCrustRenderPass::_Execute(
+    HdRenderPassStateSharedPtr const& renderPassState,
+    TfTokenVector const& renderTags) {
+    (void)renderTags;
+
+    HdRenderPassAovBindingVector const& aovBindings =
+        renderPassState->GetAovBindings();
+    if (aovBindings.empty()) {
+        static bool warned = false;
+        if (!warned) {
+            TF_WARN("hdCrust: no AOV bindings; nothing to render into");
+            warned = true;
+        }
+        return;
+    }
+
+    uint32_t width = 0;
+    uint32_t height = 0;
+    for (HdRenderPassAovBinding const& binding : aovBindings) {
+        if (binding.renderBuffer) {
+            width = binding.renderBuffer->GetWidth();
+            height = binding.renderBuffer->GetHeight();
+            break;
+        }
+    }
+    if (width == 0 || height == 0) {
+        return;
+    }
+
+    GfMatrix4d view = renderPassState->GetWorldToViewMatrix();
+    GfMatrix4d proj = renderPassState->GetProjectionMatrix();
+
+    if (!_renderer || _renderParam->GetVersion() != _lastVersion ||
+        view != _lastView || proj != _lastProj || width != _width ||
+        height != _height) {
+        _RebuildScene(view, proj, width, height);
+    }
+    if (!_renderer) {
+        return;
+    }
+
+    CrustStepStatus stepStatus = CRUST_STEP_IN_PROGRESS;
+    uint32_t sppDone = 0;
+    uint32_t chunk = uint32_t(std::max(1, TfGetEnvSetting(HDCRUST_SAMPLES_PER_STEP)));
+    crust_renderer_step(_renderer, chunk, &stepStatus, &sppDone);
+    _converged = (stepStatus == CRUST_STEP_COMPLETE);
+
+    size_t pixels = size_t(_width) * size_t(_height);
+    _rgba.resize(pixels * 4);
+    crust_renderer_read_color(_renderer, _rgba.data(), pixels);
+
+    // Both sides are bottom-up (row 0 = bottom scanline), so every write
+    // below is a straight y*width+x indexed copy — no flip anywhere.
+    for (HdRenderPassAovBinding const& binding : aovBindings) {
+        auto* buffer = static_cast<HdCrustRenderBuffer*>(binding.renderBuffer);
+        if (!buffer || buffer->GetWidth() != _width ||
+            buffer->GetHeight() != _height) {
+            continue;
+        }
+        HdFormat format = buffer->GetFormat();
+        uint8_t* out = buffer->GetStorage();
+
+        if (binding.aovName == HdAovTokens->color) {
+            if (format == HdFormatFloat32Vec4) {
+                std::memcpy(out, _rgba.data(), pixels * 4 * sizeof(float));
+            } else if (format == HdFormatFloat16Vec4) {
+                auto* half = reinterpret_cast<GfHalf*>(out);
+                for (size_t i = 0; i < pixels * 4; ++i) {
+                    half[i] = GfHalf(_rgba[i]);
+                }
+            } else if (format == HdFormatUNorm8Vec4) {
+                // 8-bit targets expect display-encoded values.
+                for (size_t i = 0; i < pixels * 4; ++i) {
+                    float v = GfClamp(_rgba[i], 0.0f, 1.0f);
+                    bool alphaChannel = (i % 4) == 3;
+                    if (!alphaChannel) {
+                        v = v <= 0.0031308f
+                                ? v * 12.92f
+                                : 1.055f * std::pow(v, 1.0f / 2.4f) - 0.055f;
+                    }
+                    out[i] = uint8_t(v * 255.0f + 0.5f);
+                }
+            } else {
+                TF_WARN("hdCrust: unsupported color format %d", int(format));
+            }
+        } else if (binding.aovName == HdAovTokens->depth &&
+                   format == HdFormatFloat32) {
+            _depth.resize(pixels);
+            crust_renderer_read_aov_depth(_renderer, _depth.data(), pixels);
+            auto* depthOut = reinterpret_cast<float*>(out);
+            for (size_t i = 0; i < pixels; ++i) {
+                depthOut[i] = _NdcDepth(proj, _depth[i]);
+            }
+        } else if (binding.aovName == HdAovTokens->primId &&
+                   format == HdFormatInt32) {
+            _ids.resize(pixels * 2);
+            crust_renderer_read_aov_id(_renderer, _ids.data(), pixels);
+            auto* idOut = reinterpret_cast<int32_t*>(out);
+            for (size_t i = 0; i < pixels; ++i) {
+                uint32_t geomId = _ids[2 * i];
+                idOut[i] = geomId < _geomToPrimId.size() ? _geomToPrimId[geomId]
+                                                         : -1;
+            }
+        }
+
+        buffer->SetConverged(_converged);
+    }
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/hydra/hdCrust/renderPass.cpp
+++ b/hydra/hdCrust/renderPass.cpp
@@ -373,6 +373,19 @@ void HdCrustRenderPass::_Execute(
         HdFormat format = buffer->GetFormat();
         uint8_t* out = buffer->GetStorage();
 
+        // Belt and braces against an under-allocated buffer (Allocate
+        // rejects overflow/invalid inputs, leaving zero-sized storage):
+        // never write more bytes than the buffer actually holds.
+        const size_t required =
+            size_t(_width) * size_t(_height) * HdDataSizeOfFormat(format);
+        if (required == 0 || buffer->GetStorageSize() < required) {
+            TF_WARN(
+                "hdCrust: render buffer %s holds %zu bytes, %zu needed; "
+                "skipping",
+                binding.aovName.GetText(), buffer->GetStorageSize(), required);
+            continue;
+        }
+
         if (binding.aovName == HdAovTokens->color) {
             if (format == HdFormatFloat32Vec4) {
                 std::memcpy(out, _rgba.data(), pixels * 4 * sizeof(float));

--- a/hydra/hdCrust/renderPass.cpp
+++ b/hydra/hdCrust/renderPass.cpp
@@ -25,9 +25,14 @@ TF_DEFINE_ENV_SETTING(HDCRUST_MAX_DEPTH, 8, "Path length bound");
 HdCrustRenderPass::HdCrustRenderPass(HdRenderIndex* index,
                                      HdRprimCollection const& collection,
                                      HdCrustRenderParam* renderParam)
-    : HdRenderPass(index, collection), _renderParam(renderParam) {}
+    : HdRenderPass(index, collection),
+      _renderParam(renderParam),
+      _geoCache(crust_geo_cache_create()) {}
 
-HdCrustRenderPass::~HdCrustRenderPass() { _DestroyRenderer(); }
+HdCrustRenderPass::~HdCrustRenderPass() {
+    _DestroyRenderer();
+    crust_geo_cache_destroy(_geoCache);
+}
 
 void HdCrustRenderPass::_DestroyRenderer() {
     if (_token) {
@@ -98,8 +103,31 @@ static void _AddLight(CrustScene* scene, HdCrustCachedLight const& light) {
                 rotation[row * 3 + col] = float(light.xform[row][col]);
             }
         }
+        if (!light.texturePath.empty()) {
+            CrustStatus status = crust_scene_add_dome_light_file(
+                scene, energyPtr, light.texturePath.c_str(), rotation);
+            if (status == CRUST_OK) {
+                return;
+            }
+            TF_WARN(
+                "hdCrust: dome texture %s failed to load (%s); using the "
+                "uniform color",
+                light.texturePath.c_str(), crust_status_string(status));
+        }
         crust_scene_add_dome_light(scene, energyPtr, 0, 0, nullptr, rotation);
     }
+}
+
+static CrustRenderSettings _MakeSettings(uint32_t width, uint32_t height) {
+    CrustRenderSettings settings;
+    crust_render_settings_default(&settings);
+    settings.width = width;
+    settings.height = height;
+    settings.samples_per_pixel =
+        uint32_t(std::max(1, TfGetEnvSetting(HDCRUST_SAMPLES_PER_PIXEL)));
+    settings.max_depth =
+        uint32_t(std::max(1, TfGetEnvSetting(HDCRUST_MAX_DEPTH)));
+    return settings;
 }
 
 void HdCrustRenderPass::_RebuildScene(GfMatrix4d const& view,
@@ -111,11 +139,17 @@ void HdCrustRenderPass::_RebuildScene(GfMatrix4d const& view,
 
     std::map<SdfPath, HdCrustCachedMesh> meshes;
     std::map<SdfPath, HdCrustCachedLight> lights;
-    _lastVersion = _renderParam->Snapshot(&meshes, &lights);
+    std::map<SdfPath, CrustMaterial> materials;
+    _lastVersion = _renderParam->Snapshot(&meshes, &lights, &materials);
     _lastView = view;
     _lastProj = proj;
     _width = width;
     _height = height;
+
+    // Deleted meshes release their prototypes.
+    for (uint64_t key : _renderParam->TakeDeadGeoKeys()) {
+        crust_geo_cache_remove(_geoCache, key);
+    }
 
     CrustScene* scene = crust_scene_create();
 
@@ -124,62 +158,82 @@ void HdCrustRenderPass::_RebuildScene(GfMatrix4d const& view,
         if (!mesh.visible || mesh.points.empty() || mesh.triangles.empty()) {
             continue;
         }
+        // Bound material if translated, else the displayColor fallback.
         CrustMaterial material;
-        crust_material_default(&material);
-        material.base_color[0] = mesh.displayColor[0];
-        material.base_color[1] = mesh.displayColor[1];
-        material.base_color[2] = mesh.displayColor[2];
-
-        // One capi mesh per placement, world-space baked — the Phase 1 C
-        // API has no instance object (the documented Phase 2 seam), so
-        // instancing is flattened here.
-        VtMatrix4dArray const singlePlacement(1, mesh.xform);
-        VtMatrix4dArray const& placements =
-            mesh.instanceXforms.empty() ? singlePlacement : mesh.instanceXforms;
-
-        std::vector<float> positions(mesh.points.size() * 3);
-        std::vector<float> normals;
-        std::vector<uint32_t> indices(mesh.triangles.size() * 3);
-        for (size_t t = 0; t < mesh.triangles.size(); ++t) {
-            indices[3 * t] = uint32_t(mesh.triangles[t][0]);
-            indices[3 * t + 1] = uint32_t(mesh.triangles[t][1]);
-            indices[3 * t + 2] = uint32_t(mesh.triangles[t][2]);
+        auto boundMaterial = materials.find(mesh.materialId);
+        if (!mesh.materialId.IsEmpty() && boundMaterial != materials.end()) {
+            material = boundMaterial->second;
+        } else {
+            crust_material_default(&material);
+            material.base_color[0] = mesh.displayColor[0];
+            material.base_color[1] = mesh.displayColor[1];
+            material.base_color[2] = mesh.displayColor[2];
         }
 
-        for (GfMatrix4d const& placement : placements) {
-            GfMatrix4d xform = mesh.instanceXforms.empty()
-                                   ? placement
-                                   : mesh.xform * placement;
+        // One kernel instance per placement over a cached prototype. The
+        // arrays are marshalled only when the (path-hash, geoVersion) key
+        // misses — i.e. only when the geometry itself changed.
+        uint64_t const key = TfHash()(entry.first);
+        std::vector<float> positions;
+        std::vector<float> normals;
+        std::vector<uint32_t> indices;
+        const float* positionsPtr = nullptr;
+        const uint32_t* indicesPtr = nullptr;
+        const float* normalsPtr = nullptr;
+        if (!crust_geo_cache_contains(_geoCache, key, mesh.geoVersion)) {
+            positions.resize(mesh.points.size() * 3);
             for (size_t i = 0; i < mesh.points.size(); ++i) {
-                GfVec3d p = xform.Transform(GfVec3d(mesh.points[i]));
-                positions[3 * i] = float(p[0]);
-                positions[3 * i + 1] = float(p[1]);
-                positions[3 * i + 2] = float(p[2]);
+                positions[3 * i] = mesh.points[i][0];
+                positions[3 * i + 1] = mesh.points[i][1];
+                positions[3 * i + 2] = mesh.points[i][2];
             }
-            const float* normalsPtr = nullptr;
+            indices.resize(mesh.triangles.size() * 3);
+            for (size_t t = 0; t < mesh.triangles.size(); ++t) {
+                indices[3 * t] = uint32_t(mesh.triangles[t][0]);
+                indices[3 * t + 1] = uint32_t(mesh.triangles[t][1]);
+                indices[3 * t + 2] = uint32_t(mesh.triangles[t][2]);
+            }
             if (!mesh.normals.empty()) {
-                // Normals map through the inverse transpose (mirrors and
-                // non-uniform scales included).
-                GfMatrix4d normalXf = xform.GetInverse().GetTranspose();
+                // Object space: the kernel's instance path maps normals
+                // through the placement's inverse transpose itself.
                 normals.resize(mesh.normals.size() * 3);
                 for (size_t i = 0; i < mesh.normals.size(); ++i) {
-                    GfVec3d n = normalXf.TransformDir(GfVec3d(mesh.normals[i]));
-                    n.Normalize();
-                    normals[3 * i] = float(n[0]);
-                    normals[3 * i + 1] = float(n[1]);
-                    normals[3 * i + 2] = float(n[2]);
+                    normals[3 * i] = mesh.normals[i][0];
+                    normals[3 * i + 1] = mesh.normals[i][1];
+                    normals[3 * i + 2] = mesh.normals[i][2];
                 }
                 normalsPtr = normals.data();
             }
+            positionsPtr = positions.data();
+            indicesPtr = indices.data();
+        }
+
+        VtMatrix4dArray const singlePlacement(1, mesh.xform);
+        VtMatrix4dArray const& placements =
+            mesh.instanceXforms.empty() ? singlePlacement : mesh.instanceXforms;
+        for (GfMatrix4d const& placement : placements) {
+            GfMatrix4d const xform = mesh.instanceXforms.empty()
+                                         ? placement
+                                         : mesh.xform * placement;
             uint32_t geomId = 0;
-            CrustStatus status = crust_scene_add_mesh(
-                scene, positions.data(), mesh.points.size(), indices.data(),
-                mesh.triangles.size(), normalsPtr, &material, &geomId);
+            CrustStatus status = crust_scene_add_instance(
+                scene, _geoCache, key, mesh.geoVersion, positionsPtr,
+                mesh.points.size(), indicesPtr, mesh.triangles.size(),
+                normalsPtr, xform.GetArray(), &material, &geomId);
             if (status != CRUST_OK) {
-                TF_WARN("hdCrust: add_mesh(%s) failed: %s",
-                        entry.first.GetText(), crust_status_string(status));
+                // Singular placements (zero scale = "hide me") are expected;
+                // anything else is worth a warning.
+                if (status != CRUST_ERROR_INVALID_ARGUMENT) {
+                    TF_WARN("hdCrust: add_instance(%s) failed: %s",
+                            entry.first.GetText(), crust_status_string(status));
+                }
                 continue;
             }
+            // The first placement populated the cache; later ones (and
+            // later rebuilds) hit it.
+            positionsPtr = nullptr;
+            indicesPtr = nullptr;
+            normalsPtr = nullptr;
             if (_geomToPrimId.size() <= geomId) {
                 _geomToPrimId.resize(geomId + 1, -1);
             }
@@ -197,13 +251,7 @@ void HdCrustRenderPass::_RebuildScene(GfMatrix4d const& view,
         TF_WARN("hdCrust: set_camera failed: %s", crust_status_string(status));
     }
 
-    CrustRenderSettings settings;
-    crust_render_settings_default(&settings);
-    settings.width = width;
-    settings.height = height;
-    settings.samples_per_pixel =
-        uint32_t(std::max(1, TfGetEnvSetting(HDCRUST_SAMPLES_PER_PIXEL)));
-    settings.max_depth = uint32_t(std::max(1, TfGetEnvSetting(HDCRUST_MAX_DEPTH)));
+    CrustRenderSettings settings = _MakeSettings(width, height);
     crust_scene_set_render_settings(scene, &settings);
 
     _token = crust_stop_token_create();
@@ -263,10 +311,42 @@ void HdCrustRenderPass::_Execute(
     GfMatrix4d view = renderPassState->GetWorldToViewMatrix();
     GfMatrix4d proj = renderPassState->GetProjectionMatrix();
 
-    if (!_renderer || _renderParam->GetVersion() != _lastVersion ||
-        view != _lastView || proj != _lastProj || width != _width ||
-        height != _height) {
+    if (!_renderer || _renderParam->GetVersion() != _lastVersion) {
+        // Scene content changed: rebuild — cheap now, since unchanged
+        // geometry hits the prototype cache and only the top-level BVH
+        // over instance bounds is rebuilt.
         _RebuildScene(view, proj, width, height);
+    } else if (width != _width || height != _height) {
+        // Resolution change: restart sampling in place, no world work.
+        CrustStopToken* fresh = crust_stop_token_create();
+        CrustRenderSettings settings = _MakeSettings(width, height);
+        if (crust_renderer_update_settings(_renderer, &settings, fresh) ==
+            CRUST_OK) {
+            crust_stop_token_destroy(_token);
+            _token = fresh;
+            _width = width;
+            _height = height;
+            _converged = false;
+        } else {
+            crust_stop_token_destroy(fresh);
+            _RebuildScene(view, proj, width, height);
+        }
+    } else if (view != _lastView || proj != _lastProj) {
+        // Camera orbit — the common interactive edit: restart sampling in
+        // place, no world work.
+        CrustStopToken* fresh = crust_stop_token_create();
+        if (crust_renderer_update_camera(_renderer, view.GetArray(),
+                                         proj.GetArray(), 0.0f, 1.0f,
+                                         fresh) == CRUST_OK) {
+            crust_stop_token_destroy(_token);
+            _token = fresh;
+            _lastView = view;
+            _lastProj = proj;
+            _converged = false;
+        } else {
+            crust_stop_token_destroy(fresh);
+            _RebuildScene(view, proj, width, height);
+        }
     }
     if (!_renderer) {
         return;

--- a/hydra/hdCrust/renderPass.h
+++ b/hydra/hdCrust/renderPass.h
@@ -43,6 +43,10 @@ private:
 
     CrustRenderer* _renderer = nullptr;
     CrustStopToken* _token = nullptr;
+    /// Prototype triangles survive scene rebuilds here — a rebuild whose
+    /// meshes all hit the cache pays only the top-level BVH over instance
+    /// bounds.
+    CrustGeoCache* _geoCache = nullptr;
 
     int _lastVersion = -1;
     GfMatrix4d _lastView{1.0};

--- a/hydra/hdCrust/renderPass.h
+++ b/hydra/hdCrust/renderPass.h
@@ -1,0 +1,65 @@
+#ifndef HDCRUST_RENDER_PASS_H
+#define HDCRUST_RENDER_PASS_H
+
+#include "renderParam.h"
+
+#include <pxr/base/gf/matrix4d.h>
+#include <pxr/imaging/hd/renderPass.h>
+#include <pxr/pxr.h>
+
+#include <crust.h>
+
+#include <vector>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// The synchronous render loop. Each _Execute call:
+///  1. rebuilds the crust scene from the render param's cache when the
+///     scene version, camera, or buffer size changed (Phase 1 semantics:
+///     rebuild everything on any dirty bit);
+///  2. advances the render by a few samples per pixel
+///     (crust_renderer_step);
+///  3. copies the framebuffer/AOVs into the bound HdRenderBuffers.
+/// Hydra keeps calling _Execute until IsConverged(), which is what makes
+/// this synchronous design progressive in practice.
+class HdCrustRenderPass final : public HdRenderPass {
+public:
+    HdCrustRenderPass(HdRenderIndex* index, HdRprimCollection const& collection,
+                      HdCrustRenderParam* renderParam);
+    ~HdCrustRenderPass() override;
+
+    bool IsConverged() const override { return _converged; }
+
+protected:
+    void _Execute(HdRenderPassStateSharedPtr const& renderPassState,
+                  TfTokenVector const& renderTags) override;
+
+private:
+    void _DestroyRenderer();
+    void _RebuildScene(GfMatrix4d const& view, GfMatrix4d const& proj,
+                       uint32_t width, uint32_t height);
+
+    HdCrustRenderParam* _renderParam;
+
+    CrustRenderer* _renderer = nullptr;
+    CrustStopToken* _token = nullptr;
+
+    int _lastVersion = -1;
+    GfMatrix4d _lastView{1.0};
+    GfMatrix4d _lastProj{1.0};
+    uint32_t _width = 0;
+    uint32_t _height = 0;
+    bool _converged = false;
+
+    /// capi geom_id -> Hydra rprim primId, rebuilt with the scene; drives
+    /// the primId AOV that makes viewport picking work.
+    std::vector<int32_t> _geomToPrimId;
+
+    std::vector<float> _rgba;
+    std::vector<float> _depth;
+    std::vector<uint32_t> _ids;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDCRUST_RENDER_PASS_H

--- a/hydra/hdCrust/rendererPlugin.cpp
+++ b/hydra/hdCrust/rendererPlugin.cpp
@@ -1,0 +1,35 @@
+#include "rendererPlugin.h"
+
+#include "renderDelegate.h"
+
+#include <pxr/imaging/hd/rendererPluginRegistry.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_REGISTRY_FUNCTION(TfType) {
+    HdRendererPluginRegistry::Define<HdCrustRendererPlugin>();
+}
+
+HdRenderDelegate* HdCrustRendererPlugin::CreateRenderDelegate() {
+    return new HdCrustRenderDelegate();
+}
+
+HdRenderDelegate* HdCrustRendererPlugin::CreateRenderDelegate(
+    HdRenderSettingsMap const& settingsMap) {
+    return new HdCrustRenderDelegate(settingsMap);
+}
+
+void HdCrustRendererPlugin::DeleteRenderDelegate(
+    HdRenderDelegate* renderDelegate) {
+    delete renderDelegate;
+}
+
+bool HdCrustRendererPlugin::IsSupported(
+    HdRendererCreateArgs const& rendererCreateArgs,
+    std::string* reasonWhyNot) const {
+    (void)rendererCreateArgs;
+    (void)reasonWhyNot;
+    return true;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/hydra/hdCrust/rendererPlugin.h
+++ b/hydra/hdCrust/rendererPlugin.h
@@ -1,0 +1,31 @@
+#ifndef HDCRUST_RENDERER_PLUGIN_H
+#define HDCRUST_RENDERER_PLUGIN_H
+
+#include <pxr/imaging/hd/rendererPlugin.h>
+#include <pxr/pxr.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// The plugin entry point Hydra's plugin registry discovers through
+/// plugInfo.json and instantiates when a host selects the "Crust" renderer.
+class HdCrustRendererPlugin final : public HdRendererPlugin {
+public:
+    HdCrustRendererPlugin() = default;
+    ~HdCrustRendererPlugin() override = default;
+
+    HdCrustRendererPlugin(const HdCrustRendererPlugin&) = delete;
+    HdCrustRendererPlugin& operator=(const HdCrustRendererPlugin&) = delete;
+
+    HdRenderDelegate* CreateRenderDelegate() override;
+    HdRenderDelegate* CreateRenderDelegate(
+        HdRenderSettingsMap const& settingsMap) override;
+    void DeleteRenderDelegate(HdRenderDelegate* renderDelegate) override;
+
+    /// A CPU path tracer: no GPU needed, supported everywhere.
+    bool IsSupported(HdRendererCreateArgs const& rendererCreateArgs,
+                     std::string* reasonWhyNot = nullptr) const override;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDCRUST_RENDERER_PLUGIN_H

--- a/hydra/hdCrust/tests/testHdCrust.cpp
+++ b/hydra/hdCrust/tests/testHdCrust.cpp
@@ -11,7 +11,9 @@
 #include <pxr/base/gf/frustum.h>
 #include <pxr/base/gf/matrix4f.h>
 #include <pxr/base/gf/rect2i.h>
+#include <pxr/base/gf/vec3f.h>
 #include <pxr/imaging/cameraUtil/framing.h>
+#include <pxr/imaging/hd/material.h>
 #include <pxr/imaging/hd/camera.h>
 #include <pxr/imaging/hd/engine.h>
 #include <pxr/imaging/hd/pluginRenderDelegateUniqueHandle.h>
@@ -69,6 +71,22 @@ private:
     HdRenderPassStateSharedPtr _renderPassState;
     TfTokenVector _renderTags;
 };
+
+// One-node UsdPreviewSurface network with a constant diffuseColor — the
+// shape UsdImaging delivers for a bound preview-surface material.
+static VtValue _MakePreviewSurface(GfVec3f const& color) {
+    HdMaterialNode node;
+    node.path = SdfPath("/materials/mat/preview");
+    node.identifier = TfToken("UsdPreviewSurface");
+    node.parameters[TfToken("diffuseColor")] = VtValue(color);
+    node.parameters[TfToken("roughness")] = VtValue(0.9f);
+    HdMaterialNetwork network;
+    network.nodes.push_back(node);
+    HdMaterialNetworkMap map;
+    map.map[HdMaterialTerminalTokens->surface] = network;
+    map.terminals.push_back(node.path);
+    return VtValue(map);
+}
 
 } // namespace
 
@@ -157,31 +175,118 @@ int main() {
     aovBindings[0].clearValue = VtValue(GfVec4f(0.0f));
     renderPassState->SetAovBindings(aovBindings);
 
-    int iterations = 0;
-    for (; iterations < 256 && !renderPass->IsConverged(); ++iterations) {
-        HdTaskSharedPtrVector tasks = {
-            std::make_shared<DrawTask>(renderPass, renderPassState)};
-        engine.Execute(index.get(), &tasks);
-    }
-    REQUIRE(renderPass->IsConverged(), "render never converged");
-    REQUIRE(renderBuffer->IsConverged(), "buffer not marked converged");
+    // Drives Execute until convergence and returns the frame; also checks
+    // finiteness on every read.
+    auto converge = [&]() -> std::vector<float> {
+        // Always execute at least once: after an edit, IsConverged() still
+        // reports the previous frame's state until an Execute syncs the
+        // dirty prims and notices the change — usdview likewise re-executes
+        // on scene invalidation rather than polling convergence first.
+        int iterations = 0;
+        do {
+            HdTaskSharedPtrVector tasks = {
+                std::make_shared<DrawTask>(renderPass, renderPassState)};
+            engine.Execute(index.get(), &tasks);
+            ++iterations;
+        } while (iterations < 1024 && !renderPass->IsConverged());
+        if (!renderPass->IsConverged()) {
+            fprintf(stderr, "FAIL: render never converged\n");
+            exit(1);
+        }
+        renderBuffer->Resolve();
+        auto const* rgba = static_cast<float const*>(renderBuffer->Map());
+        std::vector<float> frame(rgba, rgba + size_t(W) * H * 4);
+        renderBuffer->Unmap();
+        for (float v : frame) {
+            if (!std::isfinite(v)) {
+                fprintf(stderr, "FAIL: non-finite pixel\n");
+                exit(1);
+            }
+        }
+        return frame;
+    };
 
     // 4. The image made it into the Hydra buffer.
-    renderBuffer->Resolve();
-    auto const* rgba = static_cast<float const*>(renderBuffer->Map());
-    REQUIRE(rgba != nullptr, "Map() returned NULL");
+    std::vector<float> frame = converge();
+    REQUIRE(renderBuffer->IsConverged(), "buffer not marked converged");
     int nonzero = 0;
-    bool finite = true;
-    for (int i = 0; i < W * H * 4; ++i) {
-        if (rgba[i] > 0.0f) nonzero++;
-        if (!std::isfinite(rgba[i])) finite = false;
+    for (float v : frame) {
+        if (v > 0.0f) nonzero++;
     }
-    renderBuffer->Unmap();
-    REQUIRE(finite, "non-finite pixels");
     REQUIRE(nonzero > W * H, "image is (almost) all black");
 
-    printf("testHdCrust PASS: converged after %d executes, %d nonzero "
-           "channel values\n",
-           iterations, nonzero);
+    // ---- Phase 2: materials and dirty-driven edits ----------------------
+
+    const size_t center = (size_t(H / 2) * W + W / 2) * 4;
+
+    // 5. Bind a red UsdPreviewSurface. AddMaterialResource inserts the
+    // sprim; RebindMaterial marks the cube's DirtyMaterialId (BindMaterial
+    // alone marks nothing after the first sync).
+    SdfPath matId("/scene/material");
+    scene.AddMaterialResource(matId, _MakePreviewSurface(GfVec3f(1.0f, 0.0f, 0.0f)));
+    scene.RebindMaterial(SdfPath("/scene/cube"), matId);
+    std::vector<float> red = converge();
+    REQUIRE(red[center] > 2.0f * red[center + 1] &&
+                red[center] > 2.0f * red[center + 2],
+            "cube did not shade red from its bound UsdPreviewSurface");
+
+    // 6. A material edit propagates through DirtyResource.
+    scene.UpdateMaterialResource(matId, _MakePreviewSurface(GfVec3f(0.0f, 1.0f, 0.0f)));
+    std::vector<float> green = converge();
+    REQUIRE(green[center + 1] > 2.0f * green[center] &&
+                green[center + 1] > 2.0f * green[center + 2],
+            "material edit did not turn the cube green");
+
+    // 7. A transform edit re-places the cached prototype (same geometry
+    // version — the crust prototype cache hits) and changes the image.
+    GfMatrix4f moved(1.0f);
+    moved.SetTranslate(GfVec3f(2.0f, 0.0f, 0.0f));
+    scene.UpdateTransform(SdfPath("/scene/cube"), moved);
+    std::vector<float> shifted = converge();
+    REQUIRE(shifted != green, "moving the cube changed nothing");
+    REQUIRE(!(shifted[center + 1] > 2.0f * shifted[center]),
+            "cube still green at center after moving away");
+
+    // 8. A camera move takes the no-rebuild fast path
+    // (crust_renderer_update_camera) and re-converges on a different frame.
+    GfFrustum orbit;
+    orbit.SetPosition(GfVec3d(1.5, 0.5, 5.0));
+    GfCamera orbitCam;
+    orbitCam.SetFromViewAndProjectionMatrix(orbit.ComputeViewMatrix(),
+                                            orbit.ComputeProjectionMatrix());
+    scene.UpdateTransform(camId, GfMatrix4f(orbitCam.GetTransform()));
+    // HdUnitTestDelegate::UpdateTransform marks camera sprims with the
+    // RPRIM DirtyTransform bit (1<<9), which HdCamera::Sync (expecting
+    // HdCamera::DirtyTransform, 1<<0) ignores — mark it properly here.
+    index->GetChangeTracker().MarkSprimDirty(camId, HdCamera::AllDirty);
+    std::vector<float> orbited = converge();
+    REQUIRE(orbited != shifted, "camera move changed nothing");
+
+    // 9. Instancing: three placements of a new cube through an instancer,
+    // then move them — both re-converge and alter the image.
+    SdfPath instancerId("/scene/instancer");
+    scene.AddInstancer(instancerId);
+    scene.AddCube(SdfPath("/scene/proto"), GfMatrix4f(1.0f), false, instancerId);
+    VtIntArray protoIndices{0, 0, 0};
+    VtVec3fArray scales{GfVec3f(0.5f), GfVec3f(0.5f), GfVec3f(0.5f)};
+    VtVec4fArray rotates{GfVec4f(1, 0, 0, 0), GfVec4f(1, 0, 0, 0),
+                         GfVec4f(1, 0, 0, 0)};
+    VtVec3fArray translates{GfVec3f(-2, 0, 0), GfVec3f(-2, 2, 0),
+                            GfVec3f(-2, -2, 0)};
+    scene.SetInstancerProperties(instancerId, protoIndices, scales, rotates,
+                                 translates);
+    std::vector<float> instanced = converge();
+    REQUIRE(instanced != orbited, "instanced cubes changed nothing");
+
+    VtVec3fArray movedTranslates{GfVec3f(-1, 0, 0), GfVec3f(-1, 2, 0),
+                                 GfVec3f(-1, -2, 0)};
+    scene.SetInstancerProperties(instancerId, protoIndices, scales, rotates,
+                                 movedTranslates);
+    std::vector<float> instancesMoved = converge();
+    REQUIRE(instancesMoved != instanced, "moving instances changed nothing");
+
+    printf("testHdCrust PASS: beauty (%d nonzero), materials bind and edit, "
+           "transform/camera/instancer edits re-converge\n",
+           nonzero);
     return 0;
 }

--- a/hydra/hdCrust/tests/testHdCrust.cpp
+++ b/hydra/hdCrust/tests/testHdCrust.cpp
@@ -1,0 +1,187 @@
+// Headless end-to-end check of the hdCrust plugin, no GL and no usdview:
+// discovers the plugin through Hydra's registry (so PXR_PLUGINPATH_NAME
+// must point at the installed resources/ dir), builds a tiny scene with
+// hd's unit-test scene delegate, drives the render pass the way
+// Hd_TestDriver does, and asserts the color buffer converged to nonzero
+// pixels.
+//
+// Build with -DHDCRUST_BUILD_TESTS=ON; see README.md.
+
+#include <pxr/base/gf/camera.h>
+#include <pxr/base/gf/frustum.h>
+#include <pxr/base/gf/matrix4f.h>
+#include <pxr/base/gf/rect2i.h>
+#include <pxr/imaging/cameraUtil/framing.h>
+#include <pxr/imaging/hd/camera.h>
+#include <pxr/imaging/hd/engine.h>
+#include <pxr/imaging/hd/pluginRenderDelegateUniqueHandle.h>
+#include <pxr/imaging/hd/renderBuffer.h>
+#include <pxr/imaging/hd/renderDelegate.h>
+#include <pxr/imaging/hd/renderIndex.h>
+#include <pxr/imaging/hd/renderPass.h>
+#include <pxr/imaging/hd/renderPassState.h>
+#include <pxr/imaging/hd/rendererPluginRegistry.h>
+#include <pxr/imaging/hd/task.h>
+#include <pxr/imaging/hd/tokens.h>
+#include <pxr/imaging/hd/unitTestDelegate.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+#define REQUIRE(cond, msg)                                        \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, msg); \
+            return 1;                                             \
+        }                                                         \
+    } while (0)
+
+namespace {
+
+// The minimal task Hd_TestDriver uses: sync the pass, prepare the state,
+// execute.
+class DrawTask final : public HdTask {
+public:
+    DrawTask(HdRenderPassSharedPtr renderPass,
+             HdRenderPassStateSharedPtr renderPassState)
+        : HdTask(SdfPath::EmptyPath()),
+          _renderPass(std::move(renderPass)),
+          _renderPassState(std::move(renderPassState)),
+          _renderTags{HdRenderTagTokens->geometry} {}
+
+    void Sync(HdSceneDelegate*, HdTaskContext*, HdDirtyBits*) override {
+        _renderPass->Sync();
+    }
+    void Prepare(HdTaskContext*, HdRenderIndex* renderIndex) override {
+        _renderPassState->Prepare(renderIndex->GetResourceRegistry());
+    }
+    void Execute(HdTaskContext*) override {
+        _renderPass->Execute(_renderPassState, _renderTags);
+    }
+    const TfTokenVector& GetRenderTags() const override { return _renderTags; }
+
+private:
+    HdRenderPassSharedPtr _renderPass;
+    HdRenderPassStateSharedPtr _renderPassState;
+    TfTokenVector _renderTags;
+};
+
+} // namespace
+
+int main() {
+    constexpr int W = 64;
+    constexpr int H = 64;
+
+    // 1. The plugin must be discoverable through the registry — this is
+    // the piece usdview exercises that no Rust test can.
+    HdPluginRenderDelegateUniqueHandle delegate =
+        HdRendererPluginRegistry::GetInstance().CreateRenderDelegate(
+            TfToken("HdCrustRendererPlugin"));
+    REQUIRE(delegate,
+            "HdCrustRendererPlugin not found — point PXR_PLUGINPATH_NAME at "
+            "the installed hdCrust/resources directory");
+
+    std::unique_ptr<HdRenderIndex> index(
+        HdRenderIndex::New(delegate.Get(), HdDriverVector()));
+    REQUIRE(index != nullptr, "render index creation failed");
+
+    // 2. A cube, a camera and a color buffer through hd's unit-test scene
+    // delegate. No light on purpose: crust's built-in sky guarantees
+    // nonzero pixels, and the cube silhouettes against it.
+    HdUnitTestDelegate scene(index.get(), SdfPath("/scene"));
+    scene.AddCube(SdfPath("/scene/cube"), GfMatrix4f(1.0f));
+
+    SdfPath camId("/scene/camera");
+    scene.AddCamera(camId);
+    GfFrustum frustum;
+    frustum.SetPosition(GfVec3d(0.0, 0.0, 5.0));
+    GfCamera gfCam;
+    gfCam.SetFromViewAndProjectionMatrix(frustum.ComputeViewMatrix(),
+                                         frustum.ComputeProjectionMatrix());
+    scene.UpdateTransform(camId, GfMatrix4f(gfCam.GetTransform()));
+    scene.UpdateCamera(camId, HdCameraTokens->projection,
+                       VtValue(HdCamera::Perspective));
+    scene.UpdateCamera(
+        camId, HdCameraTokens->focalLength,
+        VtValue(gfCam.GetFocalLength() * float(GfCamera::FOCAL_LENGTH_UNIT)));
+    scene.UpdateCamera(
+        camId, HdCameraTokens->horizontalAperture,
+        VtValue(gfCam.GetHorizontalAperture() * float(GfCamera::APERTURE_UNIT)));
+    scene.UpdateCamera(
+        camId, HdCameraTokens->verticalAperture,
+        VtValue(gfCam.GetVerticalAperture() * float(GfCamera::APERTURE_UNIT)));
+    scene.UpdateCamera(camId, HdCameraTokens->clippingRange,
+                       VtValue(gfCam.GetClippingRange()));
+
+    SdfPath bufferId("/scene/color");
+    HdRenderBufferDescriptor desc;
+    desc.dimensions = GfVec3i(W, H, 1);
+    desc.format = HdFormatFloat32Vec4;
+    desc.multiSampled = false;
+    scene.AddRenderBuffer(bufferId, desc);
+
+    // 3. The render pass, driven exactly the way usdview's task graph
+    // would: repeat Execute until the delegate reports convergence.
+    HdRprimCollection collection(HdTokens->geometry,
+                                 HdReprSelector(HdReprTokens->smoothHull));
+    HdRenderPassSharedPtr renderPass =
+        delegate->CreateRenderPass(index.get(), collection);
+    HdRenderPassStateSharedPtr renderPassState =
+        delegate->CreateRenderPassState();
+
+    HdEngine engine;
+    // One warm-up execute so sprims/bprims sync before we look them up.
+    {
+        HdTaskSharedPtrVector tasks = {
+            std::make_shared<DrawTask>(renderPass, renderPassState)};
+        engine.Execute(index.get(), &tasks);
+    }
+
+    auto const* camera = dynamic_cast<HdCamera const*>(
+        index->GetSprim(HdPrimTypeTokens->camera, camId));
+    REQUIRE(camera != nullptr, "camera sprim missing");
+    renderPassState->SetCamera(camera);
+    renderPassState->SetFraming(CameraUtilFraming(
+        GfRect2i(GfVec2i(0, 0), W, H)));
+
+    auto* renderBuffer = dynamic_cast<HdRenderBuffer*>(
+        index->GetBprim(HdPrimTypeTokens->renderBuffer, bufferId));
+    REQUIRE(renderBuffer != nullptr, "render buffer bprim missing");
+    HdRenderPassAovBindingVector aovBindings(1);
+    aovBindings[0].aovName = HdAovTokens->color;
+    aovBindings[0].renderBuffer = renderBuffer;
+    aovBindings[0].clearValue = VtValue(GfVec4f(0.0f));
+    renderPassState->SetAovBindings(aovBindings);
+
+    int iterations = 0;
+    for (; iterations < 256 && !renderPass->IsConverged(); ++iterations) {
+        HdTaskSharedPtrVector tasks = {
+            std::make_shared<DrawTask>(renderPass, renderPassState)};
+        engine.Execute(index.get(), &tasks);
+    }
+    REQUIRE(renderPass->IsConverged(), "render never converged");
+    REQUIRE(renderBuffer->IsConverged(), "buffer not marked converged");
+
+    // 4. The image made it into the Hydra buffer.
+    renderBuffer->Resolve();
+    auto const* rgba = static_cast<float const*>(renderBuffer->Map());
+    REQUIRE(rgba != nullptr, "Map() returned NULL");
+    int nonzero = 0;
+    bool finite = true;
+    for (int i = 0; i < W * H * 4; ++i) {
+        if (rgba[i] > 0.0f) nonzero++;
+        if (!std::isfinite(rgba[i])) finite = false;
+    }
+    renderBuffer->Unmap();
+    REQUIRE(finite, "non-finite pixels");
+    REQUIRE(nonzero > W * H, "image is (almost) all black");
+
+    printf("testHdCrust PASS: converged after %d executes, %d nonzero "
+           "channel values\n",
+           iterations, nonzero);
+    return 0;
+}

--- a/hydra/hdCrust/tests/testHdCrust.cpp
+++ b/hydra/hdCrust/tests/testHdCrust.cpp
@@ -285,8 +285,25 @@ int main() {
     std::vector<float> instancesMoved = converge();
     REQUIRE(instancesMoved != instanced, "moving instances changed nothing");
 
+    // 10. A render buffer with hostile dimensions must refuse allocation
+    // (negative values would wrap to huge unsigned sizes) and end up with
+    // zero-sized storage the render pass then refuses to write into.
+    SdfPath badBufferId("/scene/badBuffer");
+    HdRenderBufferDescriptor badDesc;
+    badDesc.dimensions = GfVec3i(-4, H, 1);
+    badDesc.format = HdFormatFloat32Vec4;
+    badDesc.multiSampled = false;
+    scene.AddRenderBuffer(badBufferId, badDesc);
+    (void)converge(); // syncs the new bprim (Allocate runs and refuses)
+    auto* badBuffer = dynamic_cast<HdRenderBuffer*>(
+        index->GetBprim(HdPrimTypeTokens->renderBuffer, badBufferId));
+    REQUIRE(badBuffer != nullptr, "bad render buffer bprim missing");
+    REQUIRE(badBuffer->GetWidth() == 0 && badBuffer->GetHeight() == 0,
+            "negative-dimension Allocate was not refused");
+
     printf("testHdCrust PASS: beauty (%d nonzero), materials bind and edit, "
-           "transform/camera/instancer edits re-converge\n",
+           "transform/camera/instancer edits re-converge, hostile buffer "
+           "dims refused\n",
            nonzero);
     return 0;
 }

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -6,27 +6,34 @@ context: |
   Rust (edition 2024). The guiding goal is to bring industry-standard graphics
   formats and models — OpenUSD (scene interchange) and OpenPBR (surface shading)
   — into a Rust environment, drawing on PBRT, "Ray Tracing in One Weekend", and
-  Autodesk Standard Surface.
+  Autodesk Standard Surface. The safe-Rust rule has exactly one sanctioned
+  exception: the Hydra render delegate boundary (a future crust-capi C-ABI crate
+  + hdCrust C++ plugin) may use unsafe/FFI; engine crates never depend on it
+  (see docs/hydra_delegate.md).
 
   Guiding principles (apply when writing proposals and specs):
   - Performance is a core concern: prefer designs and data layouts that keep the
     CPU path tracer fast (Rayon parallelism, cache-friendly structures, BVH).
     Flag proposals that would regress render throughput.
   - CPU only — there is no GPU backend; do not spec one.
-  - The CLI is the only UI for now; assume no interactive/GUI surface.
+  - The CLI is the primary UI; a USD Hydra render delegate (hdCrust) is planned,
+    so engine APIs may be shaped for progressive, cancellable rendering with a
+    readable partial framebuffer — but crust-core itself stays UI-free.
   - "Production-inspired toy": favor correct, industry-aligned semantics
     (OpenUSD scene model, OpenPBR shading) over breadth of one-off features.
 
   Tech stack:
-  - Rust 2024, Cargo workspace with three crates under crates/:
-    - crust-core: the whole engine as a library (renderer, integrator, materials,
-      primitives, lights, BVH, USD import).
+  - Rust 2024, Cargo workspace with four crates under crates/:
+    - crust-rt: the intersection kernel (Embree-shaped scene/geometry API,
+      SBVH build collapsed to BVH4, instancing, motion blur).
+    - crust-core: the engine as a library (renderer, integrator, materials,
+      lights, volumes, path guiding, USD import) on top of crust-rt.
     - crust-render: the thin CLI binary (main.rs only) — clap args, builds a Scene,
-      runs the Renderer, writes EXR.
+      runs the Renderer, writes EXR + tone-mapped PNG.
     - utils: math/RNG helpers (random*, balance_heuristic, align_to_normal, clamp, Lerp).
   - Key deps: glam (Vec3A/Mat4), rayon (parallelism), exr + image (output),
-    openusd 0.5 (scene import — always compiled in, no feature flag), tracing (logging),
-    indicatif (progress bar), criterion (benches).
+    openusd 0.6 (scene import — always compiled in, no feature flag), openqmc-rs
+    (QMC sampling), tracing (logging), indicatif (progress bar), criterion (benches).
 
   Domain conventions:
   - Scenes load exclusively from USD (.usda/.usdc/.usdz). RON, Alembic (.abc),
@@ -38,9 +45,10 @@ context: |
     explicitly rather than speccing unimplemented features as done.
 
   Known incomplete work (do not spec as working):
-  - Adaptive sampling params (min_samples_per_pixel, variance_threshold, frame) are
-    parsed into RenderSettings but NOT consumed by the tracer yet.
-  - Non-sphere USD lux lights (Rect/Disk/Distant/Dome/Cylinder) warn once and are skipped.
+  - USD lux DiskLight and CylinderLight warn once and are skipped
+    (Sphere/Rect/Distant/Dome are supported).
+  - The Hydra delegate itself (crust-capi, hdCrust) does not exist yet — only the
+    engine-side groundwork (progressive/cancellable rendering, AOVs, matrix camera).
 
 # Per-artifact rules (optional).
 rules:

--- a/scripts/test_capi_c.sh
+++ b/scripts/test_capi_c.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# The C-side ABI guard for crust-capi: compiles the real crust.h from real C
+# (-std=c11 -Wall -Wextra -Werror, so a drifted declaration fails the build),
+# links the release cdylib, and runs tests/smoke.c — which exercises every
+# exported symbol and asserts deterministic, nonzero pixels.
+#
+# A shell script rather than a #[test] shelling out to cargo: a nested
+# `cargo build` under `cargo test` contends the build-dir lock.
+#
+# Usage: scripts/test_capi_c.sh   (from the repo root)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CC="${CC:-gcc}"
+
+cargo build --release -p crust-capi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+"$CC" -std=c11 -Wall -Wextra -Werror \
+    crates/crust-capi/tests/smoke.c \
+    -Icrates/crust-capi/include \
+    -Ltarget/release -lcrust_capi -lm \
+    -o "$tmp/smoke"
+
+LD_LIBRARY_PATH="target/release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" "$tmp/smoke"
+echo "test_capi_c.sh: OK"


### PR DESCRIPTION
All engine crates stay 100% safe Rust; the one sanctioned exception is
the planned Hydra render delegate boundary (a crust-capi C-ABI crate +
the hdCrust C++ HdRenderDelegate plugin), which no engine crate may ever
depend on. docs/hydra_delegate.md records the decision, why the
exception is unavoidable (Hydra's plugin ABI is C++, and a delegate
never parses USD — the openusd importer is bypassed, not extended), and
the phased roadmap. The openspec context also sheds its stale facts
(openusd 0.6, four crates, adaptive sampling long implemented).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UrwqkMDGdGwWzWsKxgUxv8